### PR TITLE
Release v2.1.0

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -75,6 +75,13 @@ RATE_LIMIT_WINDOW=900000
 # HEALTH_CHECK_EXTERNAL_PROBE=true
 
 # ============================================================================
+# INSTANCE SOFTWARE DETECTION (NodeInfo)
+# ============================================================================
+
+# Cache TTL for instance-software (NodeInfo) detection in milliseconds (default: 24h)
+# MCP_INSTANCE_SOFTWARE_TTL_MS=86400000
+
+# ============================================================================
 # RESERVED FOR FUTURE USE
 # These variables are defined but not currently used by the read-only client
 # They are reserved for potential future features

--- a/.env.production.example
+++ b/.env.production.example
@@ -70,6 +70,10 @@ INSTANCE_BLOCKING_ENABLED=true
 DYNAMIC_INSTANCE_CACHE_TTL=3600000
 MAX_DYNAMIC_INSTANCES=100
 
+# ─── Instance software detection (NodeInfo) ──────────────────────────
+# Cache TTL for instance-software (NodeInfo) detection in milliseconds (default: 24h)
+# MCP_INSTANCE_SOFTWARE_TTL_MS=86400000
+
 # ─── Performance metrics (off by default) ───────────────────────────
 # METRICS_ENABLED=true
 # METRICS_INTERVAL=60000

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -74,13 +74,11 @@ updates:
       - dependency-type: "direct"
       - dependency-type: "indirect"
     
-    # Ignore specific packages that need manual review
+    # Ignore specific packages that need manual review.
+    # NOTE: major bumps are intentionally NOT ignored wholesale — Dependabot
+    # surfaces them as individual (ungrouped) PRs so each gets explicit review.
     ignore:
-      # Major version updates require manual review
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
-      
-      # Ignore specific packages that are known to have breaking changes
+      # Node engine major bumps are coordinated manually with the engines field.
       - dependency-name: "node"
         update-types: ["version-update:semver-major"]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.0] - 2026-05-28
+
+### Added
+
+- **`get-instance-software` tool.** Detects ActivityPub software (Mastodon, Pleroma, Misskey, Akkoma, Sharkey, GotoSocial, Friendica, etc.) and version via NodeInfo 2.0/2.1. Returns a structured `{detection, software, protocols, openRegistrations}` shape, rendered as prose in the MCP response. Failure modes return `detection: "unavailable"` with a one-line reason — the tool never throws on detection failure.
+- **`activitypub://instance-info/{domain}` resource enrichment.** Resource responses now include a structured `software:` block from the same NodeInfo detection, fetched in parallel with the existing instance-info payload. Resource fetches succeed even when software detection returns `unavailable`.
+- **`MCP_INSTANCE_SOFTWARE_TTL_MS` env var.** Tunes the positive-cache TTL for NodeInfo detection results. Default: `86_400_000` (24h). Negative-cache TTL (for detection failures) is hardcoded at 1h.
+- **Dependabot config.** Weekly npm and GitHub Actions update PRs, with minor+patch updates grouped to reduce noise; major bumps surface as individual PRs for explicit review.
+
+### Breaking changes
+
+- **`activitypub://post-thread/{postUrl}` URI form removed.** Deprecated in v2.0.0 with a warning; removed in 2.1.0. Use the canonical `activitypub://post-thread/{domain}/{statusId}` form. Callers using the legacy form receive an `InvalidParams` error with a migration message.
+- **`activitypub://instance-info/{domain}` `software` field is now an object.** Previously a plain string (e.g. `"mastodon"`) sourced from the upstream instance metadata. v2.1 replaces it with the structured `{detection, software, protocols, openRegistrations}` block from NodeInfo detection. The old string is no longer present in the response. Consumers reading `body.software` as a string should switch to `body.software.software?.name`.
+
+### Internal
+
+- Windows smoke-test bin-shim resolution.
+- Windows CRLF lint failure + CodeQL URL-sanitization alert.
+- Replaced hardcoded absolute path in `upload-media` test with relative resolution.
+- New `src/discovery/nodeinfo.ts` module: NodeInfo Zod schemas, `getInstanceSoftware` with positive + negative LRU caches, SSRF/blocklist guards, same-host/subdomain check on the linked NodeInfo URL, single-flight dedup for concurrent lookups.
+- Live-Fediverse integration test against `mastodon.social` for NodeInfo detection.
+
 ## [2.0.0] - 2026-05-27
 
 > **Major release.** v2 is a security, correctness, and ergonomics overhaul of the v1 server. See `MIGRATION-v2.md` for the full upgrade guide.

--- a/MIGRATION-v2.md
+++ b/MIGRATION-v2.md
@@ -244,15 +244,15 @@ activitypub://post-thread/mastodon.social/123456
 ```
 
 The new form constructs `https://{domain}/web/statuses/{statusId}` internally,
-which is the Mastodon-compatible ActivityPub URL. Non-Mastodon instances
-(Pleroma, Misskey, etc.) that do not support this path can continue using the
-legacy `{postUrl}` form until 2.1.0.
+which is the Mastodon-compatible ActivityPub URL.
 
-> **Note:** The new `{domain}/{statusId}` template constructs a Mastodon-style URL
-> (`https://{domain}/web/statuses/{statusId}`). Non-Mastodon ActivityPub implementations
-> (Pleroma, Akkoma, Misskey, etc.) have different status URL shapes and may not resolve
-> via this form. For non-Mastodon instances, continue using the legacy `{postUrl}` form
-> until instance-software detection lands in a future release.
+> **Note:** The legacy `{postUrl}` form was **removed in v2.1.0** (deprecated in
+> v2.0.0); callers using it now receive an `InvalidParams` error. The
+> `{domain}/{statusId}` template constructs a Mastodon-style URL
+> (`https://{domain}/web/statuses/{statusId}`); non-Mastodon implementations
+> (Pleroma, Akkoma, Misskey, etc.) have different status URL shapes and may not
+> resolve via this form. To identify an instance's software before constructing a
+> URL, use the `get-instance-software` tool added in v2.1.0.
 
 Reference commit: `a6f8049`
 

--- a/docs/superpowers/plans/2026-05-28-v2.1-release.md
+++ b/docs/superpowers/plans/2026-05-28-v2.1-release.md
@@ -1,0 +1,1896 @@
+# v2.1.0 Release Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship v2.1.0 with NodeInfo-based instance-software detection, removal of the deprecated `{postUrl}` URI form, Dependabot, and the three CI fixes already on the branch.
+
+**Architecture:** A new `src/discovery/nodeinfo.ts` module owns NodeInfo discovery + parsing + LRU caching + single-flight dedup. A new MCP tool `get-instance-software` wraps it; the existing `activitypub://instance-info/{domain}` resource enriches its response with the same module's output in parallel. The deprecated `{postUrl}` branch of the `post-thread` resource handler is deleted. Dependabot is added for npm + github-actions. All work flows through TDD: failing test first, minimal implementation, commit.
+
+**Tech Stack:** TypeScript (Node 20+), Zod for schema validation, vitest + MSW for unit tests, the existing `LRUCache`, `validateExternalUrl` (SSRF guard), `instanceBlocklist` (policy), and `fetchWithRedirectGuard` + `readJsonWithLimit` (streaming fetch helpers). All these already exist in the v2 codebase.
+
+---
+
+## File structure
+
+**Create:**
+- `src/discovery/nodeinfo.ts` — NodeInfo Zod schemas, `InstanceSoftwareInfo` type, cache, `getInstanceSoftware`, `formatInstanceSoftware`.
+- `tests/unit/nodeinfo.test.ts` — unit tests for the module.
+- `.github/dependabot.yml` — npm + github-actions update config.
+
+**Modify:**
+- `src/config.ts` — add `MCP_INSTANCE_SOFTWARE_TTL_MS`.
+- `src/mcp/tools.ts` — register `get-instance-software`.
+- `src/mcp/resources.ts` — enrich `instance-info` handler; remove legacy `{postUrl}` branch from `post-thread` handler.
+- `tests/unit/mcp-tools.test.ts` — tests for the new tool.
+- `tests/unit/mcp-resources.test.ts` — tests for software enrichment + legacy URI removal.
+- `tests/integration/live-instance-discovery.test.ts` — live NodeInfo hit against `mastodon.social`.
+- `.env.example`, `.env.production.example` — document new env var.
+- `CHANGELOG.md` — v2.1.0 section.
+- `package.json` — bump version to `2.1.0`.
+
+Each task below is self-contained: write the failing test, run it, implement minimally, run it green, commit. Run on branch `docs/v2-release-polish` (existing) — no new branch.
+
+---
+
+## Task 1: NodeInfo Zod schemas + `InstanceSoftwareInfo` type
+
+**Files:**
+- Create: `src/discovery/nodeinfo.ts`
+- Test: `tests/unit/nodeinfo.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/nodeinfo.test.ts`:
+
+```ts
+/**
+ * Unit tests for the NodeInfo discovery module.
+ */
+
+import { HttpResponse, http } from "msw";
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  NodeInfoDiscoverySchema,
+  NodeInfoSchema,
+} from "../../src/discovery/nodeinfo.js";
+
+describe("NodeInfo schemas", () => {
+  describe("NodeInfoDiscoverySchema", () => {
+    it("accepts a minimal valid discovery document", () => {
+      const doc = {
+        links: [
+          {
+            rel: "http://nodeinfo.diaspora.software/ns/schema/2.0",
+            href: "https://example.social/nodeinfo/2.0",
+          },
+        ],
+      };
+      expect(() => NodeInfoDiscoverySchema.parse(doc)).not.toThrow();
+    });
+
+    it("accepts multiple link versions (2.0 + 2.1)", () => {
+      const doc = {
+        links: [
+          { rel: "http://nodeinfo.diaspora.software/ns/schema/2.0", href: "https://x/2.0" },
+          { rel: "http://nodeinfo.diaspora.software/ns/schema/2.1", href: "https://x/2.1" },
+        ],
+      };
+      expect(() => NodeInfoDiscoverySchema.parse(doc)).not.toThrow();
+    });
+
+    it("rejects when links is missing", () => {
+      expect(() => NodeInfoDiscoverySchema.parse({})).toThrow();
+    });
+
+    it("rejects when a link entry is missing href", () => {
+      expect(() =>
+        NodeInfoDiscoverySchema.parse({
+          links: [{ rel: "http://nodeinfo.diaspora.software/ns/schema/2.0" }],
+        }),
+      ).toThrow();
+    });
+  });
+
+  describe("NodeInfoSchema", () => {
+    it("accepts a NodeInfo 2.0 body", () => {
+      const body = {
+        version: "2.0",
+        software: { name: "mastodon", version: "4.3.2" },
+        protocols: ["activitypub"],
+        openRegistrations: false,
+        usage: { users: { total: 10000 } },
+        services: { inbound: [], outbound: [] },
+      };
+      expect(() => NodeInfoSchema.parse(body)).not.toThrow();
+    });
+
+    it("accepts a NodeInfo 2.1 body", () => {
+      const body = {
+        version: "2.1",
+        software: { name: "pleroma", version: "2.7.0", repository: "https://example/repo" },
+        protocols: ["activitypub"],
+        openRegistrations: true,
+      };
+      expect(() => NodeInfoSchema.parse(body)).not.toThrow();
+    });
+
+    it("rejects when software.name is missing", () => {
+      expect(() =>
+        NodeInfoSchema.parse({
+          version: "2.0",
+          software: { version: "4.3.2" },
+          protocols: ["activitypub"],
+        }),
+      ).toThrow();
+    });
+
+    it("rejects when software.version is missing", () => {
+      expect(() =>
+        NodeInfoSchema.parse({
+          version: "2.0",
+          software: { name: "mastodon" },
+          protocols: ["activitypub"],
+        }),
+      ).toThrow();
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/unit/nodeinfo.test.ts`
+Expected: FAIL with "Cannot find module" or unresolved import.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `src/discovery/nodeinfo.ts`:
+
+```ts
+import { z } from "zod";
+
+/**
+ * NodeInfo discovery document (RFC-style `/.well-known/nodeinfo` index).
+ * See: https://nodeinfo.diaspora.software/
+ */
+export const NodeInfoDiscoverySchema = z.object({
+  links: z.array(
+    z.object({
+      rel: z.string(),
+      href: z.string(),
+    }),
+  ),
+});
+
+export type NodeInfoDiscovery = z.infer<typeof NodeInfoDiscoverySchema>;
+
+/**
+ * NodeInfo body schema (versions 2.0 and 2.1).
+ * Only the fields we actually expose to LLM consumers are required;
+ * `usage`, `services`, and `metadata` are tolerated but not validated strictly.
+ */
+export const NodeInfoSchema = z.object({
+  version: z.string().optional(),
+  software: z.object({
+    name: z.string(),
+    version: z.string(),
+    repository: z.string().optional(),
+    homepage: z.string().optional(),
+  }),
+  protocols: z.array(z.string()),
+  openRegistrations: z.boolean().optional(),
+  usage: z.unknown().optional(),
+  services: z.unknown().optional(),
+  metadata: z.unknown().optional(),
+});
+
+export type NodeInfo = z.infer<typeof NodeInfoSchema>;
+
+/**
+ * Result returned by `getInstanceSoftware`.
+ * `detection: 'unavailable'` populates null fields and a one-line `reason`.
+ */
+export type InstanceSoftwareInfo = {
+  domain: string;
+  detection: "success" | "unavailable";
+  software: { name: string; version: string } | null;
+  protocols: string[] | null;
+  openRegistrations: boolean | null;
+  reason?: string;
+};
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run tests/unit/nodeinfo.test.ts`
+Expected: PASS — 7 assertions.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/discovery/nodeinfo.ts tests/unit/nodeinfo.test.ts
+git commit -m "feat(discovery): NodeInfo Zod schemas + InstanceSoftwareInfo type"
+```
+
+---
+
+## Task 2: `getInstanceSoftware` happy path with positive caching
+
+**Files:**
+- Modify: `src/discovery/nodeinfo.ts`
+- Test: `tests/unit/nodeinfo.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/unit/nodeinfo.test.ts`:
+
+```ts
+import {
+  clearNodeInfoCache,
+  getInstanceSoftware,
+} from "../../src/discovery/nodeinfo.js";
+import { server } from "../mocks/server.js";
+
+describe("getInstanceSoftware — happy path + cache", () => {
+  beforeEach(() => {
+    clearNodeInfoCache();
+  });
+
+  it("returns success with software + version + protocols for a valid instance", async () => {
+    server.use(
+      http.get("https://happy.social/.well-known/nodeinfo", () =>
+        HttpResponse.json({
+          links: [
+            {
+              rel: "http://nodeinfo.diaspora.software/ns/schema/2.0",
+              href: "https://happy.social/nodeinfo/2.0",
+            },
+          ],
+        }),
+      ),
+      http.get("https://happy.social/nodeinfo/2.0", () =>
+        HttpResponse.json({
+          version: "2.0",
+          software: { name: "mastodon", version: "4.3.2" },
+          protocols: ["activitypub"],
+          openRegistrations: false,
+        }),
+      ),
+    );
+
+    const info = await getInstanceSoftware("happy.social");
+    expect(info).toEqual({
+      domain: "happy.social",
+      detection: "success",
+      software: { name: "mastodon", version: "4.3.2" },
+      protocols: ["activitypub"],
+      openRegistrations: false,
+    });
+  });
+
+  it("prefers 2.1 over 2.0 when both are advertised", async () => {
+    server.use(
+      http.get("https://dual.social/.well-known/nodeinfo", () =>
+        HttpResponse.json({
+          links: [
+            { rel: "http://nodeinfo.diaspora.software/ns/schema/2.0", href: "https://dual.social/nodeinfo/2.0" },
+            { rel: "http://nodeinfo.diaspora.software/ns/schema/2.1", href: "https://dual.social/nodeinfo/2.1" },
+          ],
+        }),
+      ),
+      http.get("https://dual.social/nodeinfo/2.1", () =>
+        HttpResponse.json({
+          version: "2.1",
+          software: { name: "pleroma", version: "2.7.0" },
+          protocols: ["activitypub"],
+        }),
+      ),
+    );
+
+    const info = await getInstanceSoftware("dual.social");
+    expect(info.detection).toBe("success");
+    expect(info.software).toEqual({ name: "pleroma", version: "2.7.0" });
+  });
+
+  it("caches positive results — second call does not hit the network", async () => {
+    let fetchCount = 0;
+    server.use(
+      http.get("https://cached.social/.well-known/nodeinfo", () => {
+        fetchCount++;
+        return HttpResponse.json({
+          links: [
+            { rel: "http://nodeinfo.diaspora.software/ns/schema/2.0", href: "https://cached.social/nodeinfo/2.0" },
+          ],
+        });
+      }),
+      http.get("https://cached.social/nodeinfo/2.0", () => {
+        fetchCount++;
+        return HttpResponse.json({
+          version: "2.0",
+          software: { name: "mastodon", version: "4.3.2" },
+          protocols: ["activitypub"],
+        });
+      }),
+    );
+
+    await getInstanceSoftware("cached.social");
+    await getInstanceSoftware("cached.social");
+    expect(fetchCount).toBe(2); // discovery + nodeinfo fetched ONCE
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/unit/nodeinfo.test.ts -t "getInstanceSoftware"`
+Expected: FAIL with import errors for `clearNodeInfoCache` and `getInstanceSoftware`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `src/discovery/nodeinfo.ts`:
+
+```ts
+import { getLogger } from "@logtape/logtape";
+import {
+  CACHE_MAX_SIZE,
+  MAX_RESPONSE_SIZE,
+  REQUEST_TIMEOUT,
+  USER_AGENT,
+} from "../config.js";
+import { fetchWithRedirectGuard, readJsonWithLimit } from "../utils/fetch-helpers.js";
+import { LRUCache } from "../utils/lru-cache.js";
+
+const logger = getLogger("activitypub-mcp:nodeinfo");
+
+const POSITIVE_TTL_MS = 24 * 60 * 60 * 1000; // 24h
+const NODEINFO_2_REL_PREFIX = "http://nodeinfo.diaspora.software/ns/schema/2.";
+
+const cache = new LRUCache<string, InstanceSoftwareInfo>({
+  maxSize: Math.min(CACHE_MAX_SIZE, 256),
+  ttl: POSITIVE_TTL_MS,
+});
+
+export function clearNodeInfoCache(): void {
+  cache.clear();
+}
+
+export async function getInstanceSoftware(domain: string): Promise<InstanceSoftwareInfo> {
+  const normalizedDomain = domain.toLowerCase();
+
+  const cached = cache.get(normalizedDomain);
+  if (cached) {
+    logger.debug("NodeInfo cache hit", { domain: normalizedDomain });
+    return cached;
+  }
+
+  const discoveryUrl = `https://${normalizedDomain}/.well-known/nodeinfo`;
+  const discoveryDoc = await fetchJson(discoveryUrl);
+  const discovery = NodeInfoDiscoverySchema.parse(discoveryDoc);
+
+  const link = pickHighestNodeInfo2Link(discovery);
+  if (!link) {
+    throw new Error("no NodeInfo 2.0/2.1 link in discovery document");
+  }
+
+  const body = await fetchJson(link.href);
+  const nodeInfo = NodeInfoSchema.parse(body);
+
+  const info: InstanceSoftwareInfo = {
+    domain: normalizedDomain,
+    detection: "success",
+    software: {
+      name: nodeInfo.software.name,
+      version: nodeInfo.software.version,
+    },
+    protocols: nodeInfo.protocols,
+    openRegistrations: nodeInfo.openRegistrations ?? null,
+  };
+
+  cache.set(normalizedDomain, info);
+  return info;
+}
+
+function pickHighestNodeInfo2Link(
+  doc: NodeInfoDiscovery,
+): { rel: string; href: string } | undefined {
+  const matches = doc.links
+    .filter((l) => l.rel.startsWith(NODEINFO_2_REL_PREFIX))
+    .sort((a, b) => b.rel.localeCompare(a.rel));
+  return matches[0];
+}
+
+async function fetchJson(url: string): Promise<unknown> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), REQUEST_TIMEOUT);
+
+  try {
+    const response = await fetchWithRedirectGuard(
+      url,
+      {
+        method: "GET",
+        headers: {
+          Accept: "application/json",
+          "User-Agent": USER_AGENT,
+        },
+        signal: controller.signal,
+      },
+      // No-op validate for now; replaced with SSRF guard in Task 4.
+      () => Promise.resolve(),
+    );
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status} ${response.statusText}`);
+    }
+    return await readJsonWithLimit(response, MAX_RESPONSE_SIZE);
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run tests/unit/nodeinfo.test.ts`
+Expected: PASS — all tests including the 3 happy-path tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/discovery/nodeinfo.ts tests/unit/nodeinfo.test.ts
+git commit -m "feat(discovery): getInstanceSoftware happy path + positive cache"
+```
+
+---
+
+## Task 3: Structured `unavailable` failure mode + negative cache
+
+**Files:**
+- Modify: `src/discovery/nodeinfo.ts`
+- Test: `tests/unit/nodeinfo.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/unit/nodeinfo.test.ts`:
+
+```ts
+describe("getInstanceSoftware — failure modes (never throws)", () => {
+  beforeEach(() => {
+    clearNodeInfoCache();
+  });
+
+  it("returns unavailable when discovery returns 404", async () => {
+    server.use(
+      http.get("https://missing.social/.well-known/nodeinfo", () =>
+        new HttpResponse(null, { status: 404 }),
+      ),
+    );
+
+    const info = await getInstanceSoftware("missing.social");
+    expect(info.detection).toBe("unavailable");
+    expect(info.software).toBeNull();
+    expect(info.reason).toMatch(/404/);
+  });
+
+  it("returns unavailable when discovery returns malformed JSON", async () => {
+    server.use(
+      http.get("https://malformed.social/.well-known/nodeinfo", () =>
+        new HttpResponse("not json", { status: 200, headers: { "content-type": "text/plain" } }),
+      ),
+    );
+
+    const info = await getInstanceSoftware("malformed.social");
+    expect(info.detection).toBe("unavailable");
+    expect(info.reason).toBeDefined();
+  });
+
+  it("returns unavailable when NodeInfo body fails schema", async () => {
+    server.use(
+      http.get("https://badschema.social/.well-known/nodeinfo", () =>
+        HttpResponse.json({
+          links: [
+            { rel: "http://nodeinfo.diaspora.software/ns/schema/2.0", href: "https://badschema.social/nodeinfo/2.0" },
+          ],
+        }),
+      ),
+      http.get("https://badschema.social/nodeinfo/2.0", () =>
+        HttpResponse.json({ software: { name: "mastodon" } }), // missing version, protocols
+      ),
+    );
+
+    const info = await getInstanceSoftware("badschema.social");
+    expect(info.detection).toBe("unavailable");
+  });
+
+  it("returns unavailable when discovery has no 2.0/2.1 link", async () => {
+    server.use(
+      http.get("https://onlyv1.social/.well-known/nodeinfo", () =>
+        HttpResponse.json({
+          links: [
+            { rel: "http://nodeinfo.diaspora.software/ns/schema/1.0", href: "https://onlyv1.social/nodeinfo/1.0" },
+          ],
+        }),
+      ),
+    );
+
+    const info = await getInstanceSoftware("onlyv1.social");
+    expect(info.detection).toBe("unavailable");
+    expect(info.reason).toMatch(/no NodeInfo 2/i);
+  });
+
+  it("caches unavailable results — repeated failures do not refetch", async () => {
+    let fetchCount = 0;
+    server.use(
+      http.get("https://flaky.social/.well-known/nodeinfo", () => {
+        fetchCount++;
+        return new HttpResponse(null, { status: 500 });
+      }),
+    );
+
+    await getInstanceSoftware("flaky.social");
+    await getInstanceSoftware("flaky.social");
+    expect(fetchCount).toBe(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/unit/nodeinfo.test.ts -t "failure modes"`
+Expected: FAIL — current code throws instead of returning structured `unavailable`.
+
+- [ ] **Step 3: Refactor `getInstanceSoftware` to wrap failures**
+
+Replace the body of `getInstanceSoftware` in `src/discovery/nodeinfo.ts`. Also add a separate negative cache:
+
+```ts
+const NEGATIVE_TTL_MS = 60 * 60 * 1000; // 1h
+
+const negativeCache = new LRUCache<string, InstanceSoftwareInfo>({
+  maxSize: Math.min(CACHE_MAX_SIZE, 256),
+  ttl: NEGATIVE_TTL_MS,
+});
+
+export function clearNodeInfoCache(): void {
+  cache.clear();
+  negativeCache.clear();
+}
+
+export async function getInstanceSoftware(domain: string): Promise<InstanceSoftwareInfo> {
+  const normalizedDomain = domain.toLowerCase();
+
+  const positive = cache.get(normalizedDomain);
+  if (positive) return positive;
+  const negative = negativeCache.get(normalizedDomain);
+  if (negative) return negative;
+
+  try {
+    const info = await performDetection(normalizedDomain);
+    cache.set(normalizedDomain, info);
+    return info;
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    const info: InstanceSoftwareInfo = {
+      domain: normalizedDomain,
+      detection: "unavailable",
+      software: null,
+      protocols: null,
+      openRegistrations: null,
+      reason,
+    };
+    logger.info("NodeInfo detection unavailable", { domain: normalizedDomain, reason });
+    negativeCache.set(normalizedDomain, info);
+    return info;
+  }
+}
+
+async function performDetection(domain: string): Promise<InstanceSoftwareInfo> {
+  const discoveryUrl = `https://${domain}/.well-known/nodeinfo`;
+  const discoveryDoc = await fetchJson(discoveryUrl);
+  const discovery = NodeInfoDiscoverySchema.parse(discoveryDoc);
+
+  const link = pickHighestNodeInfo2Link(discovery);
+  if (!link) {
+    throw new Error("no NodeInfo 2.0/2.1 link in discovery document");
+  }
+
+  const body = await fetchJson(link.href);
+  const nodeInfo = NodeInfoSchema.parse(body);
+
+  return {
+    domain,
+    detection: "success",
+    software: { name: nodeInfo.software.name, version: nodeInfo.software.version },
+    protocols: nodeInfo.protocols,
+    openRegistrations: nodeInfo.openRegistrations ?? null,
+  };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run tests/unit/nodeinfo.test.ts`
+Expected: PASS — all happy-path AND failure-mode tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/discovery/nodeinfo.ts tests/unit/nodeinfo.test.ts
+git commit -m "feat(discovery): structured unavailable result + negative cache for NodeInfo"
+```
+
+---
+
+## Task 4: SSRF gating + instance blocklist on both URLs
+
+**Files:**
+- Modify: `src/discovery/nodeinfo.ts`
+- Test: `tests/unit/nodeinfo.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/unit/nodeinfo.test.ts`:
+
+```ts
+import { instanceBlocklist } from "../../src/policy/instance-blocklist.js";
+
+describe("getInstanceSoftware — SSRF + blocklist", () => {
+  beforeEach(() => {
+    clearNodeInfoCache();
+    instanceBlocklist.clear();
+  });
+
+  it("returns unavailable when NodeInfo link points to a private IP", async () => {
+    server.use(
+      http.get("https://ssrf.social/.well-known/nodeinfo", () =>
+        HttpResponse.json({
+          links: [
+            { rel: "http://nodeinfo.diaspora.software/ns/schema/2.0", href: "https://127.0.0.1/nodeinfo/2.0" },
+          ],
+        }),
+      ),
+    );
+
+    const info = await getInstanceSoftware("ssrf.social");
+    expect(info.detection).toBe("unavailable");
+    expect(info.reason).toMatch(/not allowed|private/i);
+  });
+
+  it("returns unavailable when input domain is blocklisted", async () => {
+    instanceBlocklist.add("blocked.social");
+
+    const info = await getInstanceSoftware("blocked.social");
+    expect(info.detection).toBe("unavailable");
+    expect(info.reason).toMatch(/block/i);
+  });
+
+  it("returns unavailable when discovery URL uses non-https scheme", async () => {
+    // Discovery URL is constructed as https:// so this is enforced by validateExternalUrl
+    // when the user supplies a domain that resolves weirdly. Sanity-check the validator
+    // path runs by checking a domain whose resolution would be blocked.
+    server.use(
+      http.get("https://localhost.social/.well-known/nodeinfo", () =>
+        HttpResponse.json({
+          links: [
+            { rel: "http://nodeinfo.diaspora.software/ns/schema/2.0", href: "http://example.com/nodeinfo/2.0" },
+          ],
+        }),
+      ),
+    );
+
+    const info = await getInstanceSoftware("localhost.social");
+    expect(info.detection).toBe("unavailable");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/unit/nodeinfo.test.ts -t "SSRF"`
+Expected: FAIL — current code has no SSRF guard or blocklist check.
+
+- [ ] **Step 3: Wire SSRF + blocklist into the fetch path**
+
+In `src/discovery/nodeinfo.ts`, add imports and replace `fetchJson` plus thread the validation into `performDetection`:
+
+```ts
+import { instanceBlocklist } from "../policy/instance-blocklist.js";
+import { validateExternalUrl } from "../validation/url.js";
+```
+
+Replace `performDetection`:
+
+```ts
+async function performDetection(domain: string): Promise<InstanceSoftwareInfo> {
+  // Policy + SSRF gate on input domain.
+  instanceBlocklist.validateNotBlocked(domain);
+
+  const discoveryUrl = `https://${domain}/.well-known/nodeinfo`;
+  await validateExternalUrl(discoveryUrl);
+  const discoveryDoc = await fetchJson(discoveryUrl);
+  const discovery = NodeInfoDiscoverySchema.parse(discoveryDoc);
+
+  const link = pickHighestNodeInfo2Link(discovery);
+  if (!link) {
+    throw new Error("no NodeInfo 2.0/2.1 link in discovery document");
+  }
+
+  // SSRF guard + blocklist on the linked NodeInfo URL.
+  await validateExternalUrl(link.href);
+  const linkedHost = new URL(link.href).hostname.toLowerCase();
+  instanceBlocklist.validateNotBlocked(linkedHost);
+
+  const body = await fetchJson(link.href);
+  const nodeInfo = NodeInfoSchema.parse(body);
+
+  return {
+    domain,
+    detection: "success",
+    software: { name: nodeInfo.software.name, version: nodeInfo.software.version },
+    protocols: nodeInfo.protocols,
+    openRegistrations: nodeInfo.openRegistrations ?? null,
+  };
+}
+```
+
+Replace the `fetchJson` validate callback so redirects are also gated:
+
+```ts
+async function fetchJson(url: string): Promise<unknown> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), REQUEST_TIMEOUT);
+
+  try {
+    const response = await fetchWithRedirectGuard(
+      url,
+      {
+        method: "GET",
+        headers: { Accept: "application/json", "User-Agent": USER_AGENT },
+        signal: controller.signal,
+      },
+      async (target) => {
+        await validateExternalUrl(target);
+        const targetHost = new URL(target).hostname;
+        instanceBlocklist.validateNotBlocked(targetHost);
+      },
+    );
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status} ${response.statusText}`);
+    }
+    return await readJsonWithLimit(response, MAX_RESPONSE_SIZE);
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run tests/unit/nodeinfo.test.ts`
+Expected: PASS — all SSRF/blocklist + earlier tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/discovery/nodeinfo.ts tests/unit/nodeinfo.test.ts
+git commit -m "feat(discovery): SSRF + blocklist gating on NodeInfo discovery and linked URL"
+```
+
+---
+
+## Task 5: Same-host (or subdomain) check on the linked NodeInfo URL
+
+**Files:**
+- Modify: `src/discovery/nodeinfo.ts`
+- Test: `tests/unit/nodeinfo.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/unit/nodeinfo.test.ts`:
+
+```ts
+describe("getInstanceSoftware — same-host check on linked URL", () => {
+  beforeEach(() => {
+    clearNodeInfoCache();
+    instanceBlocklist.clear();
+  });
+
+  it("accepts a linked NodeInfo URL on the exact same host", async () => {
+    server.use(
+      http.get("https://exact.social/.well-known/nodeinfo", () =>
+        HttpResponse.json({
+          links: [
+            { rel: "http://nodeinfo.diaspora.software/ns/schema/2.0", href: "https://exact.social/nodeinfo/2.0" },
+          ],
+        }),
+      ),
+      http.get("https://exact.social/nodeinfo/2.0", () =>
+        HttpResponse.json({
+          software: { name: "mastodon", version: "4.3.2" },
+          protocols: ["activitypub"],
+        }),
+      ),
+    );
+
+    const info = await getInstanceSoftware("exact.social");
+    expect(info.detection).toBe("success");
+  });
+
+  it("accepts a linked NodeInfo URL on a subdomain of the input", async () => {
+    server.use(
+      http.get("https://parent.social/.well-known/nodeinfo", () =>
+        HttpResponse.json({
+          links: [
+            { rel: "http://nodeinfo.diaspora.software/ns/schema/2.0", href: "https://nodeinfo.parent.social/2.0" },
+          ],
+        }),
+      ),
+      http.get("https://nodeinfo.parent.social/2.0", () =>
+        HttpResponse.json({
+          software: { name: "akkoma", version: "3.13.0" },
+          protocols: ["activitypub"],
+        }),
+      ),
+    );
+
+    const info = await getInstanceSoftware("parent.social");
+    expect(info.detection).toBe("success");
+    expect(info.software?.name).toBe("akkoma");
+  });
+
+  it("rejects a linked NodeInfo URL on an unrelated host", async () => {
+    server.use(
+      http.get("https://victim.social/.well-known/nodeinfo", () =>
+        HttpResponse.json({
+          links: [
+            { rel: "http://nodeinfo.diaspora.software/ns/schema/2.0", href: "https://attacker.com/nodeinfo/2.0" },
+          ],
+        }),
+      ),
+    );
+
+    const info = await getInstanceSoftware("victim.social");
+    expect(info.detection).toBe("unavailable");
+    expect(info.reason).toMatch(/different host|cross-host/i);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/unit/nodeinfo.test.ts -t "same-host"`
+Expected: FAIL — current code accepts cross-host links.
+
+- [ ] **Step 3: Add same-host check to `performDetection`**
+
+In `src/discovery/nodeinfo.ts`, add the helper and use it before fetching the linked NodeInfo URL:
+
+```ts
+function isSameOrSubdomain(input: string, candidate: string): boolean {
+  const a = input.toLowerCase();
+  const b = candidate.toLowerCase();
+  return b === a || b.endsWith(`.${a}`);
+}
+```
+
+Insert into `performDetection`, immediately after `await validateExternalUrl(link.href);`:
+
+```ts
+  const linkedHost = new URL(link.href).hostname.toLowerCase();
+  if (!isSameOrSubdomain(domain, linkedHost)) {
+    throw new Error(`linked NodeInfo URL on different host (${linkedHost}, expected ${domain} or subdomain)`);
+  }
+  instanceBlocklist.validateNotBlocked(linkedHost);
+```
+
+(Remove the existing `const linkedHost = …` and `instanceBlocklist.validateNotBlocked(linkedHost);` from Task 4 — they're replaced by the block above.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run tests/unit/nodeinfo.test.ts`
+Expected: PASS — same-host tests plus all earlier tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/discovery/nodeinfo.ts tests/unit/nodeinfo.test.ts
+git commit -m "feat(discovery): reject cross-host NodeInfo links (allow exact + subdomain)"
+```
+
+---
+
+## Task 6: Single-flight dedup for concurrent calls
+
+**Files:**
+- Modify: `src/discovery/nodeinfo.ts`
+- Test: `tests/unit/nodeinfo.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/unit/nodeinfo.test.ts`:
+
+```ts
+describe("getInstanceSoftware — single-flight", () => {
+  beforeEach(() => {
+    clearNodeInfoCache();
+  });
+
+  it("two concurrent calls for the same domain trigger a single discovery fetch", async () => {
+    let discoveryHits = 0;
+    server.use(
+      http.get("https://race.social/.well-known/nodeinfo", async () => {
+        discoveryHits++;
+        // Yield to let any second caller arrive before responding.
+        await new Promise((r) => setTimeout(r, 25));
+        return HttpResponse.json({
+          links: [
+            { rel: "http://nodeinfo.diaspora.software/ns/schema/2.0", href: "https://race.social/nodeinfo/2.0" },
+          ],
+        });
+      }),
+      http.get("https://race.social/nodeinfo/2.0", () =>
+        HttpResponse.json({
+          software: { name: "mastodon", version: "4.3.2" },
+          protocols: ["activitypub"],
+        }),
+      ),
+    );
+
+    const [a, b] = await Promise.all([
+      getInstanceSoftware("race.social"),
+      getInstanceSoftware("race.social"),
+    ]);
+    expect(a).toEqual(b);
+    expect(discoveryHits).toBe(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/unit/nodeinfo.test.ts -t "single-flight"`
+Expected: FAIL — current code performs 2 discovery hits because the cache only fills after the first call resolves.
+
+- [ ] **Step 3: Add in-flight map**
+
+In `src/discovery/nodeinfo.ts`, just above `clearNodeInfoCache`:
+
+```ts
+const inFlight = new Map<string, Promise<InstanceSoftwareInfo>>();
+```
+
+Modify `clearNodeInfoCache` to clear the in-flight map too:
+
+```ts
+export function clearNodeInfoCache(): void {
+  cache.clear();
+  negativeCache.clear();
+  inFlight.clear();
+}
+```
+
+Replace `getInstanceSoftware`'s body so it deduplicates:
+
+```ts
+export async function getInstanceSoftware(domain: string): Promise<InstanceSoftwareInfo> {
+  const normalizedDomain = domain.toLowerCase();
+
+  const positive = cache.get(normalizedDomain);
+  if (positive) return positive;
+  const negative = negativeCache.get(normalizedDomain);
+  if (negative) return negative;
+
+  const existing = inFlight.get(normalizedDomain);
+  if (existing) return existing;
+
+  const promise = (async () => {
+    try {
+      const info = await performDetection(normalizedDomain);
+      cache.set(normalizedDomain, info);
+      return info;
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : String(error);
+      const info: InstanceSoftwareInfo = {
+        domain: normalizedDomain,
+        detection: "unavailable",
+        software: null,
+        protocols: null,
+        openRegistrations: null,
+        reason,
+      };
+      logger.info("NodeInfo detection unavailable", { domain: normalizedDomain, reason });
+      negativeCache.set(normalizedDomain, info);
+      return info;
+    } finally {
+      inFlight.delete(normalizedDomain);
+    }
+  })();
+
+  inFlight.set(normalizedDomain, promise);
+  return promise;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run tests/unit/nodeinfo.test.ts`
+Expected: PASS — single-flight test plus all earlier tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/discovery/nodeinfo.ts tests/unit/nodeinfo.test.ts
+git commit -m "feat(discovery): single-flight dedup for concurrent NodeInfo lookups"
+```
+
+---
+
+## Task 7: `formatInstanceSoftware` prose formatter
+
+**Files:**
+- Modify: `src/discovery/nodeinfo.ts`
+- Test: `tests/unit/nodeinfo.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/unit/nodeinfo.test.ts`:
+
+```ts
+import { formatInstanceSoftware } from "../../src/discovery/nodeinfo.js";
+
+describe("formatInstanceSoftware", () => {
+  it("formats a success result as a single human-readable line", () => {
+    const text = formatInstanceSoftware({
+      domain: "mastodon.social",
+      detection: "success",
+      software: { name: "mastodon", version: "4.3.2" },
+      protocols: ["activitypub"],
+      openRegistrations: false,
+    });
+    expect(text).toContain("mastodon.social");
+    expect(text).toContain("Mastodon");
+    expect(text).toContain("4.3.2");
+    expect(text).toContain("activitypub");
+    expect(text).toContain("false");
+  });
+
+  it("formats an unavailable result with the reason", () => {
+    const text = formatInstanceSoftware({
+      domain: "missing.social",
+      detection: "unavailable",
+      software: null,
+      protocols: null,
+      openRegistrations: null,
+      reason: "HTTP 404 Not Found",
+    });
+    expect(text).toMatch(/could not detect/i);
+    expect(text).toContain("missing.social");
+    expect(text).toContain("HTTP 404");
+  });
+
+  it("capitalizes common software names", () => {
+    const text = formatInstanceSoftware({
+      domain: "x.social",
+      detection: "success",
+      software: { name: "pleroma", version: "2.7.0" },
+      protocols: ["activitypub"],
+      openRegistrations: null,
+    });
+    expect(text).toContain("Pleroma");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/unit/nodeinfo.test.ts -t "formatInstanceSoftware"`
+Expected: FAIL — `formatInstanceSoftware` doesn't exist yet.
+
+- [ ] **Step 3: Add the formatter**
+
+Append to `src/discovery/nodeinfo.ts`:
+
+```ts
+function titleCase(name: string): string {
+  if (!name) return name;
+  return name.charAt(0).toUpperCase() + name.slice(1);
+}
+
+export function formatInstanceSoftware(info: InstanceSoftwareInfo): string {
+  if (info.detection === "unavailable") {
+    return `Could not detect software for \`${info.domain}\`: ${info.reason ?? "unknown reason"}.`;
+  }
+  const software = info.software;
+  const protocols = info.protocols ?? [];
+  const openReg = info.openRegistrations;
+  const parts: string[] = [];
+  if (software) {
+    parts.push(`\`${info.domain}\` runs **${titleCase(software.name)} ${software.version}**.`);
+  } else {
+    parts.push(`\`${info.domain}\` software metadata unavailable.`);
+  }
+  if (protocols.length > 0) {
+    parts.push(`Protocols: ${protocols.join(", ")}.`);
+  }
+  if (openReg !== null) {
+    parts.push(`Open registrations: ${openReg}.`);
+  }
+  return parts.join(" ");
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run tests/unit/nodeinfo.test.ts`
+Expected: PASS — formatter tests + all prior tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/discovery/nodeinfo.ts tests/unit/nodeinfo.test.ts
+git commit -m "feat(discovery): formatInstanceSoftware prose formatter"
+```
+
+---
+
+## Task 8: Wire `MCP_INSTANCE_SOFTWARE_TTL_MS` env var into config
+
+**Files:**
+- Modify: `src/config.ts`, `.env.example`, `.env.production.example`
+- Modify: `src/discovery/nodeinfo.ts`
+- Test: `tests/unit/config.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/unit/config.test.ts`:
+
+```ts
+describe("INSTANCE_SOFTWARE_TTL", () => {
+  it("defaults to 24h (86_400_000 ms)", async () => {
+    // The const is evaluated at import time, so re-import after setting the env.
+    const original = process.env.MCP_INSTANCE_SOFTWARE_TTL_MS;
+    delete process.env.MCP_INSTANCE_SOFTWARE_TTL_MS;
+    const mod = await import(`../../src/config.js?ts=${Date.now()}`);
+    expect(mod.INSTANCE_SOFTWARE_TTL).toBe(86_400_000);
+    process.env.MCP_INSTANCE_SOFTWARE_TTL_MS = original;
+  });
+});
+```
+
+(If the existing `config.test.ts` already has a `describe` block, place this inside it or alongside; preserve style. The dynamic-import trick is a common pattern for testing env-derived consts.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/unit/config.test.ts -t "INSTANCE_SOFTWARE_TTL"`
+Expected: FAIL — `INSTANCE_SOFTWARE_TTL` is undefined.
+
+- [ ] **Step 3: Add the const**
+
+In `src/config.ts`, after the `DYNAMIC_INSTANCE_CACHE_TTL` block:
+
+```ts
+// =============================================================================
+// Instance Software Detection (NodeInfo) Configuration
+// =============================================================================
+
+/**
+ * TTL for cached NodeInfo software-detection results, in milliseconds.
+ * Default: 24h. Negative-cache TTL (for detection failures) is hardcoded at 1h.
+ */
+export const INSTANCE_SOFTWARE_TTL = parseIntEnv(
+  process.env.MCP_INSTANCE_SOFTWARE_TTL_MS,
+  86_400_000,
+);
+```
+
+In `src/discovery/nodeinfo.ts`, replace the hardcoded `POSITIVE_TTL_MS` with the import:
+
+```ts
+import {
+  CACHE_MAX_SIZE,
+  INSTANCE_SOFTWARE_TTL,
+  MAX_RESPONSE_SIZE,
+  REQUEST_TIMEOUT,
+  USER_AGENT,
+} from "../config.js";
+
+// ...
+
+const NEGATIVE_TTL_MS = 60 * 60 * 1000; // 1h, hardcoded.
+
+const cache = new LRUCache<string, InstanceSoftwareInfo>({
+  maxSize: Math.min(CACHE_MAX_SIZE, 256),
+  ttl: INSTANCE_SOFTWARE_TTL,
+});
+```
+
+(Delete the `POSITIVE_TTL_MS` const and its usage.)
+
+Document the new env var in `.env.example` and `.env.production.example`. Place under a heading consistent with the existing structure (e.g., under "Cache Configuration" or a new "Instance Software Detection" block):
+
+```ini
+# Cache TTL for instance-software (NodeInfo) detection in milliseconds (default: 24h)
+# MCP_INSTANCE_SOFTWARE_TTL_MS=86400000
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run tests/unit/config.test.ts tests/unit/nodeinfo.test.ts`
+Expected: PASS — both suites green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/config.ts src/discovery/nodeinfo.ts tests/unit/config.test.ts .env.example .env.production.example
+git commit -m "feat(config): MCP_INSTANCE_SOFTWARE_TTL_MS for NodeInfo cache TTL"
+```
+
+---
+
+## Task 9: Register `get-instance-software` MCP tool
+
+**Files:**
+- Modify: `src/mcp/tools.ts`
+- Test: `tests/unit/mcp-tools.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/unit/mcp-tools.test.ts` (find the suite that exercises tool registration; mirror its pattern). Add a new describe block:
+
+```ts
+import { HttpResponse, http } from "msw";
+import { clearNodeInfoCache } from "../../src/discovery/nodeinfo.js";
+import { auditLogger } from "../../src/audit/logger.js";
+
+describe("get-instance-software tool", () => {
+  beforeEach(() => {
+    clearNodeInfoCache();
+  });
+
+  it("returns a prose success message for a valid instance", async () => {
+    server.use(
+      http.get("https://tools-success.social/.well-known/nodeinfo", () =>
+        HttpResponse.json({
+          links: [
+            { rel: "http://nodeinfo.diaspora.software/ns/schema/2.0", href: "https://tools-success.social/nodeinfo/2.0" },
+          ],
+        }),
+      ),
+      http.get("https://tools-success.social/nodeinfo/2.0", () =>
+        HttpResponse.json({
+          software: { name: "mastodon", version: "4.3.2" },
+          protocols: ["activitypub"],
+          openRegistrations: false,
+        }),
+      ),
+    );
+
+    const result = await callRegisteredTool("get-instance-software", { domain: "tools-success.social" });
+    expect(result.isError).not.toBe(true);
+    const text = (result.content?.[0] as { text: string })?.text ?? "";
+    expect(text).toContain("Mastodon");
+    expect(text).toContain("4.3.2");
+  });
+
+  it("returns an unavailable prose message when detection fails", async () => {
+    server.use(
+      http.get("https://tools-fail.social/.well-known/nodeinfo", () =>
+        new HttpResponse(null, { status: 404 }),
+      ),
+    );
+
+    const result = await callRegisteredTool("get-instance-software", { domain: "tools-fail.social" });
+    const text = (result.content?.[0] as { text: string })?.text ?? "";
+    expect(text).toMatch(/could not detect/i);
+  });
+
+  it("rejects an invalid domain via DomainSchema", async () => {
+    await expect(
+      callRegisteredTool("get-instance-software", { domain: "not a domain" }),
+    ).rejects.toThrow();
+  });
+
+  it("emits an audit log entry on invocation", async () => {
+    server.use(
+      http.get("https://audit.social/.well-known/nodeinfo", () =>
+        HttpResponse.json({
+          links: [
+            { rel: "http://nodeinfo.diaspora.software/ns/schema/2.0", href: "https://audit.social/nodeinfo/2.0" },
+          ],
+        }),
+      ),
+      http.get("https://audit.social/nodeinfo/2.0", () =>
+        HttpResponse.json({
+          software: { name: "mastodon", version: "4.3.2" },
+          protocols: ["activitypub"],
+        }),
+      ),
+    );
+
+    const before = auditLogger.getRecentEntries().length;
+    await callRegisteredTool("get-instance-software", { domain: "audit.social" });
+    const after = auditLogger.getRecentEntries().length;
+    expect(after).toBeGreaterThan(before);
+  });
+});
+```
+
+`callRegisteredTool` is a helper that should already exist in `mcp-tools.test.ts` (it's used by every other tool test). If not, copy the pattern from the test file: it instantiates the server, runs `registerTools`, and invokes the tool by name. Reuse whatever fixture is already there.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/unit/mcp-tools.test.ts -t "get-instance-software"`
+Expected: FAIL — tool not registered.
+
+- [ ] **Step 3: Register the tool**
+
+In `src/mcp/tools.ts`, add imports near the top of the file:
+
+```ts
+import { formatInstanceSoftware, getInstanceSoftware } from "../discovery/nodeinfo.js";
+import { auditLogger } from "../audit/logger.js";
+import { DomainSchema } from "../validation/schemas.js";
+```
+
+(`auditLogger` and `DomainSchema` may already be imported — don't duplicate.)
+
+Inside `registerTools`, add a call:
+
+```ts
+  registerGetInstanceSoftwareTool(mcpServer, rateLimiter);
+```
+
+At the end of the file (next to the other `register*Tool` functions), add:
+
+```ts
+/**
+ * get-instance-software tool — detect ActivityPub software running on an instance via NodeInfo.
+ */
+function registerGetInstanceSoftwareTool(mcpServer: McpServer, rateLimiter: RateLimiter): void {
+  mcpServer.registerTool(
+    "get-instance-software",
+    {
+      title: "Detect Instance Software",
+      description:
+        "Detect the ActivityPub software (e.g. Mastodon, Pleroma, Misskey, Akkoma) and version " +
+        "running on a Fediverse instance via NodeInfo. Returns a description; if detection fails " +
+        "(no NodeInfo, malformed response, blocked host), returns a one-line 'could not detect' " +
+        "message with the reason. Never throws on detection failure.",
+      inputSchema: {
+        domain: DomainSchema.describe(
+          "Fediverse instance domain (e.g., 'mastodon.social'). Do not include scheme or path.",
+        ),
+      },
+    },
+    async ({ domain }) => {
+      const start = Date.now();
+      try {
+        checkRateLimit(rateLimiter, domain);
+        const info = await getInstanceSoftware(domain);
+        auditLogger.logToolInvocation(
+          "get-instance-software",
+          { domain },
+          { success: info.detection === "success", duration: Date.now() - start },
+        );
+        return { content: [{ type: "text", text: formatInstanceSoftware(info) }] };
+      } catch (error) {
+        const errorMessage = getErrorMessage(error);
+        auditLogger.logToolInvocation(
+          "get-instance-software",
+          { domain },
+          { success: false, duration: Date.now() - start, error: errorMessage },
+        );
+        if (error instanceof McpError) throw error;
+        return {
+          content: [
+            { type: "text", text: `Failed to detect instance software: ${errorMessage}` },
+          ],
+          isError: true,
+        };
+      }
+    },
+  );
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run tests/unit/mcp-tools.test.ts -t "get-instance-software"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/mcp/tools.ts tests/unit/mcp-tools.test.ts
+git commit -m "feat(mcp): get-instance-software tool"
+```
+
+---
+
+## Task 10: Enrich `activitypub://instance-info/{domain}` resource with software info
+
+**Files:**
+- Modify: `src/mcp/resources.ts`
+- Test: `tests/unit/mcp-resources.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/unit/mcp-resources.test.ts` (mirror its existing instance-info test pattern):
+
+```ts
+import { clearNodeInfoCache } from "../../src/discovery/nodeinfo.js";
+
+describe("instance-info resource — software enrichment", () => {
+  beforeEach(() => {
+    clearNodeInfoCache();
+  });
+
+  it("includes software detection in the response on success", async () => {
+    server.use(
+      http.get("https://enriched.social/.well-known/nodeinfo", () =>
+        HttpResponse.json({
+          links: [
+            { rel: "http://nodeinfo.diaspora.software/ns/schema/2.0", href: "https://enriched.social/nodeinfo/2.0" },
+          ],
+        }),
+      ),
+      http.get("https://enriched.social/nodeinfo/2.0", () =>
+        HttpResponse.json({
+          software: { name: "mastodon", version: "4.3.2" },
+          protocols: ["activitypub"],
+        }),
+      ),
+      // ...also stub whatever remoteClient.getInstanceInfo hits for enriched.social.
+      // Mirror the existing instance-info resource tests for the exact stubs.
+    );
+
+    const result = await readResource("activitypub://instance-info/enriched.social");
+    const body = JSON.parse(result.contents[0].text);
+    expect(body.software).toBeDefined();
+    expect(body.software.detection).toBe("success");
+    expect(body.software.software.name).toBe("mastodon");
+  });
+
+  it("returns successfully with software=unavailable when detection fails", async () => {
+    server.use(
+      http.get("https://noinfo.social/.well-known/nodeinfo", () =>
+        new HttpResponse(null, { status: 404 }),
+      ),
+      // ...stub remoteClient.getInstanceInfo for noinfo.social as in existing tests.
+    );
+
+    const result = await readResource("activitypub://instance-info/noinfo.social");
+    const body = JSON.parse(result.contents[0].text);
+    expect(body.software).toBeDefined();
+    expect(body.software.detection).toBe("unavailable");
+  });
+});
+```
+
+(`readResource` is the existing helper used elsewhere in this file. If you need to stub the upstream `getInstanceInfo` call, copy whatever stubs the existing instance-info tests use — they already exist.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/unit/mcp-resources.test.ts -t "software enrichment"`
+Expected: FAIL — `body.software` is undefined.
+
+- [ ] **Step 3: Add the enrichment**
+
+In `src/mcp/resources.ts`, add an import near the top:
+
+```ts
+import { getInstanceSoftware } from "../discovery/nodeinfo.js";
+```
+
+Modify the `registerInstanceInfoResource` handler (around line 301). Replace the body of the `async (uri, { domain }) => { ... }` handler with:
+
+```ts
+    async (uri, { domain }) => {
+      try {
+        const domainStr = extractSingleValue(domain);
+        const validDomain = DomainSchema.parse(domainStr);
+
+        checkRateLimit(rateLimiter, validDomain);
+
+        logger.info("Fetching instance info", { domain: validDomain });
+
+        const [instanceInfo, software] = await Promise.all([
+          remoteClient.getInstanceInfo(validDomain),
+          getInstanceSoftware(validDomain),
+        ]);
+
+        const normalizedInstanceInfo = {
+          ...instanceInfo,
+          title: instanceInfo.description || `${instanceInfo.software || "Unknown"} instance`,
+          uri: `https://${validDomain}`,
+          software,
+        };
+
+        return {
+          contents: [
+            {
+              uri: uri.href,
+              mimeType: "application/json",
+              text: JSON.stringify(normalizedInstanceInfo, null, 2),
+            },
+          ],
+        };
+      } catch (error) {
+        logger.error("Failed to fetch instance info", {
+          domain,
+          error: getErrorMessage(error),
+        });
+
+        if (error instanceof McpError) {
+          throw error;
+        }
+
+        throw new McpError(
+          ErrorCode.InternalError,
+          `Failed to fetch instance info: ${getErrorMessage(error)}`,
+        );
+      }
+    },
+```
+
+Note: the existing instanceInfo response already has a `software` string field from upstream `remoteClient.getInstanceInfo`. Renaming risks confusion — but our enrichment field is an object (`InstanceSoftwareInfo`), and the spread comes before the assignment, so our `software` object wins. The pre-existing `software` string was sourced from the same NodeInfo data in some code paths and is redundant once enrichment is wired. Acceptable shape: a structured `software:` object overrides the string. If existing tests asserting on the string break, update them to use the new structured shape.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run tests/unit/mcp-resources.test.ts`
+Expected: PASS — including the new enrichment tests. If any pre-existing `instance-info` test fails because it expected `software` to be a string, update it to the new structured shape.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/mcp/resources.ts tests/unit/mcp-resources.test.ts
+git commit -m "feat(mcp): enrich instance-info resource with NodeInfo software detection"
+```
+
+---
+
+## Task 11: Remove deprecated `{postUrl}` URI form from `post-thread` resource
+
+**Files:**
+- Modify: `src/mcp/resources.ts`
+- Test: `tests/unit/mcp-resources.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/unit/mcp-resources.test.ts`:
+
+```ts
+describe("post-thread resource — legacy {postUrl} removed", () => {
+  it("rejects the legacy encoded-URL form with an InvalidParams error", async () => {
+    const encodedUrl = encodeURIComponent("https://mastodon.social/@alice/123456");
+    await expect(
+      readResource(`activitypub://post-thread/${encodedUrl}`),
+    ).rejects.toThrow();
+  });
+
+  it("accepts the canonical {domain}/{statusId} form", async () => {
+    // ...stub remoteClient.fetchPostThread for "https://mastodon.social/web/statuses/123456"
+    // as the existing post-thread tests already do.
+    const result = await readResource("activitypub://post-thread/mastodon.social/123456");
+    expect(result.contents[0].text).toBeDefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify the legacy-rejection test fails**
+
+Run: `npx vitest run tests/unit/mcp-resources.test.ts -t "legacy"`
+Expected: FAIL — current code still accepts the legacy form (with a deprecation warning).
+
+- [ ] **Step 3: Delete the legacy branch**
+
+In `src/mcp/resources.ts`, replace the body of the `post-thread` resource handler. Delete the `looksLikeEncodedUrl` branch and the deprecation warning. Replace the handler body (around lines 726–805) with:
+
+```ts
+    async (uri, params) => {
+      try {
+        const domain = extractSingleValue(params.domain ?? "");
+        const statusId = extractSingleValue(params.statusId ?? "");
+
+        if (!domain || !statusId) {
+          throw new McpError(
+            ErrorCode.InvalidParams,
+            "post-thread requires {domain} and {statusId} in the URI (e.g. activitypub://post-thread/mastodon.social/123456)",
+          );
+        }
+
+        // Reject the v1 encoded-URL form explicitly to give callers a clear migration message.
+        if (domain.includes("%3A%2F%2F") || domain.includes("://")) {
+          throw new McpError(
+            ErrorCode.InvalidParams,
+            "post-thread URI template `{postUrl}` was removed in 2.1.0. " +
+              "Use activitypub://post-thread/{domain}/{statusId} instead.",
+          );
+        }
+
+        const postUrl = `https://${domain}/web/statuses/${statusId}`;
+        const parsedUrl = new URL(postUrl);
+        checkRateLimit(rateLimiter, parsedUrl.hostname);
+
+        logger.info("Fetching post thread", { postUrl });
+
+        const threadData = await remoteClient.fetchPostThread(parsedUrl.href, {
+          depth: 2,
+          maxReplies: 50,
+        });
+
+        const resourceData = {
+          postUrl: parsedUrl.href,
+          timestamp: new Date().toISOString(),
+          post: threadData.post,
+          ancestors: threadData.ancestors,
+          replies: threadData.replies,
+          totalReplies: threadData.totalReplies,
+        };
+
+        return {
+          contents: [
+            {
+              uri: uri.href,
+              mimeType: "application/json",
+              text: JSON.stringify(resourceData, null, 2),
+            },
+          ],
+        };
+      } catch (error) {
+        if (error instanceof McpError) {
+          throw error;
+        }
+        throw new McpError(
+          ErrorCode.InternalError,
+          `Failed to fetch post thread: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+    },
+```
+
+Also update the JSDoc comment block above `registerPostThreadResource` (around line 693–698):
+
+```ts
+/**
+ * Post thread resource - get a post and its full conversation thread.
+ *
+ * URI template: activitypub://post-thread/{domain}/{statusId}
+ * (Legacy {postUrl} form removed in v2.1.0; was deprecated in v2.0.0.)
+ */
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run tests/unit/mcp-resources.test.ts`
+Expected: PASS — including the new rejection test and the existing canonical-form tests. If any existing test asserts the legacy form succeeded, it must be deleted (the form is gone).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/mcp/resources.ts tests/unit/mcp-resources.test.ts
+git commit -m "feat(mcp)!: remove deprecated post-thread {postUrl} URI form
+
+The legacy encoded-URL form was deprecated in v2.0.0 with a warning.
+v2.1.0 removes it entirely. Callers must use the canonical
+activitypub://post-thread/{domain}/{statusId} form."
+```
+
+---
+
+## Task 12: Add Dependabot configuration
+
+**Files:**
+- Create: `.github/dependabot.yml`
+
+- [ ] **Step 1: Write the config**
+
+Create `.github/dependabot.yml`:
+
+```yaml
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+```
+
+- [ ] **Step 2: Verify YAML parses**
+
+Run: `npx js-yaml .github/dependabot.yml > /dev/null` (or any local YAML linter). Confirm no parse error.
+
+If `js-yaml` isn't installed globally, just visually verify the indentation. Dependabot's own GitHub-side parser will be the final authority — there's no unit test here.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/dependabot.yml
+git commit -m "ci: enable Dependabot for npm and github-actions
+
+Weekly cadence, grouped minor+patch to reduce PR noise, major bumps
+remain individual for explicit review."
+```
+
+---
+
+## Task 13: Add live-fediverse integration test for NodeInfo
+
+**Files:**
+- Modify: `tests/integration/live-instance-discovery.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/integration/live-instance-discovery.test.ts`:
+
+```ts
+import { clearNodeInfoCache, getInstanceSoftware } from "../../src/discovery/nodeinfo.js";
+
+describe("live NodeInfo detection", () => {
+  beforeEach(() => {
+    clearNodeInfoCache();
+  });
+
+  it("detects mastodon.social as Mastodon", async () => {
+    const info = await getInstanceSoftware("mastodon.social");
+    expect(info.detection).toBe("success");
+    expect(info.software?.name.toLowerCase()).toBe("mastodon");
+    expect(info.software?.version).toMatch(/^\d+/);
+    expect(info.protocols).toContain("activitypub");
+  }, 15_000);
+});
+```
+
+(The 15s timeout matches the patterns in this file. If the existing integration suite uses a different module-level timeout, drop the per-test `timeout` arg.)
+
+- [ ] **Step 2: Run integration test**
+
+Run: `npm run test:integration -- -t "live NodeInfo"`
+Expected: PASS — live hit against `mastodon.social` resolves to `{detection: 'success', software: {name: 'mastodon', ...}}`.
+
+If `mastodon.social` is unreachable in your environment, the test will time out — that's a real network failure, not a code bug. Re-run when connectivity returns.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/integration/live-instance-discovery.test.ts
+git commit -m "test(integration): live NodeInfo detection against mastodon.social"
+```
+
+---
+
+## Task 14: CHANGELOG entry + version bump
+
+**Files:**
+- Modify: `CHANGELOG.md`, `package.json`
+
+- [ ] **Step 1: Add the v2.1.0 CHANGELOG section**
+
+In `CHANGELOG.md`, immediately below the `# Changelog` header section and above the `## [2.0.0]` section, insert:
+
+```markdown
+## [2.1.0] - 2026-05-28
+
+### Added
+
+- **`get-instance-software` tool.** Detects ActivityPub software (Mastodon, Pleroma, Misskey, Akkoma, Sharkey, GotoSocial, Friendica, etc.) and version via NodeInfo. Returns a structured `{detection: 'success' | 'unavailable', software, version, protocols, openRegistrations}` shape (prose-formatted in the MCP response). Failure modes return `unavailable` with a one-line reason — never throws.
+- **`activitypub://instance-info/{domain}` resource enrichment.** Resource responses now include a `software:` block from the same NodeInfo detection. Resource fetches succeed even when software detection returns `unavailable`.
+- **`MCP_INSTANCE_SOFTWARE_TTL_MS` env var.** TTL (in ms) for cached positive NodeInfo detection results. Default: `86_400_000` (24h). Negative-cache TTL is hardcoded at 1h.
+- **Dependabot config.** Weekly npm and GitHub Actions update PRs, grouped minor+patch.
+
+### Breaking changes
+
+- **`activitypub://post-thread/{postUrl}` URI form removed.** Deprecated in v2.0.0 with a warning; removed in 2.1.0. Use the canonical `activitypub://post-thread/{domain}/{statusId}` form.
+
+### Internal
+
+- Windows smoke-test bin-shim resolution.
+- Windows CRLF lint failure + CodeQL URL-sanitization alert.
+- Replaced hardcoded absolute path in `upload-media` test with relative resolution.
+```
+
+- [ ] **Step 2: Bump `package.json` version**
+
+In `package.json`, change:
+
+```json
+"version": "2.0.0",
+```
+
+to:
+
+```json
+"version": "2.1.0",
+```
+
+- [ ] **Step 3: Verify no other places hardcode `2.0.0`**
+
+Run: `grep -rn "2\.0\.0" src/ --include="*.ts" | grep -v "node_modules"`
+Expected output: at most a handful of occurrences, none in version-sensitive constants. `SERVER_VERSION` in `src/config.ts` falls back to the env var; if it hardcodes `"2.0.0"`, update it to `"2.1.0"`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CHANGELOG.md package.json src/config.ts
+git commit -m "chore(release): bump version to 2.1.0 + CHANGELOG"
+```
+
+(Include `src/config.ts` only if `SERVER_VERSION` needed updating.)
+
+---
+
+## Task 15: Final verification — lint, typecheck, unit tests, build
+
+**Files:** none modified
+
+- [ ] **Step 1: Run lint**
+
+Run: `npm run lint`
+Expected: PASS — no Biome errors.
+
+- [ ] **Step 2: Run typecheck**
+
+Run: `npm run typecheck`
+Expected: PASS — no TypeScript errors.
+
+- [ ] **Step 3: Run the full unit test suite**
+
+Run: `npm test`
+Expected: PASS — all 624+ existing tests plus the new ones from Tasks 1–11.
+
+- [ ] **Step 4: Build the distribution**
+
+Run: `npm run build`
+Expected: PASS — `dist/` populated, no build errors.
+
+- [ ] **Step 5: Verify the bin smoke test works**
+
+Run: `node dist/mcp-main.js --version`
+Expected output: `2.1.0` (or similar).
+
+- [ ] **Step 6: Mark the work as ready for review**
+
+No code change. Push the branch:
+
+```bash
+git push origin docs/v2-release-polish
+```
+
+Then open the PR to `master` per the project's normal flow. The release.yml workflow handles tagging and npm publishing once the tag lands.
+
+---
+
+## Self-review checklist (run after writing the plan, before handoff)
+
+- [x] Spec coverage: every spec section has at least one task implementing it.
+  - NodeInfo schemas → Task 1
+  - getInstanceSoftware + cache → Tasks 2–6
+  - formatter → Task 7
+  - config env var → Task 8
+  - tool registration → Task 9
+  - resource enrichment → Task 10
+  - legacy URI removal → Task 11
+  - Dependabot → Task 12
+  - live integration test → Task 13
+  - CHANGELOG + version bump → Task 14
+  - lint/typecheck/test/build → Task 15
+- [x] No placeholders: every code block is complete.
+- [x] Type consistency: `InstanceSoftwareInfo`, `getInstanceSoftware`, `formatInstanceSoftware`, `clearNodeInfoCache`, `INSTANCE_SOFTWARE_TTL`, `MCP_INSTANCE_SOFTWARE_TTL_MS` are spelled the same way throughout.
+- [x] No spec gap added without a task.
+
+## Open notes for the implementing engineer
+
+- The spec mentions PSL-aware same-domain matching. This plan implements the conservative "exact host OR subdomain-of-input" rule (Task 5) — sufficient for actual Fediverse implementations and avoids a new dependency. If a real instance is found to host NodeInfo on an unrelated sibling subdomain, revisit.
+- Audit logging uses the existing signature: `logToolInvocation(name, params, { success, duration?, error? })`. Don't pass the raw detection string as the third argument.
+- `instanceBlocklist` is the singleton in `src/policy/instance-blocklist.js`; some test files manipulate it directly (`instanceBlocklist.add/clear`). Tests in Task 4 follow that pattern.
+- The existing instance-info resource handler currently emits a top-level `software` string (from `remoteClient.getInstanceInfo`). Task 10 replaces that with the structured `InstanceSoftwareInfo` object. If existing tests assert on the string shape, update them.
+- `mcp-tools.test.ts` already has a helper for invoking registered tools (`callRegisteredTool` or similar). Reuse that helper rather than reimplementing the registration plumbing.

--- a/docs/superpowers/specs/2026-05-28-v2.1-release-design.md
+++ b/docs/superpowers/specs/2026-05-28-v2.1-release-design.md
@@ -1,0 +1,279 @@
+# v2.1.0 Release — Design
+
+**Date:** 2026-05-28
+**Status:** Approved for implementation planning
+**Author:** Cameron Rye
+
+## Summary
+
+v2.1.0 closes out the v2 release cycle. It bundles four items:
+
+1. **CI fixes** already on `docs/v2-release-polish` (Windows smoke-test resolution, CRLF lint + CodeQL alert, hardcoded path in upload-media test).
+2. **Dependabot** for npm + github-actions.
+3. **Remove the deprecated `activitypub://post-thread/{postUrl}` URI form** — the v2.0.0 CHANGELOG already announced this removal.
+4. **Instance-software detection** — a new `get-instance-software` tool and enrichment of the existing `activitypub://instance-info/{domain}` resource, both backed by NodeInfo. This is the only item with real design surface and is the focus of this document.
+
+Item 4 ships as the informational MVP per the brainstorming outcome. Behavioral routing (per-software API branches) is deferred to a later release once real adoption signal surfaces.
+
+## Goals
+
+- Surface ActivityPub-software identity (Mastodon, Pleroma, Misskey, Akkoma, Sharkey, GotoSocial, Friendica, etc.) to LLM consumers so they can adapt their reasoning.
+- Honor the deprecation promised in v2.0.0's CHANGELOG.
+- Keep CI green on Windows and reduce manual dependency maintenance.
+
+## Non-goals
+
+- **No per-software request routing in this release.** The capability map sketched in brainstorming is a future direction, not v2.1.
+- **No NodeInfo 1.0 support.** Only 2.0 and 2.1 are in scope. Instances stuck on 1.0 will detect as `unavailable`.
+- **No `/api/v1/instance` or header-sniff fallbacks.** NodeInfo-only. Coverage is sufficient across the relevant software families.
+- **No release-please.** Manual tag-based release flow continues.
+
+## Architecture — instance-software detection
+
+### Module layout
+
+New file: `src/discovery/nodeinfo.ts`. Joins `webfinger.ts`, `instance-discovery.ts`, and `dynamic-instance-discovery.ts` under the existing `discovery/` topic.
+
+Exports:
+
+```ts
+type InstanceSoftwareInfo = {
+  domain: string
+  detection: 'success' | 'unavailable'
+  software: { name: string; version: string } | null
+  protocols: string[] | null
+  openRegistrations: boolean | null
+  reason?: string  // present iff detection === 'unavailable'
+}
+
+export function getInstanceSoftware(domain: string): Promise<InstanceSoftwareInfo>
+```
+
+Internal Zod schemas:
+
+- `NodeInfoDiscoverySchema` — validates the `/.well-known/nodeinfo` index doc (`{ links: [{ rel, href }] }`).
+- `NodeInfoSchema` — validates a NodeInfo 2.0 or 2.1 body. Required fields: `software.name`, `software.version`, `protocols`. Optional: `openRegistrations`. Other NodeInfo fields (`usage`, `services`, `metadata`) parsed loosely and ignored.
+
+Internal cache:
+
+- Single `LRUCache<string, InstanceSoftwareInfo>` instance, keyed by `domain`.
+- Positive (`detection === 'success'`) TTL: `MCP_INSTANCE_SOFTWARE_TTL_MS` (default `86_400_000` — 24 hours).
+- Negative (`detection === 'unavailable'`) TTL: 1 hour (hardcoded; not a separate env knob).
+- Bounded size: 256 entries. Existing `LRUCache` semantics handle eviction.
+
+Configuration:
+
+- Add `MCP_INSTANCE_SOFTWARE_TTL_MS` to `src/config.ts`'s Zod schema with default `86_400_000`.
+- Document in `.env.example` and `.env.production.example`.
+
+### Detection flow
+
+```text
+getInstanceSoftware(domain):
+  1. cache.get(domain) → return if hit
+  2. single-flight: if an in-flight promise for `domain` exists, return it
+  3. construct discoveryUrl = `https://${domain}/.well-known/nodeinfo`
+  4. validateExternalUrl(discoveryUrl)  // SSRF guard, blocklist, scheme allow-list
+  5. fetch via fetchHelpers (streaming size cap, retry, ETag)
+  6. parse JSON, validate with NodeInfoDiscoverySchema
+  7. pick the highest-versioned link whose rel matches
+     `http://nodeinfo.diaspora.software/ns/schema/2.[01]`
+  8. let nodeInfoUrl = picked link's href
+     a. validateExternalUrl(nodeInfoUrl)
+     b. require same registrable domain as input (PSL-aware, NOT exact match — subdomains OK)
+  9. fetch nodeInfoUrl, parse JSON, validate with NodeInfoSchema
+  10. build InstanceSoftwareInfo with detection: 'success'
+  11. cache.set(domain, info, ttl=positiveTTL); return info
+
+  any failure (HTTP error, schema mismatch, timeout, SSRF reject, blocklist hit):
+    build InstanceSoftwareInfo with detection: 'unavailable',
+      reason = a single short line (e.g. "NodeInfo discovery returned HTTP 404",
+                                          "linked NodeInfo URL on different host",
+                                          "schema validation failed: software.name missing")
+    cache.set(domain, info, ttl=negativeTTL); return info
+    NEVER throw
+```
+
+### Same-registrable-domain check
+
+Some instances host NodeInfo on a subdomain (e.g. `social.example.org` links to `nodeinfo.example.org/2.1`). The check must allow subdomains of the same registrable domain (per the Public Suffix List) but reject cross-domain redirects to an unrelated host.
+
+Implementation: use a lightweight registrable-domain helper. If pulling in `psl` or `tldts` is too heavy, a minimum-viable check is "same final two labels after stripping" with a known-bad list — but PSL-aware is preferred. Spec defers this choice to the implementation plan; the constraint is "subdomains OK, cross-host not".
+
+### Single-flight
+
+A `Map<string, Promise<InstanceSoftwareInfo>>` of in-flight requests. Before initiating a fetch, check the map; if a promise exists for `domain`, await it instead. After settlement (success or failure), delete the entry. Prevents the cold-cache thundering-herd case where two MCP requests for the same domain each trigger their own NodeInfo round-trip.
+
+### Audit logging
+
+The wrapping tool (`get-instance-software`) is audit-logged on success and failure via `auditLogger.logToolInvocation`, consistent with the v2 pattern.
+
+The module (`getInstanceSoftware`) is **not** directly audit-logged — it's called from the resource-enrichment path too, where audit logging would create noise. The tool wrapper is the audit boundary.
+
+## Tool surface
+
+In `src/mcp/tools.ts`:
+
+```ts
+server.tool(
+  'get-instance-software',
+  'Detect the ActivityPub software (e.g. Mastodon, Pleroma, Misskey) and version running on a Fediverse instance via NodeInfo. Returns null fields with a reason when detection fails.',
+  { domain: DomainSchema },
+  async ({ domain }) => {
+    const info = await getInstanceSoftware(domain)
+    auditLogger.logToolInvocation('get-instance-software', { domain }, info.detection)
+    return { content: [{ type: 'text', text: formatInstanceSoftware(info) }] }
+  },
+)
+```
+
+Output is prose, per the v2 convention (`search-instance`-style). Example success:
+
+> `mastodon.social` runs **Mastodon 4.3.2**. Protocols: activitypub. Open registrations: false.
+
+Example failure:
+
+> Could not detect software for `example.invalid`: NodeInfo discovery returned HTTP 404.
+
+The `formatInstanceSoftware` helper lives in the same module as `getInstanceSoftware`.
+
+`DomainSchema` (existing v2 validator) handles validation; instance blocklist is enforced via the existing policy module.
+
+## Resource enrichment
+
+In `src/mcp/resources.ts`, the `activitypub://instance-info/{domain}` handler runs `getInstanceSoftware(domain)` in parallel with its existing instance-info fetches:
+
+```ts
+const [instanceInfo, software] = await Promise.all([
+  fetchInstanceInfo(domain),
+  getInstanceSoftware(domain),
+])
+```
+
+The result is merged as a `software:` block at the top of the prose response. On success: a one-line `software: Mastodon 4.3.2 (protocols: activitypub)`. On failure: `software: unavailable (<reason>)`. **The resource fetch never fails because software detection failed.**
+
+## Dynamic server-info registry
+
+`get-instance-software` is registered through the same path the other v2 tools use, so the `activitypub://server-info` resource auto-lists it without hand-maintained arrays.
+
+## Removing the deprecated `{postUrl}` URI form
+
+In `src/mcp/resources.ts`, the `post-thread` resource handler currently accepts two URI templates:
+
+1. `activitypub://post-thread/{domain}/{statusId}` — Mastodon-compatible, the canonical form.
+2. `activitypub://post-thread/{postUrl}` — legacy v1 form, accepted with a deprecation warning.
+
+v2.1.0 deletes (2) entirely. Steps:
+
+- Remove the legacy branch and the deprecation warning code.
+- Remove the legacy URI template registration.
+- Update or delete the unit tests that exercise the legacy form.
+- CHANGELOG entry under **Breaking changes**: cite the v2.0.0 deprecation as the heads-up.
+
+No backward-compatibility shim. Callers using the legacy form get a clear MCP error.
+
+## Dependabot
+
+New file `.github/dependabot.yml`:
+
+```yaml
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      minor-and-patch:
+        update-types: [minor, patch]
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+```
+
+Grouped minor/patch updates keep PR noise down. Major bumps remain ungrouped so each gets individual review.
+
+## CI fixes
+
+Already on `docs/v2-release-polish`. No additional design:
+
+- `eeb44b3` — Windows bin-shim smoke test.
+- `6f3cbf8` — Windows CRLF lint failure and CodeQL URL-sanitization alert.
+- `eba1a71` — hardcoded absolute path in upload-media test.
+
+These land as-is with v2.1.0.
+
+## Configuration
+
+New env var, added to the existing `src/config.ts` Zod schema:
+
+| Var                            | Default            | Description                                                                                |
+| ------------------------------ | ------------------ | ------------------------------------------------------------------------------------------ |
+| `MCP_INSTANCE_SOFTWARE_TTL_MS` | `86_400_000` (24h) | TTL for cached NodeInfo detection results. Negative-cache TTL is hardcoded at 1h.          |
+
+Documented in `.env.example` and `.env.production.example`.
+
+## Testing
+
+### Unit tests (new): `tests/unit/nodeinfo.test.ts`
+
+- Happy path: NodeInfo 2.0 and 2.1 docs both parse correctly.
+- Discovery doc malformed → returns `detection: 'unavailable'` with a reason; never throws.
+- Linked NodeInfo URL fails schema validation → `unavailable`.
+- Cache hit: second call within the positive TTL returns the cached result without a network call (mocked fetch counter).
+- Negative cache hit: a failed lookup stays cached for the 1h window.
+- SSRF reject: a NodeInfo discovery doc linking to a private IP returns `unavailable` with a reason that mentions the SSRF reject.
+- Cross-domain reject: a NodeInfo discovery doc linking to an unrelated host returns `unavailable`.
+- Same-registrable-domain subdomain: a NodeInfo doc linking to `nodeinfo.example.org` when the input was `social.example.org` is accepted.
+- Single-flight: two concurrent calls for the same domain produce one fetch (single mocked-fetch invocation, both calls receive the same result).
+
+### Tool tests (extend): `tests/unit/mcp-tools.test.ts`
+
+- `get-instance-software` is registered.
+- Schema validates `domain` via `DomainSchema` (rejects IP literals, malformed input).
+- Instance blocklist is enforced before fetch.
+- Audit-logged on success and failure paths.
+- Output prose matches the success and failure templates.
+
+### Resource tests (extend): `tests/unit/mcp-resources.test.ts`
+
+- `activitypub://instance-info/{domain}` includes the `software:` block on success.
+- Resource fetch returns successfully when software detection returns `unavailable` (graceful merge).
+- Legacy `activitypub://post-thread/{postUrl}` URI form is rejected (no longer registered).
+- Canonical `activitypub://post-thread/{domain}/{statusId}` form continues to work.
+
+### Integration tests (extend): `tests/integration/live-instance-discovery.test.ts`
+
+- Live hit against `mastodon.social` returns `detection: 'success'` with `software.name === 'mastodon'`.
+- Optional second live hit against a Pleroma/Akkoma instance for cross-software confirmation. If a stable test target isn't available, skip this assertion to avoid flake risk.
+
+## Release artifact
+
+- Bump `package.json` to `2.1.0`.
+- New CHANGELOG `## [2.1.0]` section:
+  - **Added** — `get-instance-software` tool, NodeInfo enrichment in `activitypub://instance-info/{domain}` resource, Dependabot config.
+  - **Breaking** — legacy `activitypub://post-thread/{postUrl}` URI form removed (deprecated in v2.0.0).
+  - **Internal** — Windows CI fixes, hardcoded test path fix.
+- No `MIGRATION-v2.md` update — it's a v1→v2 document. CHANGELOG is sufficient.
+- Tag `v2.1.0`. Existing `release.yml` workflow handles tarball + smoke + npm publish.
+
+## Risk assessment
+
+- **NodeInfo coverage** is broad across the relevant software families. The "informational only" framing means unknown software is a benign `unavailable` result, not a tool failure.
+- **Single-flight** mitigates the cold-cache thundering-herd risk.
+- **SSRF/blocklist re-validation** at both fetch steps prevents NodeInfo discovery from being a redirect-based SSRF vector.
+- **Same-registrable-domain check** is the load-bearing security boundary on the linked NodeInfo URL. PSL-aware is the preferred implementation; if pulling in a PSL dependency proves heavy at planning time, an exact-host-match fallback is acceptable as a conservative starting point — at the cost of some legitimate subdomain-hosted NodeInfo instances detecting as `unavailable`. The implementation plan resolves this; the security posture (no cross-host link follow) is non-negotiable.
+- **Breaking change** (legacy URI removal) was explicitly announced in v2.0.0's CHANGELOG, giving downstream consumers warning.
+
+## Open questions
+
+None. All clarifying questions answered during brainstorming.
+
+## Out of scope (future)
+
+- Per-software request routing / capability map (Tier 3).
+- MCP SDK upgrade for elicitation, sampling, structured tool output (Tier 3).
+- Recorded fixtures for live-Fediverse integration tests (Tier 3).
+- Net-new feature directions: federated search, vision alt-text, authoring/engagement prompts (Tier 4).
+- release-please for automated CHANGELOG + version bumps.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "activitypub-mcp",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "activitypub-mcp",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "@logtape/logtape": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activitypub-mcp",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "A Model Context Protocol server for exploring and interacting with the existing Fediverse",
   "main": "dist/mcp-main.js",
   "bin": {

--- a/src/config.ts
+++ b/src/config.ts
@@ -37,7 +37,7 @@ function parseBoolEnv(value: string | undefined, defaultValue: boolean): boolean
 export const SERVER_NAME = process.env.MCP_SERVER_NAME || "activitypub-mcp";
 
 /** MCP Server version */
-export const SERVER_VERSION = process.env.MCP_SERVER_VERSION || "2.0.0";
+export const SERVER_VERSION = process.env.MCP_SERVER_VERSION || "2.1.0";
 
 /** Log level for the application */
 export const LOG_LEVEL = process.env.LOG_LEVEL || "info";
@@ -213,6 +213,19 @@ export const DYNAMIC_INSTANCE_CACHE_TTL = parseIntEnv(
 
 /** Maximum instances to fetch from external API */
 export const MAX_DYNAMIC_INSTANCES = parseIntEnv(process.env.MAX_DYNAMIC_INSTANCES, 100);
+
+// =============================================================================
+// Instance Software Detection (NodeInfo) Configuration
+// =============================================================================
+
+/**
+ * TTL for cached NodeInfo software-detection results, in milliseconds.
+ * Default: 24h. Negative-cache TTL (for detection failures) is hardcoded at 1h.
+ */
+export const INSTANCE_SOFTWARE_TTL = parseIntEnv(
+  process.env.MCP_INSTANCE_SOFTWARE_TTL_MS,
+  86_400_000,
+);
 
 // =============================================================================
 // Audit Logging Configuration

--- a/src/discovery/nodeinfo.ts
+++ b/src/discovery/nodeinfo.ts
@@ -1,0 +1,241 @@
+import { getLogger } from "@logtape/logtape";
+import { z } from "zod";
+import {
+  CACHE_MAX_SIZE,
+  INSTANCE_SOFTWARE_TTL,
+  MAX_RESPONSE_SIZE,
+  REQUEST_TIMEOUT,
+  USER_AGENT,
+} from "../config.js";
+import { instanceBlocklist } from "../policy/instance-blocklist.js";
+import { fetchWithRedirectGuard, readJsonWithLimit } from "../utils/fetch-helpers.js";
+import { LRUCache } from "../utils/lru-cache.js";
+import { validateExternalUrl } from "../validation/url.js";
+
+/**
+ * NodeInfo discovery document (RFC-style `/.well-known/nodeinfo` index).
+ * See: https://nodeinfo.diaspora.software/
+ */
+export const NodeInfoDiscoverySchema = z.object({
+  links: z.array(
+    z.object({
+      rel: z.string(),
+      href: z.string(),
+    }),
+  ),
+});
+
+export type NodeInfoDiscovery = z.infer<typeof NodeInfoDiscoverySchema>;
+
+/**
+ * NodeInfo body schema (versions 2.0 and 2.1).
+ * Only the fields we actually expose to LLM consumers are required;
+ * `usage`, `services`, and `metadata` are tolerated but not validated strictly.
+ */
+export const NodeInfoSchema = z.object({
+  version: z.string().optional(),
+  software: z.object({
+    name: z.string(),
+    version: z.string(),
+    repository: z.string().optional(),
+    homepage: z.string().optional(),
+  }),
+  protocols: z.array(z.string()),
+  openRegistrations: z.boolean().optional(),
+  usage: z.unknown().optional(),
+  services: z.unknown().optional(),
+  metadata: z.unknown().optional(),
+});
+
+export type NodeInfo = z.infer<typeof NodeInfoSchema>;
+
+/**
+ * Result returned by `getInstanceSoftware`.
+ * `detection: 'unavailable'` populates null fields and a one-line `reason`.
+ */
+export type InstanceSoftwareInfo = {
+  domain: string;
+  detection: "success" | "unavailable";
+  software: { name: string; version: string } | null;
+  protocols: string[] | null;
+  openRegistrations: boolean | null;
+  reason?: string;
+};
+
+const logger = getLogger("activitypub-mcp:nodeinfo");
+
+// Only NodeInfo 2.0 and 2.1 are in scope. Match these rels exactly — a prefix
+// match would also accept bogus rels like ".../2.1-evil" or ".../2.x", and a
+// lexical sort could rank such a rel above the genuine link. 2.1 is preferred
+// over 2.0 when both are advertised.
+const SUPPORTED_NODEINFO_RELS = [
+  "http://nodeinfo.diaspora.software/ns/schema/2.1",
+  "http://nodeinfo.diaspora.software/ns/schema/2.0",
+] as const;
+
+const cache = new LRUCache<string, InstanceSoftwareInfo>({
+  maxSize: Math.min(CACHE_MAX_SIZE, 256),
+  ttl: INSTANCE_SOFTWARE_TTL,
+});
+
+const NEGATIVE_TTL_MS = 60 * 60 * 1000; // 1h
+
+const negativeCache = new LRUCache<string, InstanceSoftwareInfo>({
+  maxSize: Math.min(CACHE_MAX_SIZE, 256),
+  ttl: NEGATIVE_TTL_MS,
+});
+
+const inFlight = new Map<string, Promise<InstanceSoftwareInfo>>();
+
+export function clearNodeInfoCache(): void {
+  cache.clear();
+  negativeCache.clear();
+  inFlight.clear();
+}
+
+export async function getInstanceSoftware(domain: string): Promise<InstanceSoftwareInfo> {
+  const normalizedDomain = domain.toLowerCase();
+
+  const positive = cache.get(normalizedDomain);
+  if (positive) return positive;
+  const negative = negativeCache.get(normalizedDomain);
+  if (negative) return negative;
+
+  const existing = inFlight.get(normalizedDomain);
+  if (existing) return existing;
+
+  const promise = (async () => {
+    try {
+      const info = await performDetection(normalizedDomain);
+      cache.set(normalizedDomain, info);
+      negativeCache.delete(normalizedDomain);
+      return info;
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : String(error);
+      const info: InstanceSoftwareInfo = {
+        domain: normalizedDomain,
+        detection: "unavailable",
+        software: null,
+        protocols: null,
+        openRegistrations: null,
+        reason,
+      };
+      logger.info("NodeInfo detection unavailable", { domain: normalizedDomain, reason });
+      negativeCache.set(normalizedDomain, info);
+      return info;
+    } finally {
+      inFlight.delete(normalizedDomain);
+    }
+  })();
+
+  inFlight.set(normalizedDomain, promise);
+  return promise;
+}
+
+async function performDetection(domain: string): Promise<InstanceSoftwareInfo> {
+  // Policy + SSRF gate on input domain.
+  instanceBlocklist.validateNotBlocked(domain);
+
+  const discoveryUrl = `https://${domain}/.well-known/nodeinfo`;
+  await validateExternalUrl(discoveryUrl);
+  const discoveryDoc = await fetchJson(discoveryUrl);
+  const discovery = NodeInfoDiscoverySchema.parse(discoveryDoc);
+
+  const link = pickHighestNodeInfo2Link(discovery);
+  if (!link) {
+    throw new Error("no NodeInfo 2.0/2.1 link in discovery document");
+  }
+
+  // SSRF guard + same-host + blocklist on the linked NodeInfo URL.
+  await validateExternalUrl(link.href);
+  const linkedHost = new URL(link.href).hostname.toLowerCase();
+  if (!isSameOrSubdomain(domain, linkedHost)) {
+    throw new Error(
+      `linked NodeInfo URL on different host (${linkedHost}, expected ${domain} or subdomain)`,
+    );
+  }
+  instanceBlocklist.validateNotBlocked(linkedHost);
+
+  const body = await fetchJson(link.href);
+  const nodeInfo = NodeInfoSchema.parse(body);
+
+  return {
+    domain,
+    detection: "success",
+    software: { name: nodeInfo.software.name, version: nodeInfo.software.version },
+    protocols: nodeInfo.protocols,
+    openRegistrations: nodeInfo.openRegistrations ?? null,
+  };
+}
+
+function isSameOrSubdomain(input: string, candidate: string): boolean {
+  // Strip a trailing dot so the FQDN form (e.g. "example.org.") of the same
+  // host is treated as equal, not rejected as a different host.
+  const a = input.toLowerCase().replace(/\.$/, "");
+  const b = candidate.toLowerCase().replace(/\.$/, "");
+  return b === a || b.endsWith(`.${a}`);
+}
+
+function pickHighestNodeInfo2Link(
+  doc: NodeInfoDiscovery,
+): { rel: string; href: string } | undefined {
+  for (const rel of SUPPORTED_NODEINFO_RELS) {
+    const match = doc.links.find((l) => l.rel === rel);
+    if (match) return match;
+  }
+  return undefined;
+}
+
+function titleCase(name: string): string {
+  if (!name) return name;
+  return name.charAt(0).toUpperCase() + name.slice(1);
+}
+
+export function formatInstanceSoftware(info: InstanceSoftwareInfo): string {
+  if (info.detection === "unavailable") {
+    return `Could not detect software for \`${info.domain}\`: ${info.reason ?? "unknown reason"}.`;
+  }
+  const software = info.software;
+  const protocols = info.protocols ?? [];
+  const openReg = info.openRegistrations;
+  const parts: string[] = [];
+  if (software) {
+    parts.push(`\`${info.domain}\` runs **${titleCase(software.name)} ${software.version}**.`);
+  } else {
+    parts.push(`\`${info.domain}\` software metadata unavailable.`);
+  }
+  if (protocols.length > 0) {
+    parts.push(`Protocols: ${protocols.join(", ")}.`);
+  }
+  if (openReg !== null) {
+    parts.push(`Open registrations: ${openReg}.`);
+  }
+  return parts.join(" ");
+}
+
+async function fetchJson(url: string): Promise<unknown> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), REQUEST_TIMEOUT);
+
+  try {
+    const response = await fetchWithRedirectGuard(
+      url,
+      {
+        method: "GET",
+        headers: { Accept: "application/json", "User-Agent": USER_AGENT },
+        signal: controller.signal,
+      },
+      async (target) => {
+        await validateExternalUrl(target);
+        const targetHost = new URL(target).hostname;
+        instanceBlocklist.validateNotBlocked(targetHost);
+      },
+    );
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status} ${response.statusText}`);
+    }
+    return await readJsonWithLimit(response, MAX_RESPONSE_SIZE);
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}

--- a/src/mcp/resources.ts
+++ b/src/mcp/resources.ts
@@ -10,6 +10,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { ErrorCode, McpError } from "@modelcontextprotocol/sdk/types.js";
 import { remoteClient } from "../activitypub/remote-client.js";
+import { getInstanceSoftware } from "../discovery/nodeinfo.js";
 import type { RateLimiter } from "../resilience/rate-limiter.js";
 import { getErrorMessage } from "../utils/errors.js";
 import { DomainSchema } from "../validation/schemas.js";
@@ -307,12 +308,16 @@ function registerInstanceInfoResource(mcpServer: McpServer, rateLimiter: RateLim
 
         logger.info("Fetching instance info", { domain: validDomain });
 
-        const instanceInfo = await remoteClient.getInstanceInfo(validDomain);
+        const [instanceInfo, software] = await Promise.all([
+          remoteClient.getInstanceInfo(validDomain),
+          getInstanceSoftware(validDomain),
+        ]);
 
         const normalizedInstanceInfo = {
           ...instanceInfo,
           title: instanceInfo.description || `${instanceInfo.software || "Unknown"} instance`,
           uri: `https://${validDomain}`,
+          software,
         };
 
         return {
@@ -693,8 +698,8 @@ function registerFederatedTimelineResource(mcpServer: McpServer, rateLimiter: Ra
 /**
  * Post thread resource - get a post and its full conversation thread.
  *
- * URI template (v2.0.x): activitypub://post-thread/{domain}/{statusId}
- * Legacy form (deprecated, removed in 2.1.0): activitypub://post-thread/{postUrl}
+ * URI template: activitypub://post-thread/{domain}/{statusId}
+ * (Legacy {postUrl} form removed in v2.1.0; was deprecated in v2.0.0.)
  */
 function registerPostThreadResource(mcpServer: McpServer, rateLimiter: RateLimiter): void {
   mcpServer.registerResource(
@@ -725,48 +730,30 @@ function registerPostThreadResource(mcpServer: McpServer, rateLimiter: RateLimit
     },
     async (uri, params) => {
       try {
-        // The {domain} segment will look like a hostname for the new form
-        // (e.g. "mastodon.social") or an encoded URL for the legacy form
-        // (e.g. "https%3A%2F%2Fmastodon.social%2F%40user%2F123456").
-        const firstSegment = extractSingleValue(params.domain ?? "");
+        const domain = extractSingleValue(params.domain ?? "");
+        const statusId = extractSingleValue(params.statusId ?? "");
 
-        let postUrl: string;
-        const looksLikeEncodedUrl =
-          firstSegment.includes("%3A%2F%2F") || firstSegment.includes("://");
-
-        if (looksLikeEncodedUrl) {
-          // Legacy form — still supported in 2.0.x with a deprecation warning.
-          logger.warn(
-            "post-thread URI template `{postUrl}` is deprecated; pass `{domain}/{statusId}` instead. Will be removed in 2.1.0.",
-            { receivedUri: uri.href },
+        // Reject the v1 encoded-URL form explicitly to give callers a clear migration message.
+        if (domain.includes("%3A%2F%2F") || domain.includes("://")) {
+          throw new McpError(
+            ErrorCode.InvalidParams,
+            "post-thread URI template `{postUrl}` was removed in 2.1.0. " +
+              "Use activitypub://post-thread/{domain}/{statusId} instead.",
           );
-          try {
-            postUrl = new URL(decodeURIComponent(firstSegment)).href;
-          } catch {
-            throw new McpError(
-              ErrorCode.InvalidParams,
-              `Invalid post URL in legacy template: ${firstSegment}`,
-            );
-          }
-        } else {
-          // New form: {domain}/{statusId}
-          const domain = firstSegment;
-          const statusId = extractSingleValue(params.statusId ?? "");
-          if (!domain || !statusId) {
-            throw new McpError(
-              ErrorCode.InvalidParams,
-              "post-thread requires {domain} and {statusId} in the URI (e.g. activitypub://post-thread/mastodon.social/123456)",
-            );
-          }
-          // Mastodon-compatible URL — works for Mastodon and most Mastodon-API-compatible
-          // implementations. Non-Mastodon instances may need the legacy {postUrl} form.
-          postUrl = `https://${domain}/web/statuses/${statusId}`;
         }
 
+        if (!domain || !statusId) {
+          throw new McpError(
+            ErrorCode.InvalidParams,
+            "post-thread requires {domain} and {statusId} in the URI (e.g. activitypub://post-thread/mastodon.social/123456)",
+          );
+        }
+
+        const postUrl = `https://${domain}/web/statuses/${statusId}`;
         const parsedUrl = new URL(postUrl);
         checkRateLimit(rateLimiter, parsedUrl.hostname);
 
-        logger.info("Fetching post thread", { postUrl, legacyForm: looksLikeEncodedUrl });
+        logger.info("Fetching post thread", { postUrl });
 
         const threadData = await remoteClient.fetchPostThread(parsedUrl.href, {
           depth: 2,
@@ -795,7 +782,6 @@ function registerPostThreadResource(mcpServer: McpServer, rateLimiter: RateLimit
         if (error instanceof McpError) {
           throw error;
         }
-
         throw new McpError(
           ErrorCode.InternalError,
           `Failed to fetch post thread: ${error instanceof Error ? error.message : String(error)}`,

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -10,8 +10,10 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { ErrorCode, McpError } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
 import { remoteClient } from "../activitypub/remote-client.js";
+import { auditLogger } from "../audit/logger.js";
 import { dynamicInstanceDiscovery } from "../discovery/dynamic-instance-discovery.js";
 import { instanceDiscovery } from "../discovery/instance-discovery.js";
+import { formatInstanceSoftware, getInstanceSoftware } from "../discovery/nodeinfo.js";
 import type { RateLimiter } from "../resilience/rate-limiter.js";
 import { healthChecker } from "../telemetry/health-check.js";
 import { performanceMonitor } from "../telemetry/performance-monitor.js";
@@ -61,6 +63,7 @@ export function registerTools(mcpServer: McpServer, rateLimiter: RateLimiter): v
 
   // Instance tools
   registerGetInstanceInfoTool(mcpServer, rateLimiter);
+  registerGetInstanceSoftwareTool(mcpServer, rateLimiter);
 
   // Utility tools
   registerConvertUrlTool(mcpServer, rateLimiter);
@@ -2263,6 +2266,73 @@ ${failedList ? `**Failed Fetches:**\n${failedList}` : ""}
               text: `Failed to batch fetch posts: ${formatErrorWithSuggestion(errorMessage)}`,
             },
           ],
+          isError: true,
+        };
+      }
+    },
+  );
+}
+
+/**
+ * get-instance-software tool — detect ActivityPub software running on an instance via NodeInfo.
+ */
+function registerGetInstanceSoftwareTool(mcpServer: McpServer, rateLimiter: RateLimiter): void {
+  mcpServer.registerTool(
+    "get-instance-software",
+    {
+      title: "Detect Instance Software",
+      description:
+        "Detect the ActivityPub software (e.g. Mastodon, Pleroma, Misskey, Akkoma) and version " +
+        "running on a Fediverse instance via NodeInfo. Returns a description; if detection fails " +
+        "(no NodeInfo, malformed response, blocked host), returns a one-line 'could not detect' " +
+        "message with the reason. Never throws on detection failure.",
+      inputSchema: {
+        domain: DomainSchema.describe(
+          "Fediverse instance domain (e.g., 'mastodon.social'). Do not include scheme or path.",
+        ),
+      },
+    },
+    async ({ domain }) => {
+      const start = Date.now();
+      const validDomain = validateDomain(domain);
+
+      const requestId = performanceMonitor.startRequest("get-instance-software", {
+        domain: validDomain,
+      });
+
+      try {
+        checkRateLimit(rateLimiter, validDomain);
+
+        logger.info("Detecting instance software", { domain: validDomain });
+
+        const info = await getInstanceSoftware(validDomain);
+        performanceMonitor.endRequest(requestId, true);
+
+        auditLogger.logToolInvocation(
+          "get-instance-software",
+          { domain: validDomain },
+          { success: info.detection === "success", duration: Date.now() - start },
+        );
+
+        return { content: [{ type: "text", text: formatInstanceSoftware(info) }] };
+      } catch (error) {
+        const errorMessage = getErrorMessage(error);
+        performanceMonitor.endRequest(requestId, false, errorMessage);
+
+        logger.error("Failed to detect instance software", {
+          domain: validDomain,
+          error: errorMessage,
+        });
+
+        auditLogger.logToolInvocation(
+          "get-instance-software",
+          { domain: validDomain },
+          { success: false, duration: Date.now() - start, error: errorMessage },
+        );
+
+        if (error instanceof McpError) throw error;
+        return {
+          content: [{ type: "text", text: `Failed to detect instance software: ${errorMessage}` }],
           isError: true,
         };
       }

--- a/tests/integration/live-instance-discovery.test.ts
+++ b/tests/integration/live-instance-discovery.test.ts
@@ -13,6 +13,7 @@
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { DynamicInstanceDiscoveryService } from "../../src/discovery/dynamic-instance-discovery.js";
+import { clearNodeInfoCache, getInstanceSoftware } from "../../src/discovery/nodeinfo.js";
 
 describe.skipIf(!process.env.RUN_INTEGRATION_TESTS)(
   "DynamicInstanceDiscoveryService - Live API Tests",
@@ -215,6 +216,20 @@ describe.skipIf(!process.env.RUN_INTEGRATION_TESTS)(
           expect(instance.domain.length).toBeGreaterThan(0);
         }
       });
+    });
+
+    describe("live NodeInfo detection", () => {
+      beforeEach(() => {
+        clearNodeInfoCache();
+      });
+
+      it("detects mastodon.social as Mastodon", async () => {
+        const info = await getInstanceSoftware("mastodon.social");
+        expect(info.detection).toBe("success");
+        expect(info.software?.name.toLowerCase()).toBe("mastodon");
+        expect(info.software?.version).toMatch(/^\d+/);
+        expect(info.protocols).toContain("activitypub");
+      }, 15_000);
     });
   },
 );

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -138,6 +138,25 @@ describe("CORS defaults (H1)", () => {
   });
 });
 
+describe("INSTANCE_SOFTWARE_TTL", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("defaults to 24h (86_400_000 ms) when env var is unset", async () => {
+    delete process.env.MCP_INSTANCE_SOFTWARE_TTL_MS;
+    const mod = await import("../../src/config.js");
+    expect(mod.INSTANCE_SOFTWARE_TTL).toBe(86_400_000);
+  });
+});
+
 describe("HEALTH_CHECK_EXTERNAL_PROBE config (M7)", () => {
   const originalEnv = process.env;
 

--- a/tests/unit/mcp-resources.test.ts
+++ b/tests/unit/mcp-resources.test.ts
@@ -34,7 +34,12 @@ vi.mock("@logtape/logtape", () => ({
   }),
 }));
 
+vi.mock("../../src/discovery/nodeinfo.js", () => ({
+  getInstanceSoftware: vi.fn(),
+}));
+
 import { remoteClient } from "../../src/activitypub/remote-client.js";
+import { getInstanceSoftware } from "../../src/discovery/nodeinfo.js";
 
 describe("MCP Resources", () => {
   let mcpServer: McpServer;
@@ -279,6 +284,56 @@ describe("MCP Resources", () => {
 
       await expect(resource?.handler(uri, { domain: "invalid" })).rejects.toThrow();
     });
+
+    it("includes software detection in the response on success", async () => {
+      (remoteClient.getInstanceInfo as Mock).mockResolvedValue({
+        domain: "enriched.social",
+        software: "mastodon",
+        version: "4.2.0",
+        description: "A social network",
+      });
+      (getInstanceSoftware as Mock).mockResolvedValue({
+        domain: "enriched.social",
+        detection: "success",
+        software: { name: "mastodon", version: "4.3.2" },
+        protocols: ["activitypub"],
+        openRegistrations: false,
+      });
+
+      const resource = registeredResources.get("instance-info");
+      const uri = new URL("activitypub://instance-info/enriched.social");
+      const result = await resource?.handler(uri, { domain: "enriched.social" });
+
+      const body = JSON.parse((result as { contents: { text: string }[] }).contents[0].text);
+      expect(body.software).toBeDefined();
+      expect(body.software.detection).toBe("success");
+      expect(body.software.software.name).toBe("mastodon");
+      expect(body.software.software.version).toBe("4.3.2");
+    });
+
+    it("returns successfully with software=unavailable when detection fails", async () => {
+      (remoteClient.getInstanceInfo as Mock).mockResolvedValue({
+        domain: "noinfo.social",
+        description: "A social network",
+      });
+      (getInstanceSoftware as Mock).mockResolvedValue({
+        domain: "noinfo.social",
+        detection: "unavailable",
+        software: null,
+        protocols: null,
+        openRegistrations: null,
+        reason: "HTTP 404 Not Found",
+      });
+
+      const resource = registeredResources.get("instance-info");
+      const uri = new URL("activitypub://instance-info/noinfo.social");
+      const result = await resource?.handler(uri, { domain: "noinfo.social" });
+
+      const body = JSON.parse((result as { contents: { text: string }[] }).contents[0].text);
+      expect(body.software).toBeDefined();
+      expect(body.software.detection).toBe("unavailable");
+      expect(body.software.reason).toMatch(/404/);
+    });
   });
 
   describe("trending resource", () => {
@@ -426,27 +481,14 @@ describe("MCP Resources", () => {
       expect(thread.postUrl).toBe("https://mastodon.social/web/statuses/123456");
     });
 
-    it("logs a deprecation warning and still works for the legacy {postUrl} form", async () => {
-      (remoteClient.fetchPostThread as Mock).mockResolvedValue({
-        post: { content: "Legacy post" },
-        ancestors: [],
-        replies: [],
-        totalReplies: 0,
-      });
-
-      const { getLogger } = await import("@logtape/logtape");
-      const mockLogger = getLogger("activitypub-mcp:resources");
-      const warnSpy = vi.spyOn(mockLogger, "warn");
-
+    it("rejects the legacy encoded-URL form with an InvalidParams error", async () => {
       const resource = registeredResources.get("post-thread");
       const encodedPostUrl = encodeURIComponent("https://mastodon.social/@user/123456");
       const uri = new URL(`activitypub://post-thread/${encodedPostUrl}`);
-      const result = await resource?.handler(uri, { domain: encodedPostUrl });
 
-      expect(result).toBeDefined();
-      expect(warnSpy).toHaveBeenCalledWith(expect.stringMatching(/deprecat/i), expect.anything());
-
-      warnSpy.mockRestore();
+      await expect(
+        resource?.handler(uri, { domain: encodedPostUrl, statusId: "" }),
+      ).rejects.toThrow(/removed in 2\.1\.0/);
     });
   });
 

--- a/tests/unit/mcp-tools.test.ts
+++ b/tests/unit/mcp-tools.test.ts
@@ -106,10 +106,21 @@ vi.mock("@logtape/logtape", () => ({
   }),
 }));
 
+vi.mock("../../src/discovery/nodeinfo.js", () => ({
+  getInstanceSoftware: vi.fn(),
+  formatInstanceSoftware: vi.fn((info) =>
+    info.detection === "success"
+      ? `\`${info.domain}\` runs ${info.software.name} ${info.software.version}.`
+      : `Could not detect software for \`${info.domain}\`: ${info.reason}.`,
+  ),
+}));
+
 // Import mocked modules
 import { remoteClient } from "../../src/activitypub/remote-client.js";
+import { auditLogger } from "../../src/audit/logger.js";
 import { dynamicInstanceDiscovery } from "../../src/discovery/dynamic-instance-discovery.js";
 import { instanceDiscovery } from "../../src/discovery/instance-discovery.js";
+import { getInstanceSoftware } from "../../src/discovery/nodeinfo.js";
 import { healthChecker } from "../../src/telemetry/health-check.js";
 import { performanceMonitor } from "../../src/telemetry/performance-monitor.js";
 
@@ -163,6 +174,7 @@ describe("MCP Tools", () => {
         "get-local-timeline",
         "get-federated-timeline",
         "get-instance-info",
+        "get-instance-software",
         "convert-url",
         "batch-fetch-actors",
         "batch-fetch-posts",
@@ -954,6 +966,91 @@ describe("MCP Tools", () => {
       expect(text).toMatch(/x{400,}/);
       // Verify it's truncated to 500, not 200
       expect(text).toMatch(/x{450,}/);
+    });
+  });
+
+  describe("get-instance-software tool", () => {
+    it("returns a prose success message for a valid instance", async () => {
+      (getInstanceSoftware as Mock).mockResolvedValue({
+        domain: "tools-success.social",
+        detection: "success",
+        software: { name: "mastodon", version: "4.3.2" },
+        protocols: ["activitypub"],
+        openRegistrations: false,
+      });
+
+      const tool = registeredTools.get("get-instance-software");
+      expect(tool).toBeDefined();
+      const result = await tool?.handler({ domain: "tools-success.social" });
+      const text = (result as { content: { text: string }[] }).content[0].text;
+      expect(text).toContain("mastodon");
+      expect(text).toContain("4.3.2");
+    });
+
+    it("returns an unavailable prose message when detection fails", async () => {
+      (getInstanceSoftware as Mock).mockResolvedValue({
+        domain: "tools-fail.social",
+        detection: "unavailable",
+        software: null,
+        protocols: null,
+        openRegistrations: null,
+        reason: "HTTP 404 Not Found",
+      });
+
+      const tool = registeredTools.get("get-instance-software");
+      const result = await tool?.handler({ domain: "tools-fail.social" });
+      const text = (result as { content: { text: string }[] }).content[0].text;
+      expect(text).toMatch(/could not detect/i);
+      expect((result as { isError?: boolean }).isError).toBeUndefined();
+    });
+
+    it("throws InvalidParams for an invalid domain", async () => {
+      const tool = registeredTools.get("get-instance-software");
+      await expect(tool?.handler({ domain: "not a domain" })).rejects.toThrow();
+      expect(getInstanceSoftware).not.toHaveBeenCalled();
+    });
+
+    it("audit-logs success=true on a successful detection", async () => {
+      (getInstanceSoftware as Mock).mockResolvedValue({
+        domain: "audit-ok.social",
+        detection: "success",
+        software: { name: "mastodon", version: "4.3.2" },
+        protocols: ["activitypub"],
+        openRegistrations: false,
+      });
+      const auditSpy = vi.spyOn(auditLogger, "logToolInvocation").mockImplementation(() => {});
+
+      const tool = registeredTools.get("get-instance-software");
+      await tool?.handler({ domain: "audit-ok.social" });
+
+      expect(auditSpy).toHaveBeenCalledWith(
+        "get-instance-software",
+        { domain: "audit-ok.social" },
+        expect.objectContaining({ success: true }),
+      );
+      auditSpy.mockRestore();
+    });
+
+    it("audit-logs success=false when detection is unavailable", async () => {
+      (getInstanceSoftware as Mock).mockResolvedValue({
+        domain: "audit-bad.social",
+        detection: "unavailable",
+        software: null,
+        protocols: null,
+        openRegistrations: null,
+        reason: "HTTP 404 Not Found",
+      });
+      const auditSpy = vi.spyOn(auditLogger, "logToolInvocation").mockImplementation(() => {});
+
+      const tool = registeredTools.get("get-instance-software");
+      await tool?.handler({ domain: "audit-bad.social" });
+
+      expect(auditSpy).toHaveBeenCalledWith(
+        "get-instance-software",
+        { domain: "audit-bad.social" },
+        expect.objectContaining({ success: false }),
+      );
+      auditSpy.mockRestore();
     });
   });
 });

--- a/tests/unit/nodeinfo.test.ts
+++ b/tests/unit/nodeinfo.test.ts
@@ -1,0 +1,575 @@
+/**
+ * Unit tests for the NodeInfo discovery module.
+ */
+
+import { HttpResponse, http } from "msw";
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  clearNodeInfoCache,
+  formatInstanceSoftware,
+  getInstanceSoftware,
+  NodeInfoDiscoverySchema,
+  NodeInfoSchema,
+} from "../../src/discovery/nodeinfo.js";
+import { instanceBlocklist } from "../../src/policy/instance-blocklist.js";
+import { server } from "../mocks/server.js";
+
+describe("NodeInfo schemas", () => {
+  describe("NodeInfoDiscoverySchema", () => {
+    it("accepts a minimal valid discovery document", () => {
+      const doc = {
+        links: [
+          {
+            rel: "http://nodeinfo.diaspora.software/ns/schema/2.0",
+            href: "https://example.social/nodeinfo/2.0",
+          },
+        ],
+      };
+      expect(() => NodeInfoDiscoverySchema.parse(doc)).not.toThrow();
+    });
+
+    it("accepts multiple link versions (2.0 + 2.1)", () => {
+      const doc = {
+        links: [
+          { rel: "http://nodeinfo.diaspora.software/ns/schema/2.0", href: "https://x/2.0" },
+          { rel: "http://nodeinfo.diaspora.software/ns/schema/2.1", href: "https://x/2.1" },
+        ],
+      };
+      expect(() => NodeInfoDiscoverySchema.parse(doc)).not.toThrow();
+    });
+
+    it("rejects when links is missing", () => {
+      expect(() => NodeInfoDiscoverySchema.parse({})).toThrow();
+    });
+
+    it("rejects when a link entry is missing href", () => {
+      expect(() =>
+        NodeInfoDiscoverySchema.parse({
+          links: [{ rel: "http://nodeinfo.diaspora.software/ns/schema/2.0" }],
+        }),
+      ).toThrow();
+    });
+  });
+
+  describe("NodeInfoSchema", () => {
+    it("accepts a NodeInfo 2.0 body", () => {
+      const body = {
+        version: "2.0",
+        software: { name: "mastodon", version: "4.3.2" },
+        protocols: ["activitypub"],
+        openRegistrations: false,
+        usage: { users: { total: 10000 } },
+        services: { inbound: [], outbound: [] },
+      };
+      expect(() => NodeInfoSchema.parse(body)).not.toThrow();
+    });
+
+    it("accepts a NodeInfo 2.1 body", () => {
+      const body = {
+        version: "2.1",
+        software: { name: "pleroma", version: "2.7.0", repository: "https://example/repo" },
+        protocols: ["activitypub"],
+        openRegistrations: true,
+      };
+      expect(() => NodeInfoSchema.parse(body)).not.toThrow();
+    });
+
+    it("rejects when software.name is missing", () => {
+      expect(() =>
+        NodeInfoSchema.parse({
+          version: "2.0",
+          software: { version: "4.3.2" },
+          protocols: ["activitypub"],
+        }),
+      ).toThrow();
+    });
+
+    it("rejects when software.version is missing", () => {
+      expect(() =>
+        NodeInfoSchema.parse({
+          version: "2.0",
+          software: { name: "mastodon" },
+          protocols: ["activitypub"],
+        }),
+      ).toThrow();
+    });
+
+    it("rejects when protocols is missing", () => {
+      expect(() =>
+        NodeInfoSchema.parse({
+          version: "2.0",
+          software: { name: "mastodon", version: "4.3.2" },
+        }),
+      ).toThrow();
+    });
+  });
+});
+
+describe("getInstanceSoftware — happy path + cache", () => {
+  beforeEach(() => {
+    clearNodeInfoCache();
+  });
+
+  it("returns success with software + version + protocols for a valid instance", async () => {
+    server.use(
+      http.get("https://happy.social/.well-known/nodeinfo", () =>
+        HttpResponse.json({
+          links: [
+            {
+              rel: "http://nodeinfo.diaspora.software/ns/schema/2.0",
+              href: "https://happy.social/nodeinfo/2.0",
+            },
+          ],
+        }),
+      ),
+      http.get("https://happy.social/nodeinfo/2.0", () =>
+        HttpResponse.json({
+          version: "2.0",
+          software: { name: "mastodon", version: "4.3.2" },
+          protocols: ["activitypub"],
+          openRegistrations: false,
+        }),
+      ),
+    );
+
+    const info = await getInstanceSoftware("happy.social");
+    expect(info).toEqual({
+      domain: "happy.social",
+      detection: "success",
+      software: { name: "mastodon", version: "4.3.2" },
+      protocols: ["activitypub"],
+      openRegistrations: false,
+    });
+  });
+
+  it("prefers 2.1 over 2.0 when both are advertised", async () => {
+    server.use(
+      http.get("https://dual.social/.well-known/nodeinfo", () =>
+        HttpResponse.json({
+          links: [
+            {
+              rel: "http://nodeinfo.diaspora.software/ns/schema/2.0",
+              href: "https://dual.social/nodeinfo/2.0",
+            },
+            {
+              rel: "http://nodeinfo.diaspora.software/ns/schema/2.1",
+              href: "https://dual.social/nodeinfo/2.1",
+            },
+          ],
+        }),
+      ),
+      http.get("https://dual.social/nodeinfo/2.1", () =>
+        HttpResponse.json({
+          version: "2.1",
+          software: { name: "pleroma", version: "2.7.0" },
+          protocols: ["activitypub"],
+        }),
+      ),
+    );
+
+    const info = await getInstanceSoftware("dual.social");
+    expect(info.detection).toBe("success");
+    expect(info.software).toEqual({ name: "pleroma", version: "2.7.0" });
+  });
+
+  it("ignores a bogus rel that sorts above the genuine 2.1 link", async () => {
+    // A misbehaving instance advertises a real 2.1 link plus a same-host rel
+    // ("2.1-evil") that lexically sorts higher. Only the exact 2.0/2.1 schema
+    // rels are valid, so the genuine link must win regardless of sort order.
+    server.use(
+      http.get("https://relbug.social/.well-known/nodeinfo", () =>
+        HttpResponse.json({
+          links: [
+            {
+              rel: "http://nodeinfo.diaspora.software/ns/schema/2.1",
+              href: "https://relbug.social/nodeinfo/2.1",
+            },
+            {
+              rel: "http://nodeinfo.diaspora.software/ns/schema/2.1-evil",
+              href: "https://relbug.social/nodeinfo/evil",
+            },
+          ],
+        }),
+      ),
+      http.get("https://relbug.social/nodeinfo/2.1", () =>
+        HttpResponse.json({
+          version: "2.1",
+          software: { name: "mastodon", version: "4.3.2" },
+          protocols: ["activitypub"],
+        }),
+      ),
+      http.get("https://relbug.social/nodeinfo/evil", () =>
+        HttpResponse.json({
+          version: "2.1",
+          software: { name: "pleroma", version: "9.9.9" },
+          protocols: ["activitypub"],
+        }),
+      ),
+    );
+
+    const info = await getInstanceSoftware("relbug.social");
+    expect(info.detection).toBe("success");
+    expect(info.software).toEqual({ name: "mastodon", version: "4.3.2" });
+  });
+
+  it("caches positive results — second call does not hit the network", async () => {
+    let fetchCount = 0;
+    server.use(
+      http.get("https://cached.social/.well-known/nodeinfo", () => {
+        fetchCount++;
+        return HttpResponse.json({
+          links: [
+            {
+              rel: "http://nodeinfo.diaspora.software/ns/schema/2.0",
+              href: "https://cached.social/nodeinfo/2.0",
+            },
+          ],
+        });
+      }),
+      http.get("https://cached.social/nodeinfo/2.0", () => {
+        fetchCount++;
+        return HttpResponse.json({
+          version: "2.0",
+          software: { name: "mastodon", version: "4.3.2" },
+          protocols: ["activitypub"],
+        });
+      }),
+    );
+
+    await getInstanceSoftware("cached.social");
+    await getInstanceSoftware("cached.social");
+    expect(fetchCount).toBe(2); // discovery + nodeinfo fetched ONCE
+  });
+});
+
+describe("getInstanceSoftware — failure modes (never throws)", () => {
+  beforeEach(() => {
+    clearNodeInfoCache();
+  });
+
+  it("returns unavailable when discovery returns 404", async () => {
+    server.use(
+      http.get(
+        "https://missing.social/.well-known/nodeinfo",
+        () => new HttpResponse(null, { status: 404 }),
+      ),
+    );
+
+    const info = await getInstanceSoftware("missing.social");
+    expect(info.detection).toBe("unavailable");
+    expect(info.software).toBeNull();
+    expect(info.reason).toMatch(/404/);
+  });
+
+  it("returns unavailable when discovery returns malformed JSON", async () => {
+    server.use(
+      http.get(
+        "https://malformed.social/.well-known/nodeinfo",
+        () =>
+          new HttpResponse("not json", { status: 200, headers: { "content-type": "text/plain" } }),
+      ),
+    );
+
+    const info = await getInstanceSoftware("malformed.social");
+    expect(info.detection).toBe("unavailable");
+    expect(info.reason).toBeDefined();
+  });
+
+  it("returns unavailable when NodeInfo body fails schema", async () => {
+    server.use(
+      http.get("https://badschema.social/.well-known/nodeinfo", () =>
+        HttpResponse.json({
+          links: [
+            {
+              rel: "http://nodeinfo.diaspora.software/ns/schema/2.0",
+              href: "https://badschema.social/nodeinfo/2.0",
+            },
+          ],
+        }),
+      ),
+      http.get(
+        "https://badschema.social/nodeinfo/2.0",
+        () => HttpResponse.json({ software: { name: "mastodon" } }), // missing version, protocols
+      ),
+    );
+
+    const info = await getInstanceSoftware("badschema.social");
+    expect(info.detection).toBe("unavailable");
+  });
+
+  it("returns unavailable when discovery has no 2.0/2.1 link", async () => {
+    server.use(
+      http.get("https://onlyv1.social/.well-known/nodeinfo", () =>
+        HttpResponse.json({
+          links: [
+            {
+              rel: "http://nodeinfo.diaspora.software/ns/schema/1.0",
+              href: "https://onlyv1.social/nodeinfo/1.0",
+            },
+          ],
+        }),
+      ),
+    );
+
+    const info = await getInstanceSoftware("onlyv1.social");
+    expect(info.detection).toBe("unavailable");
+    expect(info.reason).toMatch(/no NodeInfo 2/i);
+  });
+
+  it("caches unavailable results — repeated failures do not refetch", async () => {
+    let fetchCount = 0;
+    server.use(
+      http.get("https://flaky.social/.well-known/nodeinfo", () => {
+        fetchCount++;
+        return new HttpResponse(null, { status: 500 });
+      }),
+    );
+
+    const first = await getInstanceSoftware("flaky.social");
+    const second = await getInstanceSoftware("flaky.social");
+    expect(fetchCount).toBe(1);
+    expect(second.detection).toBe("unavailable");
+    expect(second.reason).toBe(first.reason);
+  });
+});
+
+describe("getInstanceSoftware — SSRF + blocklist", () => {
+  beforeEach(() => {
+    clearNodeInfoCache();
+    instanceBlocklist.clear();
+  });
+
+  it("returns unavailable when NodeInfo link points to a private IP", async () => {
+    server.use(
+      http.get("https://ssrf.social/.well-known/nodeinfo", () =>
+        HttpResponse.json({
+          links: [
+            {
+              rel: "http://nodeinfo.diaspora.software/ns/schema/2.0",
+              href: "https://127.0.0.1/nodeinfo/2.0",
+            },
+          ],
+        }),
+      ),
+    );
+
+    const info = await getInstanceSoftware("ssrf.social");
+    expect(info.detection).toBe("unavailable");
+    expect(info.reason).toMatch(/not allowed|private/i);
+  });
+
+  it("returns unavailable when input domain is blocklisted", async () => {
+    instanceBlocklist.addBlock({
+      domain: "blocked.social",
+      reason: "policy",
+      description: "test block",
+      addedAt: new Date().toISOString(),
+    });
+
+    const info = await getInstanceSoftware("blocked.social");
+    expect(info.detection).toBe("unavailable");
+    expect(info.reason).toMatch(/block/i);
+  });
+
+  it("returns unavailable when discovery URL uses non-https scheme", async () => {
+    // Discovery URL is constructed as https:// so this is enforced by validateExternalUrl
+    // when the user supplies a domain that resolves weirdly. Sanity-check the validator
+    // path runs by checking a domain whose resolution would be blocked.
+    server.use(
+      http.get("https://localhost.social/.well-known/nodeinfo", () =>
+        HttpResponse.json({
+          links: [
+            {
+              rel: "http://nodeinfo.diaspora.software/ns/schema/2.0",
+              href: "http://example.com/nodeinfo/2.0",
+            },
+          ],
+        }),
+      ),
+    );
+
+    const info = await getInstanceSoftware("localhost.social");
+    expect(info.detection).toBe("unavailable");
+    expect(info.reason).toMatch(/not allowed|scheme/i);
+  });
+});
+
+describe("getInstanceSoftware — single-flight", () => {
+  beforeEach(() => {
+    clearNodeInfoCache();
+  });
+
+  it("two concurrent calls for the same domain trigger a single discovery fetch", async () => {
+    let discoveryHits = 0;
+    server.use(
+      http.get("https://race.social/.well-known/nodeinfo", async () => {
+        discoveryHits++;
+        // Yield to let any second caller arrive before responding.
+        await new Promise((r) => setTimeout(r, 25));
+        return HttpResponse.json({
+          links: [
+            {
+              rel: "http://nodeinfo.diaspora.software/ns/schema/2.0",
+              href: "https://race.social/nodeinfo/2.0",
+            },
+          ],
+        });
+      }),
+      http.get("https://race.social/nodeinfo/2.0", () =>
+        HttpResponse.json({
+          software: { name: "mastodon", version: "4.3.2" },
+          protocols: ["activitypub"],
+        }),
+      ),
+    );
+
+    const [a, b] = await Promise.all([
+      getInstanceSoftware("race.social"),
+      getInstanceSoftware("race.social"),
+    ]);
+    expect(a).toEqual(b);
+    expect(discoveryHits).toBe(1);
+  });
+});
+
+describe("getInstanceSoftware — same-host check on linked URL", () => {
+  beforeEach(() => {
+    clearNodeInfoCache();
+    instanceBlocklist.clear();
+  });
+
+  it("accepts a linked NodeInfo URL on the exact same host", async () => {
+    server.use(
+      http.get("https://exact.social/.well-known/nodeinfo", () =>
+        HttpResponse.json({
+          links: [
+            {
+              rel: "http://nodeinfo.diaspora.software/ns/schema/2.0",
+              href: "https://exact.social/nodeinfo/2.0",
+            },
+          ],
+        }),
+      ),
+      http.get("https://exact.social/nodeinfo/2.0", () =>
+        HttpResponse.json({
+          software: { name: "mastodon", version: "4.3.2" },
+          protocols: ["activitypub"],
+        }),
+      ),
+    );
+
+    const info = await getInstanceSoftware("exact.social");
+    expect(info.detection).toBe("success");
+  });
+
+  it("accepts a linked NodeInfo URL on a subdomain of the input", async () => {
+    server.use(
+      http.get("https://parent.social/.well-known/nodeinfo", () =>
+        HttpResponse.json({
+          links: [
+            {
+              rel: "http://nodeinfo.diaspora.software/ns/schema/2.0",
+              href: "https://nodeinfo.parent.social/2.0",
+            },
+          ],
+        }),
+      ),
+      http.get("https://nodeinfo.parent.social/2.0", () =>
+        HttpResponse.json({
+          software: { name: "akkoma", version: "3.13.0" },
+          protocols: ["activitypub"],
+        }),
+      ),
+    );
+
+    const info = await getInstanceSoftware("parent.social");
+    expect(info.detection).toBe("success");
+    expect(info.software?.name).toBe("akkoma");
+  });
+
+  it("accepts a linked NodeInfo URL on the same host in trailing-dot FQDN form", async () => {
+    server.use(
+      http.get("https://fqdn.social/.well-known/nodeinfo", () =>
+        HttpResponse.json({
+          links: [
+            {
+              rel: "http://nodeinfo.diaspora.software/ns/schema/2.0",
+              href: "https://fqdn.social./nodeinfo/2.0",
+            },
+          ],
+        }),
+      ),
+      http.get("https://fqdn.social./nodeinfo/2.0", () =>
+        HttpResponse.json({
+          software: { name: "mastodon", version: "4.3.2" },
+          protocols: ["activitypub"],
+        }),
+      ),
+    );
+
+    const info = await getInstanceSoftware("fqdn.social");
+    expect(info.detection).toBe("success");
+    expect(info.software?.name).toBe("mastodon");
+  });
+
+  it("rejects a linked NodeInfo URL on an unrelated host", async () => {
+    server.use(
+      http.get("https://victim.social/.well-known/nodeinfo", () =>
+        HttpResponse.json({
+          links: [
+            {
+              rel: "http://nodeinfo.diaspora.software/ns/schema/2.0",
+              href: "https://attacker.test/nodeinfo/2.0",
+            },
+          ],
+        }),
+      ),
+    );
+
+    const info = await getInstanceSoftware("victim.social");
+    expect(info.detection).toBe("unavailable");
+    expect(info.reason).toMatch(/different host|cross-host/i);
+  });
+});
+
+describe("formatInstanceSoftware", () => {
+  it("formats a success result as a single human-readable line", () => {
+    const text = formatInstanceSoftware({
+      domain: "mastodon.social",
+      detection: "success",
+      software: { name: "mastodon", version: "4.3.2" },
+      protocols: ["activitypub"],
+      openRegistrations: false,
+    });
+    expect(text).toContain("mastodon.social");
+    expect(text).toContain("Mastodon");
+    expect(text).toContain("4.3.2");
+    expect(text).toContain("activitypub");
+    expect(text).toContain("false");
+  });
+
+  it("formats an unavailable result with the reason", () => {
+    const text = formatInstanceSoftware({
+      domain: "missing.social",
+      detection: "unavailable",
+      software: null,
+      protocols: null,
+      openRegistrations: null,
+      reason: "HTTP 404 Not Found",
+    });
+    expect(text).toMatch(/could not detect/i);
+    expect(text).toContain("missing.social");
+    expect(text).toContain("HTTP 404");
+  });
+
+  it("capitalizes common software names", () => {
+    const text = formatInstanceSoftware({
+      domain: "x.social",
+      detection: "success",
+      software: { name: "pleroma", version: "2.7.0" },
+      protocols: ["activitypub"],
+      openRegistrations: null,
+    });
+    expect(text).toContain("Pleroma");
+  });
+});


### PR DESCRIPTION
Closes out the v2 release cycle.

> **Merge = publish.** Merging to `master` lands the `package.json` bump to `2.1.0`, which triggers `auto-release.yml` → pushes the `v2.1.0` tag → `release.yml` runs the full gate and publishes to npm (with provenance) + creates the GitHub Release. Nothing publishes until this merges.

## Added
- **`get-instance-software` tool** — NodeInfo 2.0/2.1 software + version detection (Mastodon, Pleroma, Misskey, Akkoma, Sharkey, GotoSocial, Friendica, …). Structured result, prose output, never throws on detection failure.
- **`activitypub://instance-info/{domain}` enrichment** — same NodeInfo detection merged in parallel; the resource still succeeds when detection is `unavailable`.
- **`MCP_INSTANCE_SOFTWARE_TTL_MS`** — positive-cache TTL for detection (default 24h; negative cache hardcoded 1h).
- **Dependabot** — weekly npm + GitHub Actions PRs; minor+patch grouped, majors surfaced individually for review.

## Breaking
- **`activitypub://post-thread/{postUrl}` removed** (deprecated in v2.0.0) — use `activitypub://post-thread/{domain}/{statusId}`; the legacy form now returns `InvalidParams`.
- **`instance-info` `software` field is now a structured object**, not a plain string.

## Hardening / internal
- NodeInfo module: SSRF + blocklist re-validation at every fetch and redirect, **exact `2.0`/`2.1` rel matching** (no prefix/sort steering), same-host/subdomain check (incl. trailing-dot FQDN), single-flight dedup, positive/negative LRU caches.
- Audit-logging regression guard for `get-instance-software` (this call regressed once before).
- `package-lock.json` synced to `2.1.0` (the `validate:version` gate was failing).
- Windows CI fixes (bin-shim smoke test, CRLF lint, CodeQL alert, hardcoded test path).

## Verification
`validate:version`, `typecheck`, `lint`, and `build` are green; **661 unit tests pass**.

Full detail in `CHANGELOG.md` under `## [2.1.0]`.
