### PR TITLE
Release v2.2.0: platform-aware write layer + Misskey adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.2.0] - 2026-05-29
 
 ### Added
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "activitypub-mcp",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "activitypub-mcp",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "license": "MIT",
       "dependencies": {
         "@logtape/logtape": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activitypub-mcp",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "A Model Context Protocol server for exploring and interacting with the existing Fediverse",
   "main": "dist/mcp-main.js",
   "bin": {

--- a/src/config.ts
+++ b/src/config.ts
@@ -37,7 +37,7 @@ function parseBoolEnv(value: string | undefined, defaultValue: boolean): boolean
 export const SERVER_NAME = process.env.MCP_SERVER_NAME || "activitypub-mcp";
 
 /** MCP Server version */
-export const SERVER_VERSION = process.env.MCP_SERVER_VERSION || "2.1.0";
+export const SERVER_VERSION = process.env.MCP_SERVER_VERSION || "2.2.0";
 
 /** Log level for the application */
 export const LOG_LEVEL = process.env.LOG_LEVEL || "info";


### PR DESCRIPTION
Release prep for **v2.2.0**. The feature work (platform-aware write layer + Misskey adapter) already merged via #103; this PR only finalizes the release artifacts.

## Changes
- Bump version `2.1.0` → `2.2.0` across `package.json`, `package-lock.json` (top-level + root pkg), and `SERVER_VERSION` in `src/config.ts`
- Promote CHANGELOG `[Unreleased]` → `[2.2.0] - 2026-05-29`

## What's shipping (from #103)
- **Platform-aware write layer** — authenticated ops route to the correct fediverse API per instance via NodeInfo software detection
- **Misskey/Foundkey adapter** — core-parity ops normalized into the existing Mastodon-shaped types; Mastodon-compatible software and undetected instances keep the Mastodon adapter
- **`UnsupportedOnPlatformError`** — bookmarks, poll voting, scheduled posts return a clear "not supported on Misskey" message

## Verification (local, mirrors the release gates)
- `validate:version` ✅ all four stamps match 2.2.0
- `typecheck` ✅ · `lint` ✅ · `build` ✅
- `test` ✅ 690 passed (28 files)
- `check-tarball-contents` ✅ (81 files) · `smoke-test-bin` ✅

## After merge
Tag `v2.2.0` must be pushed to trigger `release.yml` (npm publish). Note: a tag pushed by `auto-release.yml`'s `GITHUB_TOKEN` will not trigger `release.yml` (GitHub anti-recursion) — run `release.yml` manually against the tag, or re-push the tag with a PAT.