### PR TITLE
fix(css): enable horizontal scrolling for overflowing code blocks

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1280,6 +1280,18 @@ p {
   }
 }
 
+
+/* Generic code blocks (Markdown-rendered) */
+pre {
+  overflow-x: auto;
+  max-width: 100%;
+  -webkit-overflow-scrolling: touch; /* smoother scrolling on iOS */
+}
+
+pre code {
+  white-space: pre; /* prevent wrapping inside code fences */
+}
+
 /* Utility classes */
 .text-primary {
   color: var(--color-primary);


### PR DESCRIPTION
This PR enables horizontal scrolling for overflowing code blocks across the docs site.

Changes:
- Add generic CSS for Markdown-rendered code fences: `pre { overflow-x: auto; max-width: 100%; -webkit-overflow-scrolling: touch; }`
- Ensure `pre code` preserves whitespace (no wrapping)

Rationale:
- Some code samples exceed the content width, causing layout overflow. This makes long commands and code samples usable on mobile and narrow viewports.

Scope:
- Global only (src/styles/main.css); does not affect spacing or typography.

Test plan:
- Open any doc page with long code samples; confirm horizontal scroll appears without layout shifts.

