### PR TITLE
ci: allow manual dispatch of release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,10 @@ on:
   push:
     tags:
       - 'v*'
+  # Manual fallback: auto-release.yml pushes the tag with GITHUB_TOKEN, which
+  # cannot trigger this workflow (GitHub anti-recursion). Run this manually
+  # against the vX.Y.Z tag to publish + create the release without a re-push.
+  workflow_dispatch:
 
 # id-token: write is required for OIDC-based npm provenance attestations.
 permissions:


### PR DESCRIPTION
## Why

`auto-release.yml` creates and pushes the `vX.Y.Z` tag using `secrets.GITHUB_TOKEN`. GitHub does **not** trigger new workflow runs from events created by `GITHUB_TOKEN` (anti-recursion), and `release.yml` only triggers on `push: tags: 'v*'`. So after a release PR merges, the tag exists but **npm publish + the GitHub Release never fire** until someone manually re-pushes the tag from a personal credential. This bit the v2.1.0 release (publish lagged ~8h until a manual re-push).

## Change

Add `workflow_dispatch:` to `release.yml`. This is purely additive — the existing tag-push trigger is unchanged. When the auto path stalls, you can now re-run the publish+release from the Actions tab by dispatching this workflow **against the `vX.Y.Z` tag ref** (the version is still derived from `GITHUB_REF`), instead of deleting/re-pushing the tag.

## Notes

- Does not fully automate the chain — that would need `auto-release.yml` to push the tag via a `workflow`-scoped PAT. Left out deliberately (requires a new secret).
- No runtime/package impact.