### PR TITLE
SP2: browser-based login + credential persistence

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -62,6 +62,10 @@ RATE_LIMIT_WINDOW=900000
 # ACTIVITYPUB_DEFAULT_TOKEN=
 # ACTIVITYPUB_DEFAULT_USERNAME=
 
+# Directory for the persisted credential store (accounts.json) created by
+# `activitypub-mcp login`. Default: ${XDG_CONFIG_HOME:-~/.config}/activitypub-mcp
+# ACTIVITYPUB_CONFIG_DIR=/path/to/config
+
 # ============================================================================
 # THREAD TRAVERSAL CAPS (v2 — applies to get-post-thread)
 # ============================================================================

--- a/.env.production.example
+++ b/.env.production.example
@@ -89,3 +89,7 @@ MAX_DYNAMIC_INSTANCES=100
 # Multi-account form (pipe-delimited; v2 changed from colon to avoid
 # conflict with colons in tokens):
 # ACTIVITYPUB_ACCOUNTS=id1|instance1|token1|username1|label1,id2|instance2|token2|username2|label2
+#
+# Directory for the persisted credential store (accounts.json) created by
+# `activitypub-mcp login`. Default: ${XDG_CONFIG_HOME:-~/.config}/activitypub-mcp
+# ACTIVITYPUB_CONFIG_DIR=/path/to/config

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Browser-based login.** New `activitypub-mcp login <instance>` acquires an
+  access token via Mastodon OAuth2 (PKCE) or Misskey/Foundkey MiAuth — routed by
+  NodeInfo software detection — using an ephemeral `127.0.0.1` loopback callback,
+  and persists it to `${XDG_CONFIG_HOME:-~/.config}/activitypub-mcp/accounts.json`
+  (mode `0600`). The server loads persisted accounts at startup alongside env-var
+  accounts. Adds `activitypub-mcp logout <id>` and `activitypub-mcp accounts`.
+- **`ACTIVITYPUB_CONFIG_DIR`** to override the credential-store location.
+- **Clearer auth errors.** A rejected token (401/403) now returns a
+  `TokenRejectedError` telling you to run `activitypub-mcp login <instance>`.
+
 ## [2.2.0] - 2026-05-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1270,6 +1270,37 @@ site under `src/pages/docs/` in v2.0.0.
 - `npm run test` - Run tests
 - `npm run build` - Build TypeScript
 
+### Signing in (OAuth / MiAuth)
+
+Acquire and persist an access token without hand-copying it:
+
+```bash
+# Mastodon-family (Mastodon, Pleroma, Akkoma, GotoSocial, Sharkey, Firefish)
+activitypub-mcp login mastodon.social
+
+# Misskey / Foundkey (uses MiAuth)
+activitypub-mcp login misskey.io
+```
+
+This opens your browser to authorize, captures the response on a temporary
+`127.0.0.1` callback, and saves the token to
+`${XDG_CONFIG_HOME:-~/.config}/activitypub-mcp/accounts.json` (file mode `0600`).
+The MCP server loads persisted accounts at startup alongside any env-var accounts.
+
+- `activitypub-mcp accounts` — list signed-in accounts (no secrets shown).
+- `activitypub-mcp logout <id>` — revoke (Mastodon) and remove the account.
+
+#### Notes & limitations
+
+- Tokens are stored in plaintext, protected by file permissions (like `gh`/`npm`).
+  For stronger at-rest protection, use the env-var path with a secret manager.
+- Interactive login needs a local browser + reachable loopback. Headless/CI
+  deployments keep using `ACTIVITYPUB_DEFAULT_INSTANCE` / `ACTIVITYPUB_DEFAULT_TOKEN`.
+- IDs are platform-scoped — a token works only against the instance it was issued for.
+- Misskey has no app-revoke endpoint; `logout` removes the local record (revoke the
+  token in your instance's Settings → API to fully invalidate it).
+- Foundkey is migrating off MiAuth; login may fail on builds that have removed it.
+
 ### Environment Variables
 
 Create a `.env` file:

--- a/docs/superpowers/plans/2026-05-30-oauth-onboarding.md
+++ b/docs/superpowers/plans/2026-05-30-oauth-onboarding.md
@@ -1,0 +1,2768 @@
+# Browser-Based Login + Credential Persistence Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `activitypub-mcp login/logout/accounts` CLI subcommands that acquire access tokens via Mastodon OAuth2 or Misskey MiAuth (routed by NodeInfo software detection) and persist them to an on-disk store the server loads at startup — so users stop hand-pasting tokens.
+
+**Architecture:** A `LoginStrategy` interface with two implementations (`MastodonOAuthStrategy`, `MisskeyMiAuthStrategy`) selected by `getInstanceSoftware()`, exactly mirroring SP1's `WriteAdapter`. A CLI orchestrator owns the shared mechanics — an **ephemeral-port** one-shot `127.0.0.1` loopback callback (RFC 8252) and a cross-platform browser opener — and injects them into the strategy. Tokens persist via a `node:fs` JSON store (XDG dir, `0600`) that `AccountManager` loads at startup alongside the existing env-var path. Pre-token HTTP uses a new guarded **unauthenticated** fetch helper (the existing `authenticatedFetch` can't run without a token).
+
+**Tech Stack:** TypeScript (ESM, NodeNext), Zod v4, Vitest + MSW, LogTape, `node:http`/`node:crypto`/`node:fs`/`node:child_process` (no new runtime dependency).
+
+**Spec:** `docs/superpowers/specs/2026-05-29-oauth-onboarding-design.md`
+
+**Conventions (read before starting):**
+- All commands run from repo root `/Users/cameron/Developer/activitypub-mcp`.
+- Run one test file: `npm run test -- tests/unit/<file>.test.ts`
+- Run one test by name: `npm run test -- tests/unit/<file>.test.ts -t "name"`
+- Typecheck: `npm run typecheck`  •  Lint+fix: `npm run lint:fix`  •  Version check stays green automatically.
+- **Run `npm run lint:fix` before every commit.** Biome enforces 100-col line width and import ordering, and the pre-commit hook runs `biome check` (no auto-fix) — so unformatted code (long `throw new Error(...)` / `process.stdout.write(...)` lines, imports added below code) will reject the commit unless `lint:fix` ran first.
+- ESM: import paths use the `.js` extension even for `.ts` files. Match existing style.
+- Secrets (`accessToken`, `clientSecret`, `code`, `code_verifier`, MiAuth `session`/`token`) must **never** be logged. Log only `instance`/`username`/`scopes`.
+
+---
+
+## File structure
+
+| File | Responsibility |
+|------|----------------|
+| `src/config.ts` (modify) | Add `CONFIG_DIR` resolution (`ACTIVITYPUB_CONFIG_DIR` → XDG → `~/.config`). |
+| `src/auth/credential-store.ts` (create) | `StoredAccount` schema/type + `CredentialStore` (load/upsert/remove/get) with atomic `0600` writes, perms/symlink refusal, malformed-file preservation. Exports `credentialStore` singleton. |
+| `src/auth/account-manager.ts` (modify) | Add async `loadPersisted()` (collision-guarded; env wins). |
+| `src/mcp-server.ts` (modify) | `await accountManager.loadPersisted()` at the top of `start()`. |
+| `src/utils/fetch-helpers.ts` (modify) | Add `guardedFetch()` — guarded UNauthenticated fetch (method/headers/body). |
+| `src/discovery/nodeinfo.ts` (modify) | Refactor private `fetchJson` to call `guardedFetch`. |
+| `src/auth/login/loopback-server.ts` (create) | One-shot `127.0.0.1:0` callback server; resolves only on matching `state`/`session`. |
+| `src/auth/login/browser.ts` (create) | `openBrowser(url)` — argv-array spawn, URL-print fallback. |
+| `src/auth/login/login-strategy.ts` (create) | `LoginStrategy`/`LoginResult`/`AuthorizeContext` types. |
+| `src/auth/login/scopes.ts` (create) | `MASTODON_SCOPES`, `MISSKEY_PERMISSIONS` constants. |
+| `src/auth/login/mastodon-oauth.ts` (create) | `MastodonOAuthStrategy` (app registration, PKCE authorize, token, revoke). |
+| `src/auth/login/miauth.ts` (create) | `MisskeyMiAuthStrategy` (session, consent, check). |
+| `src/auth/login/resolve.ts` (create) | `resolveLoginStrategy(instance)` via `getInstanceSoftware()`. |
+| `src/cli/login.ts` (create) | `runLogin()` orchestration + `LoginResult→StoredAccount` mapping. |
+| `src/cli/logout.ts`, `src/cli/accounts.ts` (create) | `runLogout()`, `runAccounts()`. |
+| `src/cli/index.ts` (create) | `dispatchCli(argv)` subcommand router. |
+| `src/mcp-main.ts` (modify) | Call `dispatchCli` before `validateConfiguration()`/server start. |
+| `src/utils/errors.ts` (modify) | Add `TokenRejectedError`. |
+| `src/auth/adapters/write-adapter.ts` (modify) | `authenticatedFetch` throws `TokenRejectedError` on 401/403. |
+| `src/mcp/tools-write.ts` (modify) | Add `login` hint to the "no account" guard messages. |
+| `README.md`, `.env.example`, `.env.production.example`, `CHANGELOG.md` (modify) | Document login + storage + limitations. |
+
+Tests are created alongside each task under `tests/unit/`.
+
+---
+
+## Task 1: Config dir + `CredentialStore` core (schema + CRUD + atomic write)
+
+**Files:**
+- Modify: `src/config.ts`
+- Create: `src/auth/credential-store.ts`
+- Test: `tests/unit/credential-store.test.ts`
+
+- [ ] **Step 1: Add `CONFIG_DIR` to config**
+
+In `src/config.ts`, after the `SERVER_VERSION` block (around line 40), add:
+
+```ts
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+/**
+ * Directory for the persisted credential store (accounts.json).
+ * Precedence: ACTIVITYPUB_CONFIG_DIR → $XDG_CONFIG_HOME/activitypub-mcp → ~/.config/activitypub-mcp.
+ */
+export const CONFIG_DIR =
+  process.env.ACTIVITYPUB_CONFIG_DIR ||
+  join(process.env.XDG_CONFIG_HOME || join(homedir(), ".config"), "activitypub-mcp");
+```
+
+(Place the two `node:` imports with the other imports at the top of the file if imports are grouped there; otherwise inline above is fine for NodeNext.)
+
+- [ ] **Step 2: Write the failing test**
+
+Create `tests/unit/credential-store.test.ts`:
+
+```ts
+/**
+ * Unit tests for the on-disk credential store.
+ */
+
+import { mkdtempSync, readFileSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+let dir: string;
+
+function freshStore() {
+  // Re-import with a per-test CONFIG_DIR (config reads env at import time).
+  dir = mkdtempSync(join(tmpdir(), "apmcp-store-"));
+  process.env.ACTIVITYPUB_CONFIG_DIR = join(dir, "config");
+  return import(`../../src/auth/credential-store.js?ts=${Date.now()}-${Math.random().toString(36).slice(2)}`);
+}
+
+const sample = {
+  id: "alice@mastodon.test",
+  instance: "mastodon.test",
+  username: "alice",
+  accessToken: "tok-123",
+  tokenType: "Bearer",
+  scopes: ["read", "write", "follow"],
+  clientId: "cid",
+  clientSecret: "csecret",
+  createdAt: "2026-01-01T00:00:00.000Z",
+};
+
+describe("CredentialStore", () => {
+  const originalEnv = process.env;
+  beforeEach(() => {
+    vi.resetModules(); // force config.js to re-read ACTIVITYPUB_CONFIG_DIR per test
+    process.env = { ...originalEnv };
+  });
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("returns an empty list when the file is absent", async () => {
+    const { CredentialStore } = await freshStore();
+    const store = new CredentialStore();
+    expect(await store.loadAccounts()).toEqual([]);
+  });
+
+  it("upserts and loads an account, writing the file 0600", async () => {
+    const { CredentialStore } = await freshStore();
+    const store = new CredentialStore();
+    await store.upsert(sample);
+
+    const loaded = await store.loadAccounts();
+    expect(loaded).toHaveLength(1);
+    expect(loaded[0]).toEqual(sample);
+
+    const filePath = join(process.env.ACTIVITYPUB_CONFIG_DIR as string, "accounts.json");
+    const mode = statSync(filePath).mode & 0o777;
+    expect(mode).toBe(0o600);
+    // File must be parseable JSON.
+    expect(() => JSON.parse(readFileSync(filePath, "utf-8"))).not.toThrow();
+  });
+
+  it("upsert replaces an existing id", async () => {
+    const { CredentialStore } = await freshStore();
+    const store = new CredentialStore();
+    await store.upsert(sample);
+    await store.upsert({ ...sample, accessToken: "tok-NEW" });
+    const loaded = await store.loadAccounts();
+    expect(loaded).toHaveLength(1);
+    expect(loaded[0].accessToken).toBe("tok-NEW");
+  });
+
+  it("get returns one account or undefined", async () => {
+    const { CredentialStore } = await freshStore();
+    const store = new CredentialStore();
+    await store.upsert(sample);
+    expect((await store.getAccount("alice@mastodon.test"))?.username).toBe("alice");
+    expect(await store.getAccount("nope")).toBeUndefined();
+  });
+
+  it("remove deletes by id and reports success", async () => {
+    const { CredentialStore } = await freshStore();
+    const store = new CredentialStore();
+    await store.upsert(sample);
+    expect(await store.remove("alice@mastodon.test")).toBe(true);
+    expect(await store.remove("alice@mastodon.test")).toBe(false);
+    expect(await store.loadAccounts()).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `npm run test -- tests/unit/credential-store.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 4: Implement the store**
+
+Create `src/auth/credential-store.ts`:
+
+```ts
+/**
+ * On-disk credential store for accounts acquired via `activitypub-mcp login`.
+ *
+ * Plain node:fs JSON file at CONFIG_DIR/accounts.json. Secrets are protected by
+ * filesystem permissions (0600 file / 0700 dir) — the chosen trade-off (no
+ * keychain/encryption). Writes are atomic (temp + rename) so a crash never
+ * leaves a half-written file.
+ */
+
+import { getLogger } from "@logtape/logtape";
+import { randomBytes } from "node:crypto";
+import { chmodSync, mkdirSync } from "node:fs";
+import { open, readFile, rename, stat } from "node:fs/promises";
+import { join } from "node:path";
+import { z } from "zod";
+import { CONFIG_DIR } from "../config.js";
+
+const logger = getLogger("activitypub-mcp:credential-store");
+
+export const StoredAccountSchema = z.object({
+  id: z.string(),
+  instance: z.string(),
+  username: z.string(),
+  accessToken: z.string(),
+  tokenType: z.string().default("Bearer"),
+  scopes: z.array(z.string()),
+  clientId: z.string().optional(),
+  clientSecret: z.string().optional(),
+  label: z.string().optional(),
+  createdAt: z.string(),
+});
+export type StoredAccount = z.infer<typeof StoredAccountSchema>;
+
+const FileSchema = z.object({
+  version: z.literal(1),
+  accounts: z.array(StoredAccountSchema),
+});
+
+export class CredentialStore {
+  private readonly dir: string;
+  private readonly file: string;
+
+  constructor(dir: string = CONFIG_DIR) {
+    this.dir = dir;
+    this.file = join(dir, "accounts.json");
+  }
+
+  /** Load all persisted accounts. Absent file → []. */
+  async loadAccounts(): Promise<StoredAccount[]> {
+    let raw: string;
+    try {
+      raw = await readFile(this.file, "utf-8");
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
+      throw error;
+    }
+    const parsed = FileSchema.parse(JSON.parse(raw));
+    return parsed.accounts;
+  }
+
+  async getAccount(id: string): Promise<StoredAccount | undefined> {
+    return (await this.loadAccounts()).find((a) => a.id === id);
+  }
+
+  /** Insert or replace an account by id. */
+  async upsert(account: StoredAccount): Promise<void> {
+    const accounts = await this.loadAccounts();
+    const next = accounts.filter((a) => a.id !== account.id);
+    next.push(StoredAccountSchema.parse(account));
+    await this.write(next);
+    logger.info("Persisted account", { id: account.id, instance: account.instance });
+  }
+
+  /** Remove an account by id; returns whether it existed. */
+  async remove(id: string): Promise<boolean> {
+    const accounts = await this.loadAccounts();
+    const next = accounts.filter((a) => a.id !== id);
+    if (next.length === accounts.length) return false;
+    await this.write(next);
+    logger.info("Removed persisted account", { id });
+    return true;
+  }
+
+  /** Atomic write: temp file (0600, O_EXCL) in the same dir, then rename. */
+  private async write(accounts: StoredAccount[]): Promise<void> {
+    mkdirSync(this.dir, { recursive: true, mode: 0o700 });
+    const body = `${JSON.stringify({ version: 1, accounts }, null, 2)}\n`;
+    const tmp = join(this.dir, `accounts.json.${randomBytes(6).toString("hex")}.tmp`);
+    const handle = await open(tmp, "wx", 0o600);
+    try {
+      await handle.writeFile(body);
+      await handle.sync();
+    } finally {
+      await handle.close();
+    }
+    await rename(tmp, this.file);
+    chmodSync(this.file, 0o600);
+  }
+
+  /** Exposed for the loader's permission hardening (Task 2). */
+  get filePath(): string {
+    return this.file;
+  }
+  get dirPath(): string {
+    return this.dir;
+  }
+
+  // `stat` is imported for Task 2; referenced here to keep the import used.
+  protected statFile(): ReturnType<typeof stat> {
+    return stat(this.file);
+  }
+}
+
+export const credentialStore = new CredentialStore();
+```
+
+> Note: `stat` is imported now and used fully in Task 2; the `statFile()` shim keeps
+> the import live so this task typechecks. Task 2 replaces it with real hardening.
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `npm run test -- tests/unit/credential-store.test.ts`
+Expected: PASS — 5 specs.
+
+- [ ] **Step 6: Typecheck + commit**
+
+```bash
+npm run typecheck
+git add src/config.ts src/auth/credential-store.ts tests/unit/credential-store.test.ts
+git commit -m "feat(auth): credential store with atomic 0600 persistence + CONFIG_DIR"
+```
+
+---
+
+## Task 2: `CredentialStore` hardening (perms/symlink refusal + malformed preservation)
+
+**Files:**
+- Modify: `src/auth/credential-store.ts`
+- Test: `tests/unit/credential-store.test.ts` (append)
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/unit/credential-store.test.ts`:
+
+```ts
+import { chmodSync, symlinkSync, writeFileSync } from "node:fs";
+import { existsSync, readdirSync } from "node:fs";
+
+describe("CredentialStore hardening", () => {
+  const originalEnv = process.env;
+  beforeEach(() => {
+    vi.resetModules(); // force config.js to re-read ACTIVITYPUB_CONFIG_DIR per test
+    process.env = { ...originalEnv };
+  });
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("relaxes an over-permissive file back to 0600 on load", async () => {
+    const { CredentialStore } = await freshStore();
+    const store = new CredentialStore();
+    await store.upsert(sample);
+    const filePath = join(process.env.ACTIVITYPUB_CONFIG_DIR as string, "accounts.json");
+    chmodSync(filePath, 0o644);
+
+    await store.loadAccounts();
+    const mode = statSync(filePath).mode & 0o777;
+    expect(mode).toBe(0o600);
+  });
+
+  it("refuses to read a symlinked accounts file", async () => {
+    const { CredentialStore } = await freshStore();
+    const cfg = process.env.ACTIVITYPUB_CONFIG_DIR as string;
+    mkdtempSync; // noop to keep import; real dir below
+    const target = join(dir, "evil.json");
+    writeFileSync(target, JSON.stringify({ version: 1, accounts: [] }));
+    // Build the config dir and symlink accounts.json -> evil.json.
+    const store = new CredentialStore();
+    await store.upsert(sample); // creates cfg + a real file
+    const filePath = join(cfg, "accounts.json");
+    // Replace with a symlink.
+    const { rmSync } = await import("node:fs");
+    rmSync(filePath);
+    symlinkSync(target, filePath);
+
+    await expect(store.loadAccounts()).rejects.toThrow(/symlink|refus/i);
+  });
+
+  it("preserves a malformed file as .corrupt and returns []", async () => {
+    const { CredentialStore } = await freshStore();
+    const store = new CredentialStore();
+    await store.upsert(sample);
+    const filePath = join(process.env.ACTIVITYPUB_CONFIG_DIR as string, "accounts.json");
+    writeFileSync(filePath, "{ this is not valid json");
+
+    expect(await store.loadAccounts()).toEqual([]);
+    const dirContents = readdirSync(process.env.ACTIVITYPUB_CONFIG_DIR as string);
+    expect(dirContents.some((f) => f.startsWith("accounts.json.corrupt-"))).toBe(true);
+    expect(existsSync(filePath)).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test -- tests/unit/credential-store.test.ts -t "hardening"`
+Expected: FAIL — current `loadAccounts` doesn't chmod, refuse symlinks, or preserve malformed files.
+
+- [ ] **Step 3: Implement hardening**
+
+In `src/auth/credential-store.ts`, replace the `loadAccounts` method (and delete the `statFile` shim) with:
+
+```ts
+  async loadAccounts(): Promise<StoredAccount[]> {
+    let info: Awaited<ReturnType<typeof lstat>>;
+    try {
+      info = await lstat(this.file);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
+      throw error;
+    }
+    if (info.isSymbolicLink()) {
+      throw new Error(`Refusing to read credential file: ${this.file} is a symlink`);
+    }
+    // Refuse a file owned by another user (POSIX only; getuid is undefined on Windows).
+    // Not unit-tested: chown to a foreign uid needs root, so this is impl-only defense.
+    if (typeof process.getuid === "function" && info.uid !== process.getuid()) {
+      throw new Error(`Refusing to read credential file: ${this.file} is not owned by the current user`);
+    }
+    // Relax over-permissive files back to 0600 rather than only warning.
+    if ((info.mode & 0o077) !== 0) {
+      logger.warn("Credential file was group/other-accessible; tightening to 0600", {
+        file: this.file,
+      });
+      chmodSync(this.file, 0o600);
+    }
+
+    const raw = await readFile(this.file, "utf-8");
+    try {
+      return FileSchema.parse(JSON.parse(raw)).accounts;
+    } catch (error) {
+      const corrupt = `${this.file}.corrupt-${Date.now()}`;
+      await rename(this.file, corrupt);
+      logger.error("Credential file invalid; preserved and treating store as empty", {
+        file: this.file,
+        preservedAs: corrupt,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return [];
+    }
+  }
+```
+
+Add `lstat` to the `node:fs/promises` import line and remove the now-unused `stat`:
+
+```ts
+import { lstat, open, readFile, rename } from "node:fs/promises";
+```
+
+Delete the `protected statFile()` method and the `get filePath`/`get dirPath` are kept (used by tests/loader).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm run test -- tests/unit/credential-store.test.ts`
+Expected: PASS — core + hardening specs.
+
+- [ ] **Step 5: Typecheck + commit**
+
+```bash
+npm run typecheck
+git add src/auth/credential-store.ts tests/unit/credential-store.test.ts
+git commit -m "feat(auth): harden credential store (symlink refusal, perms, corrupt-file preservation)"
+```
+
+---
+
+## Task 3: `AccountManager.loadPersisted()` (collision-guarded; env wins)
+
+**Files:**
+- Modify: `src/auth/account-manager.ts`
+- Test: `tests/unit/account-manager.test.ts` (append)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/unit/account-manager.test.ts`:
+
+```ts
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+describe("AccountManager.loadPersisted", () => {
+  const originalEnv = process.env;
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = { ...originalEnv };
+    delete process.env.ACTIVITYPUB_DEFAULT_INSTANCE;
+    delete process.env.ACTIVITYPUB_DEFAULT_TOKEN;
+    delete process.env.ACTIVITYPUB_ACCOUNTS;
+  });
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  async function withStore() {
+    const dir = mkdtempSync(join(tmpdir(), "apmcp-lp-"));
+    process.env.ACTIVITYPUB_CONFIG_DIR = join(dir, "cfg");
+    const { CredentialStore } = await import(
+      `../../src/auth/credential-store.js?ts=${Date.now()}-${Math.random().toString(36).slice(2)}`
+    );
+    return new CredentialStore();
+  }
+
+  it("loads persisted accounts into the manager", async () => {
+    const store = await withStore();
+    await store.upsert({
+      id: "bob@misskey.test",
+      instance: "misskey.test",
+      username: "bob",
+      accessToken: "tok",
+      tokenType: "Bearer",
+      scopes: ["read:account"],
+      createdAt: "2026-01-01T00:00:00.000Z",
+    });
+    const { AccountManager } = await import("../../src/auth/account-manager.js");
+    const manager = new AccountManager();
+    await manager.loadPersisted(store);
+    expect(manager.getAccount("bob@misskey.test")?.username).toBe("bob");
+  });
+
+  it("env-var account wins on id collision (persisted skipped)", async () => {
+    process.env.ACTIVITYPUB_DEFAULT_INSTANCE = "env.test";
+    process.env.ACTIVITYPUB_DEFAULT_TOKEN = "env-token";
+    const store = await withStore();
+    await store.upsert({
+      id: "default",
+      instance: "persisted.test",
+      username: "persisted",
+      accessToken: "persisted-token",
+      tokenType: "Bearer",
+      scopes: ["read"],
+      createdAt: "2026-01-01T00:00:00.000Z",
+    });
+    const { AccountManager } = await import("../../src/auth/account-manager.js");
+    const manager = new AccountManager();
+    await manager.loadPersisted(store);
+    expect(manager.getAccount("default")?.instance).toBe("env.test");
+  });
+
+  it("never throws if the store read fails", async () => {
+    const { AccountManager } = await import("../../src/auth/account-manager.js");
+    const manager = new AccountManager();
+    const brokenStore = {
+      loadAccounts: () => Promise.reject(new Error("disk gone")),
+    } as unknown as { loadAccounts: () => Promise<never> };
+    await expect(manager.loadPersisted(brokenStore as never)).resolves.toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test -- tests/unit/account-manager.test.ts -t "loadPersisted"`
+Expected: FAIL — `loadPersisted` is not a method.
+
+- [ ] **Step 3: Implement**
+
+In `src/auth/account-manager.ts`, add a type-only import near the top:
+
+```ts
+import type { CredentialStore } from "./credential-store.js";
+```
+
+Add this method to the `AccountManager` class (e.g. after `verifyAccount`):
+
+```ts
+  /**
+   * Merge on-disk persisted accounts into the manager. Env-var accounts (loaded
+   * in the constructor) WIN on id collision — deploy-time config is authoritative.
+   * Never throws: a store failure logs and leaves env accounts intact.
+   *
+   * @param store - injected for testability; defaults to the shared singleton.
+   */
+  async loadPersisted(store?: CredentialStore): Promise<void> {
+    try {
+      const resolved = store ?? (await import("./credential-store.js")).credentialStore;
+      const records = await resolved.loadAccounts();
+      for (const rec of records) {
+        if (this.accounts.has(rec.id)) {
+          logger.warn("Persisted account shadowed by env account; skipping", { id: rec.id });
+          continue;
+        }
+        this.addAccount({
+          id: rec.id,
+          instance: rec.instance,
+          username: rec.username,
+          accessToken: rec.accessToken,
+          tokenType: rec.tokenType,
+          scopes: rec.scopes,
+          label: rec.label,
+        });
+      }
+    } catch (error) {
+      logger.error("Failed to load persisted accounts (env accounts unaffected)", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+```
+
+> `addAccount` regenerates `createdAt` in-memory; the on-disk record keeps its
+> original timestamp. That's acceptable — `createdAt` is local bookkeeping.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm run test -- tests/unit/account-manager.test.ts`
+Expected: PASS — existing env tests plus the 3 new specs.
+
+- [ ] **Step 5: Typecheck + commit**
+
+```bash
+npm run typecheck
+git add src/auth/account-manager.ts tests/unit/account-manager.test.ts
+git commit -m "feat(auth): AccountManager.loadPersisted merges store (env wins on collision)"
+```
+
+---
+
+## Task 4: Load persisted accounts at server startup
+
+**Files:**
+- Modify: `src/mcp-server.ts`
+- Test: `tests/unit/mcp-server-startup.test.ts` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/mcp-server-startup.test.ts`:
+
+```ts
+/**
+ * Verifies the server loads persisted accounts before connecting a transport.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("server startup loads persisted accounts", () => {
+  const originalEnv = process.env;
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = { ...originalEnv };
+  });
+  afterEach(() => {
+    process.env = originalEnv;
+    vi.restoreAllMocks();
+  });
+
+  it("awaits accountManager.loadPersisted() during start()", async () => {
+    const { accountManager } = await import("../../src/auth/account-manager.js");
+    const spy = vi.spyOn(accountManager, "loadPersisted").mockResolvedValue(undefined);
+
+    const { default: ActivityPubMCPServer } = await import("../../src/mcp-server.js");
+    const server = new ActivityPubMCPServer();
+    // Stub the transport connect so start() doesn't open stdio.
+    // @ts-expect-error reaching into the private mcpServer for the test
+    server.mcpServer.connect = vi.fn().mockResolvedValue(undefined);
+
+    await server.start("stdio");
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test -- tests/unit/mcp-server-startup.test.ts`
+Expected: FAIL — `loadPersisted` is never called by `start()`.
+
+- [ ] **Step 3: Implement**
+
+In `src/mcp-server.ts`, add the import (near the other auth imports):
+
+```ts
+import { accountManager } from "./auth/account-manager.js";
+```
+
+(If `accountManager` is already imported, don't duplicate.) Then change the top of `start()` so persisted accounts load before either transport connects:
+
+```ts
+  async start(transportMode?: "stdio" | "http"): Promise<void> {
+    const mode = transportMode ?? CONFIG.transportMode;
+
+    // Load persisted (logged-in) accounts before serving. Never throws.
+    await accountManager.loadPersisted();
+
+    if (mode === "http") {
+      await this.startHttpTransport();
+    } else {
+      await this.startStdioTransport();
+    }
+  }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm run test -- tests/unit/mcp-server-startup.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Typecheck + commit**
+
+```bash
+npm run typecheck
+git add src/mcp-server.ts tests/unit/mcp-server-startup.test.ts
+git commit -m "feat(server): load persisted accounts before transport connect"
+```
+
+---
+
+## Task 5: `guardedFetch` helper + nodeinfo refactor
+
+**Files:**
+- Modify: `src/utils/fetch-helpers.ts`
+- Modify: `src/discovery/nodeinfo.ts`
+- Test: `tests/unit/guarded-fetch.test.ts` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/guarded-fetch.test.ts`:
+
+```ts
+import { HttpResponse, http } from "msw";
+import { setupServer } from "msw/node";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { guardedFetch } from "../../src/utils/fetch-helpers.js";
+
+vi.mock("../../src/validation/url.js", () => ({
+  validateExternalUrl: vi.fn().mockResolvedValue(undefined),
+}));
+
+const server = setupServer();
+beforeAll(() => server.listen({ onUnhandledRequest: "bypass" }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+describe("guardedFetch", () => {
+  it("performs a GET and parses JSON by default", async () => {
+    server.use(http.get("https://x.test/thing", () => HttpResponse.json({ a: 1 })));
+    const res = await guardedFetch<{ a: number }>("https://x.test/thing");
+    expect(res.ok).toBe(true);
+    expect(res.status).toBe(200);
+    expect(res.data).toEqual({ a: 1 });
+  });
+
+  it("sends a form-encoded POST body and reads JSON", async () => {
+    let contentType: string | null = null;
+    let body = "";
+    server.use(
+      http.post("https://x.test/token", async ({ request }) => {
+        contentType = request.headers.get("content-type");
+        body = await request.text();
+        return HttpResponse.json({ access_token: "t" });
+      }),
+    );
+    const res = await guardedFetch<{ access_token: string }>("https://x.test/token", {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({ grant_type: "authorization_code", code: "c" }).toString(),
+    });
+    expect(contentType).toContain("application/x-www-form-urlencoded");
+    expect(body).toContain("grant_type=authorization_code");
+    expect(res.data?.access_token).toBe("t");
+  });
+
+  it("returns ok:false with parsed error body on 4xx", async () => {
+    server.use(
+      http.post("https://x.test/fail", () =>
+        HttpResponse.json({ error: { message: "nope" } }, { status: 403 }),
+      ),
+    );
+    const res = await guardedFetch<{ error: { message: string } }>("https://x.test/fail", {
+      method: "POST",
+      body: "{}",
+      headers: { "Content-Type": "application/json" },
+    });
+    expect(res.ok).toBe(false);
+    expect(res.status).toBe(403);
+    expect(res.data?.error.message).toBe("nope");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test -- tests/unit/guarded-fetch.test.ts`
+Expected: FAIL — `guardedFetch` is not exported.
+
+- [ ] **Step 3: Implement `guardedFetch`**
+
+Put the three new `import` lines at the **top** of `src/utils/fetch-helpers.ts` (Biome's `organizeImports` requires imports first — appending them below the functions makes `npm run lint` report a diff), and add the rest of the code below the existing functions:
+
+```ts
+import { MAX_RESPONSE_SIZE, REQUEST_TIMEOUT, USER_AGENT } from "../config.js";
+import { instanceBlocklist } from "../policy/instance-blocklist.js";
+import { validateExternalUrl } from "../validation/url.js";
+
+export interface GuardedFetchOptions {
+  method?: string;
+  headers?: Record<string, string>;
+  body?: string;
+  timeoutMs?: number;
+}
+
+export interface GuardedResponse<T> {
+  ok: boolean;
+  status: number;
+  statusText: string;
+  /** Parsed JSON body, or undefined if the body was empty / not JSON. */
+  data: T | undefined;
+}
+
+/**
+ * Guarded UNauthenticated fetch: SSRF allow-list + operator blocklist on the
+ * initial URL and every redirect hop, abort/timeout, streaming size cap, and
+ * best-effort JSON parsing. Used by NodeInfo discovery and the login flows'
+ * pre-token calls (which have no Bearer token, so they can't use
+ * authenticatedFetch).
+ */
+export async function guardedFetch<T = unknown>(
+  url: string,
+  options: GuardedFetchOptions = {},
+): Promise<GuardedResponse<T>> {
+  await validateExternalUrl(url);
+  instanceBlocklist.validateNotBlocked(new URL(url).hostname);
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), options.timeoutMs ?? REQUEST_TIMEOUT);
+  try {
+    const response = await fetchWithRedirectGuard(
+      url,
+      {
+        method: options.method ?? "GET",
+        headers: {
+          Accept: "application/json",
+          "User-Agent": USER_AGENT,
+          ...options.headers,
+        },
+        body: options.body,
+        signal: controller.signal,
+      },
+      async (target) => {
+        await validateExternalUrl(target);
+        instanceBlocklist.validateNotBlocked(new URL(target).hostname);
+      },
+    );
+
+    let data: T | undefined;
+    if (response.status !== 204) {
+      try {
+        data = await readJsonWithLimit<T>(response, MAX_RESPONSE_SIZE);
+      } catch {
+        data = undefined; // empty / non-JSON body
+      }
+    }
+    return { ok: response.ok, status: response.status, statusText: response.statusText, data };
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+```
+
+- [ ] **Step 4: Refactor nodeinfo to use it**
+
+In `src/discovery/nodeinfo.ts`, replace the private `fetchJson` (lines ~216-241) with:
+
+```ts
+async function fetchJson(url: string): Promise<unknown> {
+  const res = await guardedFetch(url);
+  if (!res.ok) {
+    throw new Error(`HTTP ${res.status} ${res.statusText}`);
+  }
+  return res.data;
+}
+```
+
+Now fix `nodeinfo.ts`'s imports to the **exact** final set (the project has `noUnusedLocals: true` and Biome `noUnusedImports`, so any leftover import is a hard `tsc`/lint failure — `TS6133`). Replace the fetch-helpers import with just `guardedFetch`:
+
+```ts
+import { guardedFetch } from "../utils/fetch-helpers.js";
+```
+
+and trim the `../config.js` import down to only what the LRU caches still use — dropping the now-unused `MAX_RESPONSE_SIZE`, `REQUEST_TIMEOUT`, **and** `USER_AGENT`:
+
+```ts
+import { CACHE_MAX_SIZE, INSTANCE_SOFTWARE_TTL } from "../config.js";
+```
+
+Keep the `instanceBlocklist` and `validateExternalUrl` imports — `performDetection` still calls them directly on the discovery + linked URLs. The old `fetchJson` was the only user of `fetchWithRedirectGuard`/`readJsonWithLimit`/`USER_AGENT`/`MAX_RESPONSE_SIZE`/`REQUEST_TIMEOUT`, so all five are now gone. Verify with `npm run typecheck` (catches any missed unused import).
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `npm run test -- tests/unit/guarded-fetch.test.ts tests/unit/nodeinfo.test.ts`
+Expected: PASS — new helper specs AND all existing nodeinfo specs (behavior preserved).
+
+- [ ] **Step 6: Typecheck + lint + commit**
+
+```bash
+npm run typecheck && npm run lint
+git add src/utils/fetch-helpers.ts src/discovery/nodeinfo.ts tests/unit/guarded-fetch.test.ts
+git commit -m "feat(utils): guardedFetch (unauthenticated guarded fetch); nodeinfo uses it"
+```
+
+---
+
+## Task 6: Loopback callback server (ephemeral port, one-shot)
+
+**Files:**
+- Create: `src/auth/login/loopback-server.ts`
+- Test: `tests/unit/loopback-server.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/loopback-server.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { createLoopbackServer } from "../../src/auth/login/loopback-server.js";
+
+describe("createLoopbackServer", () => {
+  it("binds 127.0.0.1 with an ephemeral port and a /callback redirect URI", async () => {
+    const lb = await createLoopbackServer();
+    try {
+      expect(lb.redirectUri).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/callback$/);
+    } finally {
+      lb.close();
+    }
+  });
+
+  it("resolves with the query when state matches", async () => {
+    const lb = await createLoopbackServer();
+    const pending = lb.waitForCallback({ state: "abc" });
+    await fetch(`${lb.redirectUri}?code=xyz&state=abc`);
+    const params = await pending;
+    expect(params.get("code")).toBe("xyz");
+    lb.close();
+  });
+
+  it("does NOT resolve on a mismatched state (responds 404)", async () => {
+    const lb = await createLoopbackServer();
+    let resolved = false;
+    lb.waitForCallback({ state: "abc" }).then(() => {
+      resolved = true;
+    });
+    const res = await fetch(`${lb.redirectUri}?code=xyz&state=WRONG`);
+    expect(res.status).toBe(404);
+    await new Promise((r) => setTimeout(r, 20));
+    expect(resolved).toBe(false);
+    lb.close();
+  });
+
+  it("matches on session for the MiAuth flow", async () => {
+    const lb = await createLoopbackServer();
+    const pending = lb.waitForCallback({ session: "sess-1" });
+    await fetch(`${lb.redirectUri}?session=sess-1`);
+    const params = await pending;
+    expect(params.get("session")).toBe("sess-1");
+    lb.close();
+  });
+
+  it("rejects after the timeout", async () => {
+    const lb = await createLoopbackServer();
+    await expect(lb.waitForCallback({ state: "abc", timeoutMs: 30 })).rejects.toThrow(/timed out/i);
+    lb.close();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test -- tests/unit/loopback-server.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement**
+
+Create `src/auth/login/loopback-server.ts`:
+
+```ts
+/**
+ * One-shot OAuth loopback callback server (RFC 8252 §7.3).
+ *
+ * Binds to 127.0.0.1 on an OS-assigned EPHEMERAL port (never a fixed/predictable
+ * one, never 0.0.0.0) so a co-resident local process cannot pre-bind and steal
+ * the authorization code / MiAuth session. Resolves only when /callback carries
+ * the exact expected `state` (Mastodon) or `session` (Misskey), compared in
+ * constant time; everything else gets a static 404 and does not resolve.
+ */
+
+import { timingSafeEqual } from "node:crypto";
+import { createServer, type Server } from "node:http";
+
+const SUCCESS_PAGE =
+  "<!doctype html><meta charset=utf-8><title>activitypub-mcp</title>" +
+  "<body style=\"font-family:sans-serif;padding:2rem\">" +
+  "<h1>Authorized</h1><p>You can close this window and return to the terminal.</p>";
+
+function safeEqual(a: string, b: string): boolean {
+  const ab = Buffer.from(a);
+  const bb = Buffer.from(b);
+  if (ab.length !== bb.length) return false;
+  return timingSafeEqual(ab, bb);
+}
+
+export interface CallbackExpectation {
+  state?: string;
+  session?: string;
+  timeoutMs?: number;
+}
+
+export interface LoopbackServer {
+  /** http://127.0.0.1:<port>/callback */
+  redirectUri: string;
+  /** Resolves once with the callback query params, or rejects on timeout. */
+  waitForCallback(expected: CallbackExpectation): Promise<URLSearchParams>;
+  close(): void;
+}
+
+const DEFAULT_TIMEOUT_MS = 300_000; // 5 minutes
+
+export function createLoopbackServer(port = 0): Promise<LoopbackServer> {
+  return new Promise((resolveServer, rejectServer) => {
+    let resolveCb: ((params: URLSearchParams) => void) | null = null;
+    let expectation: CallbackExpectation | null = null;
+    let activeTimer: ReturnType<typeof setTimeout> | null = null;
+
+    const server: Server = createServer((req, res) => {
+      const url = new URL(req.url ?? "/", "http://127.0.0.1");
+      if (url.pathname !== "/callback" || !resolveCb || !expectation) {
+        res.writeHead(404).end();
+        return;
+      }
+      const params = url.searchParams;
+      const okState = expectation.state ? safeEqual(params.get("state") ?? "", expectation.state) : true;
+      const okSession = expectation.session
+        ? safeEqual(params.get("session") ?? "", expectation.session)
+        : true;
+      if (!okState || !okSession) {
+        res.writeHead(404).end();
+        return;
+      }
+      res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" }).end(SUCCESS_PAGE);
+      const done = resolveCb;
+      resolveCb = null;
+      done(params);
+    });
+
+    server.on("error", rejectServer);
+    server.listen(port, "127.0.0.1", () => {
+      const addr = server.address();
+      if (!addr || typeof addr === "string") {
+        server.close();
+        rejectServer(new Error("Failed to bind loopback server"));
+        return;
+      }
+      const redirectUri = `http://127.0.0.1:${addr.port}/callback`;
+
+      resolveServer({
+        redirectUri,
+        waitForCallback(expected) {
+          expectation = expected;
+          return new Promise<URLSearchParams>((resolve, reject) => {
+            const ms = expected.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+            const timer = setTimeout(() => {
+              resolveCb = null;
+              activeTimer = null;
+              reject(new Error(`Authorization timed out after ${ms}ms`));
+            }, ms);
+            timer.unref(); // never keep the process alive waiting on a callback
+            activeTimer = timer;
+            resolveCb = (params) => {
+              clearTimeout(timer);
+              activeTimer = null;
+              resolve(params);
+            };
+          });
+        },
+        close() {
+          if (activeTimer) {
+            clearTimeout(activeTimer);
+            activeTimer = null;
+          }
+          resolveCb = null;
+          server.close();
+        },
+      });
+    });
+  });
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm run test -- tests/unit/loopback-server.test.ts`
+Expected: PASS — 5 specs.
+
+- [ ] **Step 5: Typecheck + commit**
+
+```bash
+npm run typecheck
+git add src/auth/login/loopback-server.ts tests/unit/loopback-server.test.ts
+git commit -m "feat(login): ephemeral-port one-shot loopback callback server"
+```
+
+---
+
+## Task 7: Cross-platform browser opener
+
+**Files:**
+- Create: `src/auth/login/browser.ts`
+- Test: `tests/unit/browser.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/browser.test.ts`:
+
+```ts
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const spawnMock = vi.fn();
+vi.mock("node:child_process", () => ({
+  spawn: (...args: unknown[]) => {
+    spawnMock(...args);
+    return { on: vi.fn(), unref: vi.fn() };
+  },
+}));
+
+describe("openBrowser", () => {
+  afterEach(() => {
+    spawnMock.mockReset();
+    vi.unstubAllGlobals();
+  });
+
+  it("passes the URL as a discrete argv item (no shell string)", async () => {
+    vi.stubGlobal("process", { ...process, platform: "darwin" });
+    const { openBrowser } = await import(`../../src/auth/login/browser.js?ts=${Date.now()}`);
+    const url = "https://x.test/oauth/authorize?state=a&scope=read%20write&x=^%";
+    await openBrowser(url);
+    const [cmd, args] = spawnMock.mock.calls[0];
+    expect(cmd).toBe("open");
+    expect(args).toContain(url); // exact URL, never interpolated into a shell string
+  });
+
+  it("uses xdg-open on linux", async () => {
+    vi.stubGlobal("process", { ...process, platform: "linux" });
+    const { openBrowser } = await import(`../../src/auth/login/browser.js?ts=${Date.now()}`);
+    await openBrowser("https://x.test/");
+    expect(spawnMock.mock.calls[0][0]).toBe("xdg-open");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test -- tests/unit/browser.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement**
+
+Create `src/auth/login/browser.ts`:
+
+```ts
+/**
+ * Opens the system browser to a URL using an argv-array spawn (never a shell
+ * string), so query values containing &, %, ^ cannot be interpreted by a shell.
+ * On failure the caller falls back to printing the URL.
+ */
+
+import { spawn } from "node:child_process";
+
+export function openBrowser(url: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    let command: string;
+    let args: string[];
+    switch (process.platform) {
+      case "darwin":
+        command = "open";
+        args = [url];
+        break;
+      case "win32":
+        // `start` is a cmd builtin; "" is the (empty) window title, url is a discrete arg.
+        command = "cmd";
+        args = ["/c", "start", "", url];
+        break;
+      default:
+        command = "xdg-open";
+        args = [url];
+        break;
+    }
+    try {
+      const child = spawn(command, args, { stdio: "ignore", detached: true });
+      child.on("error", reject);
+      child.unref();
+      resolve();
+    } catch (error) {
+      reject(error instanceof Error ? error : new Error(String(error)));
+    }
+  });
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm run test -- tests/unit/browser.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Typecheck + commit**
+
+```bash
+npm run typecheck
+git add src/auth/login/browser.ts tests/unit/browser.test.ts
+git commit -m "feat(login): cross-platform browser opener (argv-array spawn)"
+```
+
+---
+
+## Task 8: `LoginStrategy` types + scope constants
+
+**Files:**
+- Create: `src/auth/login/login-strategy.ts`
+- Create: `src/auth/login/scopes.ts`
+
+- [ ] **Step 1: Create the scope constants**
+
+Create `src/auth/login/scopes.ts`:
+
+```ts
+/**
+ * Single source of truth for the OAuth scopes / MiAuth permissions requested
+ * during login. Referenced by both app registration and the authorize URL.
+ */
+
+/**
+ * Mastodon-family top-level scopes covering the SP1 write surface. Broad but
+ * maximally compatible; `follow` is deprecated since 3.5.0 (redundant with
+ * `write`) but kept for compatibility and to match the legacy default.
+ */
+export const MASTODON_SCOPES = "read write follow";
+
+/**
+ * Misskey/Foundkey permissions, trimmed to least-privilege for the SP1 write
+ * surface. `read:account` covers whoami + home timeline + relationship reads
+ * (Misskey has no separate read-timeline scope). Poll-voting and notification
+ * writes are intentionally omitted (SP1 makes those Mastodon-only / read-only).
+ */
+export const MISSKEY_PERMISSIONS = [
+  "read:account",
+  "read:following",
+  "write:notes",
+  "write:reactions",
+  "write:following",
+  "write:blocks",
+  "write:mutes",
+  "write:drive",
+  "read:notifications",
+] as const;
+```
+
+- [ ] **Step 2: Create the strategy interface**
+
+Create `src/auth/login/login-strategy.ts`:
+
+```ts
+/**
+ * Contracts for platform login strategies. The CLI orchestrator owns the shared
+ * mechanics (loopback server, browser opener, timeout) and injects them via
+ * AuthorizeContext; each strategy implements only its platform's protocol.
+ */
+
+import type { StoredAccount } from "../credential-store.js";
+
+export interface AuthorizeContext {
+  /** Validated bare domain (DomainSchema), lowercased. */
+  instance: string;
+  /** http://127.0.0.1:<ephemeral-port>/callback */
+  redirectUri: string;
+  /** Platform-appropriate scope/permission list (from scopes.ts). */
+  scopes: string[];
+  openBrowser: (url: string) => Promise<void>;
+  waitForCallback: (expected: { state?: string; session?: string }) => Promise<URLSearchParams>;
+}
+
+export interface LoginResult {
+  instance: string;
+  username: string;
+  accessToken: string;
+  tokenType: string;
+  scopes: string[];
+  clientId?: string;
+  clientSecret?: string;
+}
+
+export interface LoginStrategy {
+  readonly kind: "mastodon" | "misskey";
+  authorize(ctx: AuthorizeContext): Promise<LoginResult>;
+  /** Revoke the token server-side. Unimplemented on Misskey (no MiAuth revoke). */
+  revoke?(account: StoredAccount): Promise<void>;
+}
+```
+
+- [ ] **Step 3: Typecheck**
+
+Run: `npm run typecheck`
+Expected: PASS (types only; `StoredAccount` is a type-only import — no cycle).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/auth/login/login-strategy.ts src/auth/login/scopes.ts
+git commit -m "feat(login): LoginStrategy interface + scope/permission constants"
+```
+
+---
+
+## Task 9: `MastodonOAuthStrategy`
+
+**Files:**
+- Create: `src/auth/login/mastodon-oauth.ts`
+- Test: `tests/unit/mastodon-oauth.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/mastodon-oauth.test.ts`:
+
+```ts
+import { HttpResponse, http } from "msw";
+import { setupServer } from "msw/node";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { MastodonOAuthStrategy } from "../../src/auth/login/mastodon-oauth.js";
+
+vi.mock("../../src/validation/url.js", () => ({
+  validateExternalUrl: vi.fn().mockResolvedValue(undefined),
+}));
+
+const server = setupServer();
+beforeAll(() => server.listen({ onUnhandledRequest: "bypass" }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+const strategy = new MastodonOAuthStrategy();
+
+function ctx(overrides: Partial<Parameters<typeof strategy.authorize>[0]> = {}) {
+  return {
+    instance: "mastodon.test",
+    redirectUri: "http://127.0.0.1:7777/callback",
+    scopes: ["read", "write", "follow"],
+    openBrowser: vi.fn().mockResolvedValue(undefined),
+    // Default: hand back a code + the state the strategy generated.
+    waitForCallback: vi.fn(async (exp: { state?: string }) => {
+      const p = new URLSearchParams();
+      p.set("code", "auth-code");
+      if (exp.state) p.set("state", exp.state);
+      return p;
+    }),
+    ...overrides,
+  };
+}
+
+describe("MastodonOAuthStrategy.authorize", () => {
+  it("registers an app, opens authorize with PKCE, exchanges the code, and returns a LoginResult", async () => {
+    let appBody = "";
+    let tokenBody = "";
+    server.use(
+      http.post("https://mastodon.test/api/v1/apps", async ({ request }) => {
+        appBody = await request.text();
+        return HttpResponse.json({ client_id: "cid", client_secret: "csecret" });
+      }),
+      http.post("https://mastodon.test/oauth/token", async ({ request }) => {
+        tokenBody = await request.text();
+        return HttpResponse.json({ access_token: "tok", token_type: "Bearer", scope: "read write follow" });
+      }),
+      http.get("https://mastodon.test/api/v1/accounts/verify_credentials", () =>
+        HttpResponse.json({ id: "1", username: "alice", acct: "alice", url: "https://mastodon.test/@alice" }),
+      ),
+    );
+
+    const c = ctx();
+    const result = await strategy.authorize(c);
+
+    expect(appBody).toContain("client_name=activitypub-mcp");
+    expect(appBody).toContain(encodeURIComponent("http://127.0.0.1:7777/callback"));
+    // Authorize URL carries PKCE + state.
+    const openedUrl = (c.openBrowser as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    expect(openedUrl).toContain("code_challenge=");
+    expect(openedUrl).toContain("code_challenge_method=S256");
+    expect(openedUrl).toContain("state=");
+    // Token exchange includes the verifier + the code.
+    expect(tokenBody).toContain("grant_type=authorization_code");
+    expect(tokenBody).toContain("code=auth-code");
+    expect(tokenBody).toContain("code_verifier=");
+    expect(result).toMatchObject({
+      instance: "mastodon.test",
+      username: "alice",
+      accessToken: "tok",
+      tokenType: "Bearer",
+      scopes: ["read", "write", "follow"],
+      clientId: "cid",
+      clientSecret: "csecret",
+    });
+  });
+
+  it("rejects when the app registration fails with the platform error", async () => {
+    server.use(
+      http.post("https://mastodon.test/api/v1/apps", () =>
+        HttpResponse.json({ error: "bad client" }, { status: 422 }),
+      ),
+    );
+    await expect(strategy.authorize(ctx())).rejects.toThrow(/bad client|422/);
+  });
+});
+
+describe("MastodonOAuthStrategy.revoke", () => {
+  it("posts client creds + token to /oauth/revoke", async () => {
+    let body = "";
+    server.use(
+      http.post("https://mastodon.test/oauth/revoke", async ({ request }) => {
+        body = await request.text();
+        return HttpResponse.json({});
+      }),
+    );
+    await strategy.revoke({
+      id: "alice@mastodon.test",
+      instance: "mastodon.test",
+      username: "alice",
+      accessToken: "tok",
+      tokenType: "Bearer",
+      scopes: [],
+      clientId: "cid",
+      clientSecret: "csecret",
+      createdAt: "2026-01-01T00:00:00.000Z",
+    });
+    expect(body).toContain("token=tok");
+    expect(body).toContain("client_id=cid");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test -- tests/unit/mastodon-oauth.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement**
+
+Create `src/auth/login/mastodon-oauth.ts`:
+
+```ts
+/**
+ * Mastodon-family OAuth2 login (also Pleroma/Akkoma/GotoSocial/Sharkey/Firefish
+ * where they expose the Mastodon OAuth API). Loopback redirect + always-on PKCE
+ * S256. A fresh client app is registered per login because the ephemeral
+ * redirect port changes and Mastodon matches redirect_uri exactly.
+ */
+
+import { createHash, randomBytes } from "node:crypto";
+import { guardedFetch } from "../../utils/fetch-helpers.js";
+import type { StoredAccount } from "../credential-store.js";
+import type { AuthorizeContext, LoginResult, LoginStrategy } from "./login-strategy.js";
+
+const FORM = { "Content-Type": "application/x-www-form-urlencoded" };
+
+function base64url(buf: Buffer): string {
+  return buf.toString("base64url");
+}
+
+function platformError(data: unknown, status: number): string {
+  const d = data as { error_description?: string; error?: string } | undefined;
+  return d?.error_description || d?.error || `HTTP ${status}`;
+}
+
+export class MastodonOAuthStrategy implements LoginStrategy {
+  readonly kind = "mastodon" as const;
+
+  async authorize(ctx: AuthorizeContext): Promise<LoginResult> {
+    const base = `https://${ctx.instance}`;
+    const scope = ctx.scopes.join(" ");
+
+    // 1. Register a fresh client app for this exact redirect_uri.
+    const appRes = await guardedFetch<{ client_id: string; client_secret: string }>(
+      `${base}/api/v1/apps`,
+      {
+        method: "POST",
+        headers: FORM,
+        body: new URLSearchParams({
+          client_name: "activitypub-mcp",
+          redirect_uris: ctx.redirectUri,
+          scopes: scope,
+          website: "https://github.com/cameronrye/activitypub-mcp",
+        }).toString(),
+      },
+    );
+    if (!appRes.ok || !appRes.data) {
+      throw new Error(`Failed to register app: ${platformError(appRes.data, appRes.status)}`);
+    }
+    const { client_id, client_secret } = appRes.data;
+
+    // 2. PKCE + state.
+    const verifier = base64url(randomBytes(32));
+    const challenge = base64url(createHash("sha256").update(verifier).digest());
+    const state = base64url(randomBytes(32));
+
+    // 3. Authorize in the browser.
+    const authorizeUrl =
+      `${base}/oauth/authorize?` +
+      new URLSearchParams({
+        response_type: "code",
+        client_id,
+        redirect_uri: ctx.redirectUri,
+        scope,
+        state,
+        code_challenge: challenge,
+        code_challenge_method: "S256",
+      }).toString();
+    await ctx.openBrowser(authorizeUrl);
+
+    // 4. Capture the code (loopback verifies state).
+    const params = await ctx.waitForCallback({ state });
+    // Mix-up defense (RFC 9700 §4.4): if the AS returned an `iss`, it must be our instance.
+    const iss = params.get("iss");
+    if (iss && new URL(iss).host !== ctx.instance) {
+      throw new Error("Authorization issuer mismatch (possible mix-up attack)");
+    }
+    const code = params.get("code");
+    if (!code) throw new Error("Authorization callback returned no code");
+
+    // 5. Exchange the code for a token (always send code_verifier).
+    const tokenRes = await guardedFetch<{ access_token: string; token_type: string; scope?: string }>(
+      `${base}/oauth/token`,
+      {
+        method: "POST",
+        headers: FORM,
+        body: new URLSearchParams({
+          grant_type: "authorization_code",
+          code,
+          client_id,
+          client_secret,
+          redirect_uri: ctx.redirectUri,
+          code_verifier: verifier,
+          scope,
+        }).toString(),
+      },
+    );
+    if (!tokenRes.ok || !tokenRes.data?.access_token) {
+      throw new Error(`Token exchange failed: ${platformError(tokenRes.data, tokenRes.status)}`);
+    }
+    const granted = tokenRes.data.scope ? tokenRes.data.scope.split(" ") : ctx.scopes;
+
+    // 6. Whoami.
+    const whoami = await guardedFetch<{ username: string }>(
+      `${base}/api/v1/accounts/verify_credentials`,
+      { headers: { Authorization: `Bearer ${tokenRes.data.access_token}` } },
+    );
+    if (!whoami.ok || !whoami.data?.username) {
+      throw new Error(`Could not read account: ${platformError(whoami.data, whoami.status)}`);
+    }
+
+    return {
+      instance: ctx.instance,
+      username: whoami.data.username,
+      accessToken: tokenRes.data.access_token,
+      tokenType: tokenRes.data.token_type || "Bearer",
+      scopes: granted,
+      clientId: client_id,
+      clientSecret: client_secret,
+    };
+  }
+
+  async revoke(account: StoredAccount): Promise<void> {
+    if (!account.clientId || !account.clientSecret) return;
+    await guardedFetch(`https://${account.instance}/oauth/revoke`, {
+      method: "POST",
+      headers: FORM,
+      body: new URLSearchParams({
+        client_id: account.clientId,
+        client_secret: account.clientSecret,
+        token: account.accessToken,
+      }).toString(),
+    });
+  }
+}
+
+export const mastodonOAuthStrategy = new MastodonOAuthStrategy();
+```
+
+> Whoami uses `guardedFetch` with an explicit `Authorization` header here (rather
+> than SP1 `authenticatedFetch`) so the strategy stays self-contained and testable;
+> it is still SSRF/blocklist-guarded.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm run test -- tests/unit/mastodon-oauth.test.ts`
+Expected: PASS — authorize + error + revoke specs.
+
+- [ ] **Step 5: Typecheck + commit**
+
+```bash
+npm run typecheck
+git add src/auth/login/mastodon-oauth.ts tests/unit/mastodon-oauth.test.ts
+git commit -m "feat(login): Mastodon OAuth2 strategy (PKCE, loopback, revoke)"
+```
+
+---
+
+## Task 10: `MisskeyMiAuthStrategy`
+
+**Files:**
+- Create: `src/auth/login/miauth.ts`
+- Test: `tests/unit/miauth.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/miauth.test.ts`:
+
+```ts
+import { HttpResponse, http } from "msw";
+import { setupServer } from "msw/node";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { MisskeyMiAuthStrategy } from "../../src/auth/login/miauth.js";
+
+vi.mock("../../src/validation/url.js", () => ({
+  validateExternalUrl: vi.fn().mockResolvedValue(undefined),
+}));
+
+const server = setupServer();
+beforeAll(() => server.listen({ onUnhandledRequest: "bypass" }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+const strategy = new MisskeyMiAuthStrategy();
+
+describe("MisskeyMiAuthStrategy.authorize", () => {
+  it("opens the miauth consent URL and exchanges the session for a token", async () => {
+    server.use(
+      http.post("https://misskey.test/api/miauth/:uuid/check", () =>
+        HttpResponse.json({ ok: true, token: "mk-token", user: { username: "bob" } }),
+      ),
+    );
+
+    const openBrowser = vi.fn().mockResolvedValue(undefined);
+    const result = await strategy.authorize({
+      instance: "misskey.test",
+      redirectUri: "http://127.0.0.1:7777/callback",
+      scopes: ["write:notes", "read:account"],
+      openBrowser,
+      // Echo back the session the strategy generated.
+      waitForCallback: vi.fn(async (exp: { session?: string }) => {
+        const p = new URLSearchParams();
+        if (exp.session) p.set("session", exp.session);
+        return p;
+      }),
+    });
+
+    const openedUrl = openBrowser.mock.calls[0][0] as string;
+    expect(openedUrl).toMatch(/^https:\/\/misskey\.test\/miauth\/[0-9a-f-]+\?/);
+    expect(openedUrl).toContain("name=activitypub-mcp");
+    expect(openedUrl).toContain(encodeURIComponent("write:notes,read:account"));
+    expect(result).toMatchObject({
+      instance: "misskey.test",
+      username: "bob",
+      accessToken: "mk-token",
+      tokenType: "Bearer",
+      scopes: ["write:notes", "read:account"],
+    });
+    expect(result.clientId).toBeUndefined();
+  });
+
+  it("rejects when check returns ok:false", async () => {
+    server.use(
+      http.post("https://misskey.test/api/miauth/:uuid/check", () => HttpResponse.json({ ok: false })),
+    );
+    await expect(
+      strategy.authorize({
+        instance: "misskey.test",
+        redirectUri: "http://127.0.0.1:7777/callback",
+        scopes: ["write:notes"],
+        openBrowser: vi.fn().mockResolvedValue(undefined),
+        waitForCallback: vi.fn(async (exp: { session?: string }) => {
+          const p = new URLSearchParams();
+          if (exp.session) p.set("session", exp.session);
+          return p;
+        }),
+      }),
+    ).rejects.toThrow(/authorization (was )?(not approved|failed|denied)|ok:false|not approved/i);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test -- tests/unit/miauth.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement**
+
+Create `src/auth/login/miauth.ts`:
+
+```ts
+/**
+ * Misskey / Foundkey MiAuth login. The user approves a session UUID in the
+ * browser; the callback returns ?session=<uuid>, then POST /api/miauth/<uuid>/check
+ * yields the access token + user inline (no app registration, no client secret,
+ * no separate whoami). The session UUID is a secret (its bearer can call /check).
+ *
+ * Note: Foundkey is deprecating MiAuth in favor of OAuth2 — on a build where
+ * /miauth is unavailable this surfaces a clear error.
+ */
+
+import { randomUUID } from "node:crypto";
+import { guardedFetch } from "../../utils/fetch-helpers.js";
+import type { AuthorizeContext, LoginResult, LoginStrategy } from "./login-strategy.js";
+
+interface MiAuthCheck {
+  ok: boolean;
+  token?: string;
+  user?: { username?: string };
+}
+
+export class MisskeyMiAuthStrategy implements LoginStrategy {
+  readonly kind = "misskey" as const;
+
+  async authorize(ctx: AuthorizeContext): Promise<LoginResult> {
+    const session = randomUUID();
+    const base = `https://${ctx.instance}`;
+
+    const consentUrl =
+      `${base}/miauth/${session}?` +
+      new URLSearchParams({
+        name: "activitypub-mcp",
+        callback: ctx.redirectUri,
+        permission: ctx.scopes.join(","),
+      }).toString();
+    await ctx.openBrowser(consentUrl);
+
+    // Loopback verifies the returned session matches.
+    await ctx.waitForCallback({ session });
+
+    const res = await guardedFetch<MiAuthCheck>(`${base}/api/miauth/${session}/check`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{}",
+    });
+    if (!res.ok || !res.data?.ok || !res.data.token) {
+      throw new Error("MiAuth authorization was not approved");
+    }
+    const username = res.data.user?.username;
+    if (!username) throw new Error("MiAuth check returned no user identity");
+
+    return {
+      instance: ctx.instance,
+      username, // bare local handle from /check; never falls back to the domain
+      accessToken: res.data.token,
+      tokenType: "Bearer",
+      scopes: ctx.scopes, // /check does not report the granted subset
+    };
+  }
+}
+
+export const misskeyMiAuthStrategy = new MisskeyMiAuthStrategy();
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm run test -- tests/unit/miauth.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Typecheck + commit**
+
+```bash
+npm run typecheck
+git add src/auth/login/miauth.ts tests/unit/miauth.test.ts
+git commit -m "feat(login): Misskey MiAuth strategy"
+```
+
+---
+
+## Task 11: `resolveLoginStrategy`
+
+**Files:**
+- Create: `src/auth/login/resolve.ts`
+- Test: `tests/unit/login-resolve.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/login-resolve.test.ts`:
+
+```ts
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../src/discovery/nodeinfo.js", () => ({
+  getInstanceSoftware: vi.fn(),
+}));
+
+import { mastodonOAuthStrategy } from "../../src/auth/login/mastodon-oauth.js";
+import { misskeyMiAuthStrategy } from "../../src/auth/login/miauth.js";
+import { resolveLoginStrategy } from "../../src/auth/login/resolve.js";
+import { getInstanceSoftware } from "../../src/discovery/nodeinfo.js";
+
+function detected(name: string | null) {
+  return {
+    domain: "x.test",
+    detection: name ? "success" : "unavailable",
+    software: name ? { name, version: "1" } : null,
+    protocols: name ? ["activitypub"] : null,
+    openRegistrations: null,
+  };
+}
+
+afterEach(() => vi.clearAllMocks());
+
+describe("resolveLoginStrategy", () => {
+  it.each([
+    ["misskey", misskeyMiAuthStrategy],
+    ["Misskey", misskeyMiAuthStrategy],
+    ["foundkey", misskeyMiAuthStrategy],
+    ["mastodon", mastodonOAuthStrategy],
+    ["pleroma", mastodonOAuthStrategy],
+    ["sharkey", mastodonOAuthStrategy],
+    ["firefish", mastodonOAuthStrategy],
+    ["gotosocial", mastodonOAuthStrategy],
+    ["totally-unknown", mastodonOAuthStrategy],
+  ])("maps %s to the right strategy", async (name, expected) => {
+    vi.mocked(getInstanceSoftware).mockResolvedValue(detected(name) as never);
+    expect(await resolveLoginStrategy("x.test")).toBe(expected);
+  });
+
+  it("defaults to Mastodon when detection is unavailable", async () => {
+    vi.mocked(getInstanceSoftware).mockResolvedValue(detected(null) as never);
+    expect(await resolveLoginStrategy("x.test")).toBe(mastodonOAuthStrategy);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test -- tests/unit/login-resolve.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement**
+
+Create `src/auth/login/resolve.ts`:
+
+```ts
+/**
+ * Picks the login strategy for an instance from detected software, mirroring
+ * adapters/resolve.ts: only Misskey-family software uses MiAuth; everything else
+ * (including detection failure / unknown) defaults to Mastodon OAuth2.
+ */
+
+import { getInstanceSoftware } from "../../discovery/nodeinfo.js";
+import type { LoginStrategy } from "./login-strategy.js";
+import { mastodonOAuthStrategy } from "./mastodon-oauth.js";
+import { misskeyMiAuthStrategy } from "./miauth.js";
+
+const MISSKEY_FAMILY = new Set(["misskey", "foundkey"]);
+
+export async function resolveLoginStrategy(instance: string): Promise<LoginStrategy> {
+  const info = await getInstanceSoftware(instance);
+  const name = info.software?.name?.toLowerCase();
+  return name && MISSKEY_FAMILY.has(name) ? misskeyMiAuthStrategy : mastodonOAuthStrategy;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm run test -- tests/unit/login-resolve.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Typecheck + commit**
+
+```bash
+npm run typecheck
+git add src/auth/login/resolve.ts tests/unit/login-resolve.test.ts
+git commit -m "feat(login): resolveLoginStrategy by detected software"
+```
+
+---
+
+## Task 12: `runLogin` CLI orchestration
+
+**Files:**
+- Create: `src/cli/login.ts`
+- Test: `tests/unit/cli-login.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/cli-login.test.ts`:
+
+```ts
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../src/auth/login/resolve.js", () => ({
+  resolveLoginStrategy: vi.fn(),
+}));
+vi.mock("../../src/auth/login/loopback-server.js", () => ({
+  createLoopbackServer: vi.fn(),
+}));
+vi.mock("../../src/auth/login/browser.js", () => ({
+  openBrowser: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { resolveLoginStrategy } from "../../src/auth/login/resolve.js";
+import { createLoopbackServer } from "../../src/auth/login/loopback-server.js";
+
+describe("runLogin", () => {
+  const originalEnv = process.env;
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = { ...originalEnv };
+    const dir = mkdtempSync(join(tmpdir(), "apmcp-cli-"));
+    process.env.ACTIVITYPUB_CONFIG_DIR = join(dir, "cfg");
+  });
+  afterEach(() => {
+    process.env = originalEnv;
+    vi.clearAllMocks();
+  });
+
+  it("runs the strategy and persists the resulting account", async () => {
+    vi.mocked(createLoopbackServer).mockResolvedValue({
+      redirectUri: "http://127.0.0.1:7777/callback",
+      waitForCallback: vi.fn(),
+      close: vi.fn(),
+    });
+    const authorize = vi.fn().mockResolvedValue({
+      instance: "mastodon.test",
+      username: "alice",
+      accessToken: "tok",
+      tokenType: "Bearer",
+      scopes: ["read", "write", "follow"],
+      clientId: "cid",
+      clientSecret: "csecret",
+    });
+    vi.mocked(resolveLoginStrategy).mockResolvedValue({ kind: "mastodon", authorize } as never);
+
+    const { runLogin } = await import("../../src/cli/login.js");
+    await runLogin(["mastodon.test"]);
+
+    const { credentialStore } = await import("../../src/auth/credential-store.js");
+    const stored = await credentialStore.getAccount("alice@mastodon.test");
+    expect(stored?.accessToken).toBe("tok");
+    expect(stored?.instance).toBe("mastodon.test");
+  });
+
+  it("rejects an invalid instance domain before opening a browser", async () => {
+    const { runLogin } = await import("../../src/cli/login.js");
+    await expect(runLogin(["not a domain"])).rejects.toThrow();
+    expect(resolveLoginStrategy).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test -- tests/unit/cli-login.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement**
+
+Create `src/cli/login.ts`:
+
+```ts
+/**
+ * `activitypub-mcp login <instance> [--port N] [--id ID] [--label L]`
+ *
+ * Validates the instance, resolves the platform login strategy, runs the
+ * interactive flow against an ephemeral loopback callback, and persists the
+ * resulting token. Never logs secrets.
+ */
+
+import { credentialStore, type StoredAccount } from "../auth/credential-store.js";
+import { openBrowser } from "../auth/login/browser.js";
+import { createLoopbackServer } from "../auth/login/loopback-server.js";
+import { resolveLoginStrategy } from "../auth/login/resolve.js";
+import { MASTODON_SCOPES, MISSKEY_PERMISSIONS } from "../auth/login/scopes.js";
+import { instanceBlocklist } from "../policy/instance-blocklist.js";
+import { DomainSchema } from "../validation/schemas.js";
+
+interface LoginFlags {
+  port?: number;
+  id?: string;
+  label?: string;
+}
+
+function parseFlags(rest: string[]): LoginFlags {
+  const flags: LoginFlags = {};
+  for (let i = 0; i < rest.length; i++) {
+    const arg = rest[i];
+    if (arg === "--port") flags.port = Number.parseInt(rest[++i] ?? "", 10);
+    else if (arg === "--id") flags.id = rest[++i];
+    else if (arg === "--label") flags.label = rest[++i];
+  }
+  return flags;
+}
+
+export async function runLogin(argv: string[]): Promise<void> {
+  const [rawInstance, ...rest] = argv;
+  if (!rawInstance) throw new Error("Usage: activitypub-mcp login <instance> [--port N] [--id ID] [--label L]");
+
+  const instance = DomainSchema.parse(rawInstance).toLowerCase();
+  instanceBlocklist.validateNotBlocked(instance);
+  const flags = parseFlags(rest);
+
+  const strategy = await resolveLoginStrategy(instance);
+  const scopes = strategy.kind === "misskey" ? [...MISSKEY_PERMISSIONS] : MASTODON_SCOPES.split(" ");
+
+  const loopback = await createLoopbackServer(flags.port ?? 0);
+  try {
+    const result = await strategy.authorize({
+      instance,
+      redirectUri: loopback.redirectUri,
+      scopes,
+      openBrowser: async (url) => {
+        try {
+          await openBrowser(url);
+          process.stdout.write("→ Opening your browser to authorize…\n");
+        } catch {
+          process.stdout.write(`→ Open this URL to authorize:\n  ${url}\n`);
+        }
+      },
+      waitForCallback: (expected) => loopback.waitForCallback(expected),
+    });
+
+    const account: StoredAccount = {
+      id: flags.id ?? `${result.username.toLowerCase()}@${instance}`,
+      instance: result.instance,
+      username: result.username,
+      accessToken: result.accessToken,
+      tokenType: result.tokenType,
+      scopes: result.scopes,
+      clientId: result.clientId,
+      clientSecret: result.clientSecret,
+      label: flags.label,
+      createdAt: new Date().toISOString(),
+    };
+    await credentialStore.upsert(account);
+    process.stdout.write(`✓ Authorized as @${account.username}@${account.instance} (id: ${account.id})\n`);
+  } finally {
+    loopback.close();
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm run test -- tests/unit/cli-login.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Add the secret-hygiene acceptance test (spec requirement)**
+
+Create `tests/unit/secret-hygiene.test.ts` — a full MSW-backed login asserting no token/client-secret/verifier reaches stdout or stderr:
+
+```ts
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { HttpResponse, http } from "msw";
+import { setupServer } from "msw/node";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../src/validation/url.js", () => ({
+  validateExternalUrl: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("../../src/discovery/nodeinfo.js", () => ({
+  getInstanceSoftware: vi.fn().mockResolvedValue({
+    domain: "mastodon.test",
+    detection: "success",
+    software: { name: "mastodon", version: "4.3.0" },
+    protocols: ["activitypub"],
+    openRegistrations: true,
+  }),
+}));
+vi.mock("../../src/auth/login/loopback-server.js", () => ({
+  createLoopbackServer: vi.fn().mockResolvedValue({
+    redirectUri: "http://127.0.0.1:7777/callback",
+    waitForCallback: vi.fn(async (exp: { state?: string }) => {
+      const p = new URLSearchParams();
+      p.set("code", "auth-code");
+      if (exp.state) p.set("state", exp.state);
+      return p;
+    }),
+    close: vi.fn(),
+  }),
+}));
+vi.mock("../../src/auth/login/browser.js", () => ({
+  openBrowser: vi.fn().mockResolvedValue(undefined),
+}));
+
+const SECRET_TOKEN = "SECRET-ACCESS-TOKEN-zzz";
+const SECRET_CLIENT = "SECRET-CLIENT-SECRET-zzz";
+
+const server = setupServer(
+  http.post("https://mastodon.test/api/v1/apps", () =>
+    HttpResponse.json({ client_id: "cid", client_secret: SECRET_CLIENT }),
+  ),
+  http.post("https://mastodon.test/oauth/token", () =>
+    HttpResponse.json({ access_token: SECRET_TOKEN, token_type: "Bearer", scope: "read write follow" }),
+  ),
+  http.get("https://mastodon.test/api/v1/accounts/verify_credentials", () =>
+    HttpResponse.json({ id: "1", username: "alice", acct: "alice", url: "https://mastodon.test/@alice" }),
+  ),
+);
+beforeAll(() => server.listen({ onUnhandledRequest: "bypass" }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+describe("secret hygiene: a full login leaks no secrets to stdout/stderr", () => {
+  const originalEnv = process.env;
+  let captured: string;
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = { ...originalEnv };
+    process.env.ACTIVITYPUB_CONFIG_DIR = join(mkdtempSync(join(tmpdir(), "apmcp-hy-")), "cfg");
+    captured = "";
+    const sink = ((chunk: string | Uint8Array) => {
+      captured += chunk.toString();
+      return true;
+    }) as typeof process.stdout.write;
+    vi.spyOn(process.stdout, "write").mockImplementation(sink);
+    vi.spyOn(process.stderr, "write").mockImplementation(sink);
+  });
+  afterEach(() => {
+    process.env = originalEnv;
+    vi.restoreAllMocks();
+  });
+
+  it("prints the success line but no token / client secret / verifier", async () => {
+    const { runLogin } = await import("../../src/cli/login.js");
+    await runLogin(["mastodon.test"]);
+
+    expect(captured).toContain("Authorized as @alice@mastodon.test");
+    expect(captured).not.toContain(SECRET_TOKEN);
+    expect(captured).not.toContain(SECRET_CLIENT);
+    expect(captured).not.toContain("code_verifier");
+  });
+});
+```
+
+> This is the spec's acceptance criterion. Logger calls in `login/*`,
+> `credential-store`, and `account-manager` pass only `instance`/`username`/`id` —
+> never a token — so the LogTape sink (whatever stream it writes to) is also clean.
+
+- [ ] **Step 6: Typecheck + commit**
+
+```bash
+npm run typecheck
+git add src/cli/login.ts tests/unit/cli-login.test.ts tests/unit/secret-hygiene.test.ts
+git commit -m "feat(cli): runLogin orchestration + secret-hygiene test"
+```
+
+---
+
+## Task 13: `runLogout` + `runAccounts`
+
+**Files:**
+- Create: `src/cli/logout.ts`, `src/cli/accounts.ts`
+- Test: `tests/unit/cli-accounts.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/cli-accounts.test.ts`:
+
+```ts
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("runLogout / runAccounts", () => {
+  const originalEnv = process.env;
+  let out: string;
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = { ...originalEnv };
+    const dir = mkdtempSync(join(tmpdir(), "apmcp-acc-"));
+    process.env.ACTIVITYPUB_CONFIG_DIR = join(dir, "cfg");
+    delete process.env.ACTIVITYPUB_DEFAULT_INSTANCE;
+    delete process.env.ACTIVITYPUB_DEFAULT_TOKEN;
+    delete process.env.ACTIVITYPUB_ACCOUNTS;
+    out = "";
+    vi.spyOn(process.stdout, "write").mockImplementation((chunk: string | Uint8Array) => {
+      out += chunk.toString();
+      return true;
+    });
+  });
+  afterEach(() => {
+    process.env = originalEnv;
+    vi.restoreAllMocks();
+  });
+
+  const mastodonAccount = {
+    id: "alice@mastodon.test",
+    instance: "mastodon.test",
+    username: "alice",
+    accessToken: "tok",
+    tokenType: "Bearer",
+    scopes: ["read", "write"],
+    clientId: "cid",
+    clientSecret: "csecret",
+    createdAt: "2026-01-01T00:00:00.000Z",
+  };
+
+  it("logout revokes (Mastodon) and removes the account", async () => {
+    const { credentialStore } = await import("../../src/auth/credential-store.js");
+    await credentialStore.upsert(mastodonAccount);
+
+    const revoke = vi.fn().mockResolvedValue(undefined);
+    vi.doMock("../../src/auth/login/resolve.js", () => ({
+      resolveLoginStrategy: vi.fn().mockResolvedValue({ kind: "mastodon", revoke }),
+    }));
+    const { runLogout } = await import("../../src/cli/logout.js");
+    await runLogout(["alice@mastodon.test"]);
+
+    expect(revoke).toHaveBeenCalledTimes(1);
+    expect(await credentialStore.getAccount("alice@mastodon.test")).toBeUndefined();
+  });
+
+  it("logout errors clearly for an unknown id", async () => {
+    const { runLogout } = await import("../../src/cli/logout.js");
+    await expect(runLogout(["nope"])).rejects.toThrow(/not found|no persisted/i);
+  });
+
+  it("accounts lists persisted accounts (tagged) without secrets", async () => {
+    const { credentialStore } = await import("../../src/auth/credential-store.js");
+    await credentialStore.upsert(mastodonAccount);
+    const { runAccounts } = await import("../../src/cli/accounts.js");
+    await runAccounts();
+    expect(out).toContain("alice@mastodon.test");
+    expect(out).toContain("(persisted)");
+    expect(out).not.toContain("tok");
+    expect(out).not.toContain("csecret");
+  });
+
+  it("accounts merges env accounts, tagged (env)", async () => {
+    process.env.ACTIVITYPUB_DEFAULT_INSTANCE = "env.test";
+    process.env.ACTIVITYPUB_DEFAULT_TOKEN = "env-token";
+    const { runAccounts } = await import("../../src/cli/accounts.js");
+    await runAccounts();
+    expect(out).toContain("env.test");
+    expect(out).toContain("(env)");
+    expect(out).not.toContain("env-token");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test -- tests/unit/cli-accounts.test.ts`
+Expected: FAIL — modules not found.
+
+- [ ] **Step 3: Implement `logout`**
+
+Create `src/cli/logout.ts`:
+
+```ts
+/**
+ * `activitypub-mcp logout <id>` — revoke (Mastodon) + remove from the store.
+ */
+
+import { credentialStore } from "../auth/credential-store.js";
+import { resolveLoginStrategy } from "../auth/login/resolve.js";
+
+export async function runLogout(argv: string[]): Promise<void> {
+  const id = argv[0];
+  if (!id) throw new Error("Usage: activitypub-mcp logout <id>");
+
+  const account = await credentialStore.getAccount(id);
+  if (!account) {
+    throw new Error(`No persisted account found with id "${id}". Run \`activitypub-mcp accounts\` to list.`);
+  }
+
+  const strategy = await resolveLoginStrategy(account.instance);
+  if (strategy.revoke && account.clientId && account.clientSecret) {
+    try {
+      await strategy.revoke(account);
+    } catch {
+      process.stdout.write("⚠ Server-side token revoke failed; removing the local record anyway.\n");
+    }
+  } else if (strategy.kind === "misskey") {
+    process.stdout.write(
+      "ℹ Misskey has no app-revoke endpoint; removing the local record. " +
+        "To fully revoke, delete the app token in your instance's Settings → API.\n",
+    );
+  }
+
+  await credentialStore.remove(id);
+  process.stdout.write(`✓ Logged out @${account.username}@${account.instance} (id: ${id})\n`);
+}
+```
+
+- [ ] **Step 4: Implement `accounts`**
+
+Create `src/cli/accounts.ts`:
+
+```ts
+/**
+ * `activitypub-mcp accounts` — list ALL configured accounts (env + persisted),
+ * matching the in-conversation `list-accounts` tool so the two surfaces agree.
+ * Each row is tagged with its source; no secrets are printed.
+ */
+
+import { accountManager } from "../auth/account-manager.js";
+import { credentialStore } from "../auth/credential-store.js";
+
+export async function runAccounts(): Promise<void> {
+  await accountManager.loadPersisted();
+  const persistedIds = new Set((await credentialStore.loadAccounts()).map((a) => a.id));
+  const accounts = accountManager.listAccounts();
+  if (accounts.length === 0) {
+    process.stdout.write("No accounts. Run `activitypub-mcp login <instance>` to sign in.\n");
+    return;
+  }
+  process.stdout.write(`Accounts (${accounts.length}):\n`);
+  for (const a of accounts) {
+    const source = persistedIds.has(a.id) ? "persisted" : "env";
+    const label = a.label ? ` "${a.label}"` : "";
+    const active = a.isActive ? " (active)" : "";
+    process.stdout.write(
+      `  • ${a.id}${label} — @${a.username}@${a.instance} [${a.scopes.join(", ")}] (${source})${active}\n`,
+    );
+  }
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `npm run test -- tests/unit/cli-accounts.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Typecheck + commit**
+
+```bash
+npm run typecheck
+git add src/cli/logout.ts src/cli/accounts.ts tests/unit/cli-accounts.test.ts
+git commit -m "feat(cli): logout (revoke + remove) and accounts list"
+```
+
+---
+
+## Task 14: CLI dispatch + entry-point wiring
+
+**Files:**
+- Create: `src/cli/index.ts`
+- Modify: `src/mcp-main.ts`
+- Test: `tests/unit/cli-dispatch.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/cli-dispatch.test.ts`:
+
+```ts
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../src/cli/login.js", () => ({ runLogin: vi.fn().mockResolvedValue(undefined) }));
+vi.mock("../../src/cli/logout.js", () => ({ runLogout: vi.fn().mockResolvedValue(undefined) }));
+vi.mock("../../src/cli/accounts.js", () => ({ runAccounts: vi.fn().mockResolvedValue(undefined) }));
+
+import { runAccounts } from "../../src/cli/accounts.js";
+import { dispatchCli } from "../../src/cli/index.js";
+import { runLogin } from "../../src/cli/login.js";
+
+afterEach(() => vi.clearAllMocks());
+
+describe("dispatchCli", () => {
+  it("routes login and reports handled=true", async () => {
+    expect(await dispatchCli(["login", "mastodon.test"])).toBe(true);
+    expect(runLogin).toHaveBeenCalledWith(["mastodon.test"]);
+  });
+
+  it("routes accounts", async () => {
+    expect(await dispatchCli(["accounts"])).toBe(true);
+    expect(runAccounts).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns false for no subcommand (server should start)", async () => {
+    expect(await dispatchCli([])).toBe(false);
+    expect(await dispatchCli(["--version"])).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test -- tests/unit/cli-dispatch.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the dispatcher**
+
+Create `src/cli/index.ts`:
+
+```ts
+/**
+ * Subcommand router for the activitypub-mcp bin. Returns true if a subcommand
+ * was handled (caller must then exit/return instead of starting the server),
+ * false if there was no subcommand (start the MCP server as usual).
+ */
+
+import { runAccounts } from "./accounts.js";
+import { runLogin } from "./login.js";
+import { runLogout } from "./logout.js";
+
+const COMMANDS = new Set(["login", "logout", "accounts"]);
+
+export async function dispatchCli(argv: string[]): Promise<boolean> {
+  const [command, ...rest] = argv;
+  if (!command || !COMMANDS.has(command)) return false;
+
+  switch (command) {
+    case "login":
+      await runLogin(rest);
+      return true;
+    case "logout":
+      await runLogout(rest);
+      return true;
+    case "accounts":
+      await runAccounts();
+      return true;
+    default:
+      return false;
+  }
+}
+```
+
+- [ ] **Step 4: Wire it into the entry point**
+
+In `src/mcp-main.ts`, add the import and dispatch at the very top of `main()`, before `validateConfiguration()`:
+
+```ts
+import { dispatchCli } from "./cli/index.js";
+```
+
+```ts
+async function main() {
+  // Subcommands (login/logout/accounts) run instead of the server.
+  try {
+    if (await dispatchCli(process.argv.slice(2))) {
+      return;
+    }
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+
+  // Parse remaining CLI flags (-h/-v) for the server path.
+  parseArgs();
+
+  try {
+    validateConfiguration();
+    const server = new ActivityPubMCPServer();
+    await server.start();
+  } catch (error) {
+    logger.error("Failed to start ActivityPub MCP Server", { error });
+    process.exit(1);
+  }
+}
+```
+
+(Leave `parseArgs()`/`printHelp()`/`printVersion()` as-is; `dispatchCli` returns false for flags/no-args so the server path is preserved.)
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `npm run test -- tests/unit/cli-dispatch.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Typecheck + lint + commit**
+
+```bash
+npm run typecheck && npm run lint
+git add src/cli/index.ts src/mcp-main.ts tests/unit/cli-dispatch.test.ts
+git commit -m "feat(cli): subcommand dispatch wired into the bin entry point"
+```
+
+---
+
+## Task 15: `TokenRejectedError` + re-auth seam + guard hints
+
+**Files:**
+- Modify: `src/utils/errors.ts`
+- Modify: `src/auth/adapters/write-adapter.ts`
+- Modify: `src/mcp/tools-write.ts`
+- Test: `tests/unit/utils.test.ts` (append), `tests/unit/authenticated-client.test.ts` (append)
+
+- [ ] **Step 1: Write the failing test for the error class**
+
+Append to `tests/unit/utils.test.ts`:
+
+```ts
+import { TokenRejectedError } from "../../src/utils/errors.js";
+
+describe("TokenRejectedError", () => {
+  it("formats a re-auth message with instance + username", () => {
+    const err = new TokenRejectedError("mastodon.social", "alice");
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe("TokenRejectedError");
+    expect(err.instance).toBe("mastodon.social");
+    expect(err.message).toContain("@alice@mastodon.social");
+    expect(err.message).toContain("activitypub-mcp login mastodon.social");
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npm run test -- tests/unit/utils.test.ts -t "TokenRejectedError"`
+Expected: FAIL — not exported.
+
+- [ ] **Step 3: Implement the error class**
+
+Append to `src/utils/errors.ts`:
+
+```ts
+/**
+ * Thrown when an authenticated request is rejected with HTTP 401 — the token was
+ * revoked or expired. (403 is NOT treated as token rejection: it is also used for
+ * per-operation permission/scope errors that adapters must surface verbatim, e.g.
+ * Misskey's `{error:{message}}` body.) Carries the account identity so the message
+ * can point the user at the exact re-login command.
+ */
+export class TokenRejectedError extends Error {
+  constructor(
+    public readonly instance: string,
+    public readonly username: string,
+  ) {
+    super(
+      `The token for @${username}@${instance} was rejected (revoked or expired). ` +
+        `Run \`activitypub-mcp login ${instance}\` to re-authorize.`,
+    );
+    this.name = "TokenRejectedError";
+  }
+}
+```
+
+- [ ] **Step 4: Write the failing test for the fetch seam**
+
+Append to `tests/unit/authenticated-client.test.ts` (this file already mocks `validation/url.js` and `discovery/nodeinfo.js` per SP1):
+
+```ts
+import { authenticatedFetch } from "../../src/auth/adapters/write-adapter.js";
+import { TokenRejectedError } from "../../src/utils/errors.js";
+
+describe("authenticatedFetch token rejection", () => {
+  const account = {
+    id: "a",
+    instance: "example.social",
+    username: "alice",
+    accessToken: "tok",
+    tokenType: "Bearer",
+    scopes: ["read", "write"],
+    createdAt: "2026-01-01T00:00:00.000Z",
+  };
+
+  it("throws TokenRejectedError on HTTP 401", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response("nope", { status: 401 }));
+    await expect(authenticatedFetch(account, "/api/v1/accounts/verify_credentials")).rejects.toBeInstanceOf(
+      TokenRejectedError,
+    );
+    fetchSpy.mockRestore();
+  });
+});
+```
+
+- [ ] **Step 5: Run to verify it fails**
+
+Run: `npm run test -- tests/unit/authenticated-client.test.ts -t "token rejection"`
+Expected: FAIL — `authenticatedFetch` returns the 401 response instead of throwing.
+
+- [ ] **Step 6: Implement the seam**
+
+In `src/auth/adapters/write-adapter.ts`, import the error:
+
+```ts
+import { TokenRejectedError } from "../../utils/errors.js";
+```
+
+In `authenticatedFetch`, after the response is received (just before `return response;` at the end of the success path), add:
+
+```ts
+    if (response.status === 401) {
+      throw new TokenRejectedError(account.instance, account.username);
+    }
+```
+
+Make sure this is inside the `try` after `clearTimeout(timeoutId);` and before `return response;`, so the timeout is always cleared. **Only 401** is caught — 403 must keep flowing back as a `Response` so adapters can extract platform error bodies (SP1's `tests/unit/misskey-adapter.test.ts` "extracts Misskey error messages" returns HTTP 403 `{error:{message:"Permission denied"}}` and asserts that message; throwing on 403 would break it). The thrown `TokenRejectedError` passes through the existing `catch (error)` unchanged — its `name` is not `"AbortError"`, so it is re-thrown to the tool catch blocks where `getErrorMessage()`/`formatErrorWithSuggestion()` render its message. (The existing adapter methods that check `!response.ok` for other statuses are unaffected.)
+
+- [ ] **Step 7: Add the "no account" login hint to the guards**
+
+In `src/mcp/tools-write.ts`, update the two guard messages to mention `login`:
+
+```ts
+function requireWriteEnabled(): void {
+  if (!authenticatedClient.isWriteEnabled()) {
+    throw new McpError(
+      ErrorCode.InternalError,
+      "This write operation requires authentication. Run `activitypub-mcp login <instance>` to sign in, " +
+        "or set ACTIVITYPUB_DEFAULT_INSTANCE and ACTIVITYPUB_DEFAULT_TOKEN environment variables.",
+    );
+  }
+}
+```
+
+```ts
+function requireAuthEnabled(): void {
+  if (!authenticatedClient.isWriteEnabled()) {
+    throw new McpError(
+      ErrorCode.InternalError,
+      "This tool requires an authenticated account. Run `activitypub-mcp login <instance>` to sign in, " +
+        "or set ACTIVITYPUB_DEFAULT_INSTANCE and ACTIVITYPUB_DEFAULT_TOKEN environment variables.",
+    );
+  }
+}
+```
+
+Also wire the **second** re-auth hook the spec requires: the `verify-account` tool's
+"invalid or expired" message (the `if (!info)` branch, around line 305 in
+`tools-write.ts`). Change its closing line so a rejected token points at `login`:
+
+```ts
+Account credentials for \`${targetId}\` (@${account.username}@${account.instance}) are invalid or expired.
+
+Run \`activitypub-mcp login ${account.instance}\` to re-authorize.
+```
+
+(Replace the existing "Please update your access token." line; keep the surrounding
+`return { content: [...], isError: true }` structure intact.)
+
+- [ ] **Step 8: Run tests to verify they pass**
+
+Run: `npm run test -- tests/unit/utils.test.ts tests/unit/authenticated-client.test.ts tests/unit/misskey-adapter.test.ts`
+Expected: PASS — new specs plus the existing SP1 specs. Because only **401** throws (not 403), the Misskey adapter's 403 body-extraction test ("extracts Misskey error messages") still gets a `Response` and passes unchanged.
+
+- [ ] **Step 9: Full suite + typecheck + lint**
+
+Run: `npm run test && npm run typecheck && npm run lint`
+Expected: PASS across the tree. (`TokenRejectedError` messages flow through the existing `formatErrorWithSuggestion(getErrorMessage(error))` in the ~28 write-tool catch blocks unchanged — `getErrorMessage` returns the error's `message`.)
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/utils/errors.ts src/auth/adapters/write-adapter.ts src/mcp/tools-write.ts tests/unit/utils.test.ts tests/unit/authenticated-client.test.ts
+git commit -m "feat(auth): TokenRejectedError on 401/403 + login hints in write guards"
+```
+
+---
+
+## Task 16: Documentation
+
+**Files:**
+- Modify: `README.md`, `.env.example`, `.env.production.example`, `CHANGELOG.md`
+
+- [ ] **Step 1: README — login section**
+
+In `README.md`, under the authentication/multi-platform section, add:
+
+```md
+### Signing in (OAuth / MiAuth)
+
+Acquire and persist an access token without hand-copying it:
+
+```bash
+# Mastodon-family (Mastodon, Pleroma, Akkoma, GotoSocial, Sharkey, Firefish)
+activitypub-mcp login mastodon.social
+
+# Misskey / Foundkey (uses MiAuth)
+activitypub-mcp login misskey.io
+```
+
+This opens your browser to authorize, captures the response on a temporary
+`127.0.0.1` callback, and saves the token to
+`${XDG_CONFIG_HOME:-~/.config}/activitypub-mcp/accounts.json` (file mode `0600`).
+The MCP server loads persisted accounts at startup alongside any env-var accounts.
+
+- `activitypub-mcp accounts` — list signed-in accounts (no secrets shown).
+- `activitypub-mcp logout <id>` — revoke (Mastodon) and remove the account.
+
+**Notes & limitations**
+- Tokens are stored in plaintext, protected by file permissions (like `gh`/`npm`).
+  For stronger at-rest protection, use the env-var path with a secret manager.
+- Interactive login needs a local browser + reachable loopback. Headless/CI
+  deployments keep using `ACTIVITYPUB_DEFAULT_INSTANCE` / `ACTIVITYPUB_DEFAULT_TOKEN`.
+- IDs are platform-scoped — a token works only against the instance it was issued for.
+- Misskey has no app-revoke endpoint; `logout` removes the local record (revoke the
+  token in your instance's Settings → API to fully invalidate it).
+- Foundkey is migrating off MiAuth; login may fail on builds that have removed it.
+```
+
+- [ ] **Step 2: `.env.example` + `.env.production.example`**
+
+Add to both, near the authentication section:
+
+```ini
+# Directory for the persisted credential store (accounts.json) created by
+# `activitypub-mcp login`. Default: ${XDG_CONFIG_HOME:-~/.config}/activitypub-mcp
+# ACTIVITYPUB_CONFIG_DIR=/path/to/config
+```
+
+- [ ] **Step 3: CHANGELOG**
+
+Add an `### Added` entry under a new `## [Unreleased]` heading:
+
+```md
+## [Unreleased]
+
+### Added
+
+- **Browser-based login.** New `activitypub-mcp login <instance>` acquires an
+  access token via Mastodon OAuth2 (PKCE) or Misskey/Foundkey MiAuth — routed by
+  NodeInfo software detection — using an ephemeral `127.0.0.1` loopback callback,
+  and persists it to `${XDG_CONFIG_HOME:-~/.config}/activitypub-mcp/accounts.json`
+  (mode `0600`). The server loads persisted accounts at startup alongside env-var
+  accounts. Adds `activitypub-mcp logout <id>` and `activitypub-mcp accounts`.
+- **`ACTIVITYPUB_CONFIG_DIR`** to override the credential-store location.
+- **Clearer auth errors.** A rejected token (401/403) now returns a
+  `TokenRejectedError` telling you to run `activitypub-mcp login <instance>`.
+```
+
+- [ ] **Step 4: Verify docs build / links**
+
+Run: `npm run build`
+Expected: PASS (no code changed; this confirms the tree still compiles).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add README.md .env.example .env.production.example CHANGELOG.md
+git commit -m "docs: document login/logout/accounts, credential storage, and limitations"
+```
+
+---
+
+## Final verification
+
+- [ ] **Run the entire suite, typecheck, lint, build, version check**
+
+```bash
+npm run validate:version && npm run typecheck && npm run lint && npm run test && npm run build
+```
+
+Expected: all PASS. Investigate any regression before considering the plan complete
+(most likely a moved/renamed import — search for the symbol and fix the path).
+
+- [ ] **Manual smoke (optional, needs a real account)**
+
+```bash
+node dist/mcp-main.js login <your-instance>
+node dist/mcp-main.js accounts
+node dist/mcp-main.js logout <id>
+```
+
+---
+
+## Self-Review (completed during planning)
+
+**Spec coverage:**
+- CLI + ephemeral loopback → Tasks 6, 12, 14. ✓
+- node:fs 0600 store + CONFIG_DIR + hardening → Tasks 1, 2. ✓
+- Both platforms via strategy interface (OAuth2 + MiAuth) → Tasks 8–11. ✓
+- guarded UNauthenticated fetch (not authenticatedFetch) + nodeinfo refactor → Task 5. ✓
+- AccountManager.loadPersisted (env-wins, guarded) + startup await → Tasks 3, 4. ✓
+- Re-auth seam at the 401-observing fetch + "no account" guard hints → Task 15. ✓
+- logout/revoke, accounts list, list/switch integration (via loadPersisted) → Tasks 13, 3. ✓
+- Trimmed Misskey perms + Mastodon scope constant → Task 8. ✓
+- Browser argv-array spawn → Task 7. ✓
+- Config registration + docs/limitations → Tasks 1, 16. ✓
+- Build sequence honored (store → manager → fetch → mechanics → strategies → CLI → re-auth → docs). ✓
+
+**Type consistency:** `StoredAccount` (Task 1) is the single shape used by the store,
+`loadPersisted` (Task 3), strategies' `revoke` (Tasks 8–10), and the CLI (Tasks 12–13).
+`LoginResult`/`AuthorizeContext`/`LoginStrategy` (Task 8) match the strategy
+implementations (Tasks 9–10) and `resolveLoginStrategy` return type (Task 11).
+`guardedFetch`/`GuardedResponse` (Task 5) signatures match every call site
+(Tasks 9–10). `createLoopbackServer`→`LoopbackServer` (Task 6) matches the
+`AuthorizeContext.waitForCallback` shape consumed by strategies and produced by the CLI.
+
+**Placeholder scan:** none — every step contains complete code or an exact command.

--- a/docs/superpowers/specs/2026-05-29-oauth-onboarding-design.md
+++ b/docs/superpowers/specs/2026-05-29-oauth-onboarding-design.md
@@ -1,0 +1,506 @@
+# Browser-Based Login + Credential Persistence — Design
+
+**Date:** 2026-05-29
+**Status:** Approved (design)
+**Sub-project:** 2 of 4 (foundation-first sequencing; follows the platform-aware write layer)
+
+> This design was adversarially reviewed (Mastodon OAuth2 + Misskey MiAuth protocol
+> fact-checks against upstream docs/source, codebase-fit, RFC 8252/7636/9700 security,
+> and completeness). The protocol details below are verified; the network-plumbing,
+> loopback-port, re-auth-seam, and credential-store sections reflect the review's
+> corrections.
+
+## Problem
+
+Authenticated accounts are created **only** from environment variables at process
+startup (`ACTIVITYPUB_DEFAULT_INSTANCE`/`ACTIVITYPUB_DEFAULT_TOKEN`, or the
+pipe-delimited `ACTIVITYPUB_ACCOUNTS`) and live **in memory** for the lifetime of the
+process (`src/auth/account-manager.ts`). Two consequences:
+
+1. **No way to acquire a token.** Users must manually create an access token on their
+   instance (Mastodon: Preferences → Development → New application; Misskey: Settings →
+   API) and paste it into an env var. There is no OAuth/authorization flow anywhere in
+   the codebase.
+2. **Nothing persists.** The runtime account tools (`list-accounts`, `switch-account`)
+   operate on the in-memory map; there is no durable store, so a token must be
+   re-supplied on every launch.
+
+SP1 (platform-aware write layer) made Misskey writes work, but a Misskey user still has
+to hand-provision a token. SP2 closes that onboarding gap.
+
+## Goal
+
+Add a real browser-based login flow that acquires and **persists** an access token,
+covering **Mastodon-family OAuth2** and **Misskey/Foundkey MiAuth**, routed by the
+existing `getInstanceSoftware()` NodeInfo detection. Delivered as **CLI subcommands on
+the existing `activitypub-mcp` bin** plus a **persistent credential store** that
+`AccountManager` loads at startup.
+
+The environment-variable path is **unchanged and remains first-class** for headless/CI
+deployments. Persisted accounts are additive.
+
+## Non-goals
+
+- **No token refresh / expiry machinery.** Mastodon and Misskey access tokens are
+  long-lived today; re-running `login` is the recovery path. (See "Token lifetime".)
+- **No OS keychain or at-rest encryption.** Secrets are protected by file permissions
+  (`0600`) — the explicit trade-off chosen during brainstorming.
+- **No MCP-tool-driven (LLM-mediated) login.** The interactive flow is a CLI concern;
+  the LLM never sees the authorization code or token.
+- **No HTTP-transport callback route.** The loopback callback is a local one-shot
+  server owned by the CLI, independent of the optional StreamableHTTP transport.
+- **No headless-browser onboarding.** Interactive login assumes a local browser and a
+  reachable `127.0.0.1` loopback. Headless/CI users continue to use env-var tokens
+  (documented). The flow prints the authorize URL as a fallback but adds no
+  out-of-band paste mode.
+- **No new runtime dependency.** Implemented with `node:http`, `node:crypto`, `node:fs`,
+  and `node:child_process` only, consistent with the lean prod-dependency set
+  (`@logtape/logtape`, `@modelcontextprotocol/sdk`, `zod`).
+
+## Architecture
+
+New `src/auth/login/` directory, parallel to the SP1 `src/auth/adapters/`:
+
+```text
+src/auth/
+  login/
+    login-strategy.ts   // LoginStrategy interface + LoginResult/AuthorizeContext types
+    mastodon-oauth.ts   // MastodonOAuthStrategy: app registration, authorize, token, revoke (PKCE)
+    miauth.ts           // MisskeyMiAuthStrategy: session UUID, miauth consent, check
+    resolve.ts          // resolveLoginStrategy(instance) via getInstanceSoftware()
+    loopback-server.ts  // one-shot 127.0.0.1 HTTP callback (RFC 8252), ephemeral port
+    browser.ts          // cross-platform browser opener (argv-array spawn); prints URL fallback
+    scopes.ts           // the per-platform scope/permission constants (single source of truth)
+  credential-store.ts   // node:fs JSON store, XDG config dir, 0700 dir / 0600 file; CRUD
+  account-manager.ts    // (modify) async loadPersisted() merges store with env-var accounts
+src/cli/
+  index.ts              // subcommand dispatch (login / logout / accounts)
+  login.ts              // `login <instance>` orchestration + LoginResult→StoredAccount mapping
+  logout.ts             // `logout <id>`
+  accounts.ts           // `accounts` (merged list, no secrets)
+src/utils/fetch-helpers.ts // (modify) export guardedFetch() — guarded UNauthenticated fetch
+src/discovery/nodeinfo.ts  // (modify) refactor private fetchJson to call guardedFetch
+src/mcp-main.ts            // (modify) subcommand dispatch before validateConfiguration()/server
+src/mcp-server.ts          // (modify) await accountManager.loadPersisted() at top of start()
+src/mcp/tools-write.ts     // (modify) "no account" hint + 401 re-auth hint wiring
+src/utils/errors.ts        // (modify) add TokenRejectedError
+src/config.ts              // (modify) register ACTIVITYPUB_CONFIG_DIR
+.env.example, .env.production.example, README.md // (modify) document login + storage
+```
+
+### `LoginStrategy` interface
+
+```ts
+export interface AuthorizeContext {
+  instance: string;            // validated bare domain (DomainSchema), lowercased
+  redirectUri: string;         // http://127.0.0.1:<ephemeral-port>/callback
+  scopes: string[];            // platform-appropriate scope/permission list (from scopes.ts)
+  // Injected by the CLI orchestrator (the shared mechanics):
+  openBrowser: (url: string) => Promise<void>;
+  waitForCallback: (expected: { state?: string; session?: string }) => Promise<URLSearchParams>;
+}
+
+export interface LoginResult {
+  instance: string;            // lowercased
+  username: string;            // bare local handle from the platform "whoami"
+  accessToken: string;
+  tokenType: string;           // "Bearer"
+  scopes: string[];            // Mastodon: granted scope from /oauth/token; Misskey: requested perms
+  clientId?: string;           // cached for revoke (Mastodon only)
+  clientSecret?: string;       // cached for revoke (Mastodon only)
+}
+
+export interface LoginStrategy {
+  readonly kind: "mastodon" | "misskey";
+  authorize(ctx: AuthorizeContext): Promise<LoginResult>;
+  /** Revoke the access token server-side. Unimplemented on Misskey (no MiAuth revoke). */
+  revoke?(account: StoredAccount): Promise<void>;
+}
+```
+
+`StoredAccount` (below) is the home type, declared in `credential-store.ts`;
+`login-strategy.ts` imports it **type-only**. The CLI (`src/cli/login.ts`) maps
+`LoginResult → StoredAccount` (assigning `id`, `createdAt`, `label`) and calls
+`store.upsert()` — strategies never touch the store.
+
+The CLI orchestrator owns the shared mechanics (ephemeral-port selection, loopback
+server, browser open, timeout) and injects them via `AuthorizeContext`, so each strategy
+contains only its platform's protocol steps and is unit-testable with mocked seams.
+
+### Strategy selection (`login/resolve.ts`)
+
+```text
+resolveLoginStrategy(instance):
+  info = await getInstanceSoftware(instance)        // cached + single-flight (SP1)
+  name = info.software?.name?.toLowerCase()
+  if name in { "misskey", "foundkey" }  -> misskeyMiAuthStrategy
+  else                                  -> mastodonOAuthStrategy   // incl. unavailable/unknown
+```
+
+Identical routing rule and fail-safe default (Mastodon) as `adapters/resolve.ts`, which
+is correct for Pleroma/Akkoma/GotoSocial (Mastodon-compatible OAuth2). **Caveats the
+implementation must handle:**
+
+- **Sharkey/Firefish** are Misskey-family forks but their NodeInfo software name is
+  `sharkey`/`firefish`, so they route to the **Mastodon OAuth2** strategy. Recent
+  builds expose the Mastodon `/api/v1/apps` + `/oauth/*` endpoints, so this works; if a
+  given build only speaks MiAuth, the OAuth2 strategy fails with a clear error. (Not
+  worth a capability probe in v1; documented limitation.)
+- **GotoSocial** does not implement PKCE (it ignores the challenge params — harmless,
+  see below) and only honors granular scopes since v0.19.0. The implementation must read
+  the **granted** scope from the `/oauth/token` response rather than assuming the
+  requested string was honored.
+- **Foundkey** *inherited* MiAuth but is **deprecating/removing it** in favor of OAuth2.
+  On a Foundkey build where `features.miauth` (from `GET /api/meta`) is false, the
+  MiAuth `/check` endpoint may not exist and the strategy fails. v1 routes `foundkey →
+  MiAuth` and surfaces a clear error on failure; a `features.miauth` probe is a possible
+  future refinement. Documented limitation.
+
+## Flows
+
+Both flows use a **loopback redirect** (RFC 8252 §7.3 — OAuth for native apps): the CLI
+binds a one-shot HTTP server to **`127.0.0.1:0` (an ephemeral, OS-assigned port)** and
+uses the resulting `http://127.0.0.1:<port>/callback` as the callback. An ephemeral port
+(not a fixed well-known one) is required so a co-resident local process cannot
+pre-bind a predictable port and steal the callback (RFC 9700 §4.8) — this is the **sole**
+channel protection on the Misskey path, which has no PKCE. `--port <N>` is an explicit
+override for firewalled setups only. The instance is validated (`DomainSchema`) and
+blocklist-checked **before** the browser is opened.
+
+### Mastodon-family OAuth2
+
+Because Mastodon/Doorkeeper matches `redirect_uri` by **exact string** (it does *not*
+honor RFC 8252 §7.3 variable-loopback-port), and the port is ephemeral per login, a
+**fresh client app is registered each login** — there is no cross-login client-app
+cache. (App records are lightweight; this trades a little instance-side app sprawl for
+the security of ephemeral ports.)
+
+1. **Client app:** `POST https://<instance>/api/v1/apps` (form-encoded) with
+   `client_name=activitypub-mcp`, `redirect_uris=<loopback>`, `scopes=read write follow`,
+   `website=https://github.com/cameronrye/activitypub-mcp`. Response yields `client_id`
+   + `client_secret`.
+2. **PKCE:** generate `code_verifier` = base64url(`crypto.randomBytes(32)`) (43–128 chars,
+   no padding) and `code_challenge` = base64url(sha256(`code_verifier`)). We **always**
+   send `code_challenge`/`code_challenge_method=S256` at authorize and **always** send
+   `code_verifier` at token. PKCE S256 is the **primary** code-interception defense for
+   this native app (RFC 8252 §8.1); the Mastodon `client_secret` is a registration
+   artifact, **not** a truly confidential credential (it is stored in `accounts.json`
+   and re-issued to anyone who registers). PKCE landed in Mastodon **4.3.0** (S256 only;
+   `plain` rejected); pre-4.3 instances ignore the unknown `code_challenge` param and
+   the `client_secret` carries the exchange — so the flow completes either way because we
+   unconditionally send both.
+3. **Authorize:** open
+   `https://<instance>/oauth/authorize?response_type=code&client_id=…&redirect_uri=…&scope=read%20write%20follow&state=<csprng>&code_challenge=…&code_challenge_method=S256`.
+   `state` = base64url(`crypto.randomBytes(32)`) (≥128 bits).
+4. **Callback:** the loopback server resolves **only** when `/callback` carries a `state`
+   that matches the generated value (length-safe constant-time compare via
+   `crypto.timingSafeEqual`); a missing/mismatched `state` → 404, no resolve. If the
+   instance returns an `iss` param, verify it matches the expected instance origin
+   (mix-up defense). On match, serve a **static** "you can close this window" page (no
+   reflection of `code`/`state`) and shut the server down.
+5. **Token:** `POST https://<instance>/oauth/token` (form-encoded) with
+   `grant_type=authorization_code`, `code`, `client_id`, `client_secret`, `redirect_uri`,
+   `code_verifier`, `scope`. The token endpoint origin is the **originally-resolved,
+   guarded instance** — never anything derived from the callback. Parse `access_token`,
+   `token_type`, and the authoritative **granted** `scope` (space-separated; may differ
+   from requested — parse defensively).
+6. **Whoami:** `GET https://<instance>/api/v1/accounts/verify_credentials` (this is the
+   one call with a token, so it uses SP1 `authenticatedFetch`) → `username`.
+7. Build `LoginResult` (carrying `clientId`/`clientSecret`) → CLI persists.
+
+`revoke(account)`: `POST https://<instance>/oauth/revoke` (form-encoded) with `client_id`,
+`client_secret`, `token`.
+
+### Misskey / Foundkey MiAuth
+
+1. **Session:** generate a v4 UUID with `crypto.randomUUID()` (CSPRNG, ~122 bits). Treat
+   it as a **secret** — the bearer of the UUID can call the public `/check` and obtain
+   the real token.
+2. **Authorize:** open
+   `https://<instance>/miauth/<uuid>?name=activitypub-mcp&callback=<url-encoded loopback>&permission=<comma-separated perms>`.
+   No `icon` (CLI app), no app pre-registration, no client secret.
+3. **Callback:** Misskey redirects to the callback with `?session=<uuid>` appended. The
+   loopback resolves **only** when the returned `session` equals the generated UUID
+   (constant-time compare); otherwise 404, no resolve.
+4. **Check:** `POST https://<instance>/api/miauth/<uuid>/check` (empty JSON body `{}`),
+   called **immediately and exactly once** → `{ ok: true, token, user }`. The `token` is
+   the access token; `user.username` is the whoami (no separate verify call needed — the
+   `user` object is returned inline).
+5. Build `LoginResult` (no `clientId`/`clientSecret`; `scopes` = the requested permission
+   set, since `/check` does not report the granted subset) → CLI persists.
+
+`revoke` is **not implemented** on Misskey: there is no documented public MiAuth revoke
+endpoint (server-side revocation is only via the instance's Settings → API UI). `logout`
+drops the local record and prints a note pointing to the instance UI.
+
+**Misskey permission set** (`login/scopes.ts`, trimmed to least-privilege for the SP1
+write surface — all strings verified to exist in `misskey-js` `consts.ts`):
+`read:account` (whoami + home timeline + relationship reads — Misskey has no separate
+read-timeline scope), `read:following`, `write:notes` (post/reply/renote),
+`write:reactions`, `write:following` (follow/unfollow), `write:blocks`, `write:mutes`,
+`write:drive` (media upload), `read:notifications`. **Deliberately omitted:**
+`write:votes` and `write:notifications` (SP1 makes poll-voting Mastodon-only and exposes
+notifications read-only), and the unused `read:blocks`/`read:mutes`/`read:drive`.
+
+### Shared mechanics
+
+- **`loopback-server.ts`:** binds `node:http` to `127.0.0.1:0` (ephemeral; never
+  `0.0.0.0`); reads the assigned port from `server.address()`. Responds **static 404** to
+  any path other than `/callback` and to `/callback` requests lacking the expected
+  `state`/`session`, **without** resolving (so a local prober cannot DoS the one-shot
+  promise with junk). Resolves the promise only on a valid callback; caps request
+  header/body size; rejects on a **300s** timeout. Always closes the socket in a
+  `finally`. The success page is static HTML.
+- **`browser.ts`:** spawns the platform opener with `child_process.spawn` using an
+  **argv array (never a shell string)** — `open <url>` (darwin), `xdg-open <url>`
+  (linux/other), and on win32 `cmd /c start "" <url>` with the URL as a discrete argument
+  (no shell interpolation of `&`/`%`/`^`). On spawn failure it logs and the CLI prints
+  the URL for manual opening (the loopback keeps listening).
+- **Guarded unauthenticated fetch (`guardedFetch`):** the pre-token calls (Mastodon
+  `/api/v1/apps`, `/oauth/token`, `/oauth/revoke`; Misskey `/check`) have **no token**, so
+  they **cannot** use SP1 `authenticatedFetch` (which forces a `Bearer` header and JSON
+  content-type). Instead, generalize `nodeinfo.ts`'s private `fetchJson` into an exported
+  `guardedFetch(url, { method, headers, body })` in `utils/fetch-helpers.ts` that runs
+  `validateExternalUrl(url)` + `instanceBlocklist.validateNotBlocked(host)` +
+  `fetchWithRedirectGuard` (re-validating every hop) + `AbortController` timeout +
+  `readJsonWithLimit(MAX_RESPONSE_SIZE)`, and lets the caller set method/headers/body.
+  Mastodon `/api/v1/apps` and `/oauth/token`/`/oauth/revoke` send
+  `Content-Type: application/x-www-form-urlencoded` (`URLSearchParams` body); the Misskey
+  `/check` sends `application/json` `{}`. `nodeinfo.ts` is refactored to call the same
+  helper (its current GET-only behavior is the default). Only the post-token Mastodon
+  whoami uses `authenticatedFetch`.
+
+## Credential store (`src/auth/credential-store.ts`)
+
+- Plain `node:fs` JSON file (no `unstorage` — it is not a project dependency). Directory:
+  `ACTIVITYPUB_CONFIG_DIR` if set, else `${XDG_CONFIG_HOME:-~/.config}/activitypub-mcp/`
+  (tilde expanded to `os.homedir()`). File: `accounts.json`.
+- Record shape:
+
+  ```ts
+  interface StoredAccount {
+    id: string;            // default `${username}@${instance}` (both lowercased); or --id
+    instance: string;      // lowercased
+    username: string;      // bare local handle from whoami; '@'/whitespace rejected
+    accessToken: string;
+    tokenType: string;     // "Bearer"
+    scopes: string[];
+    clientId?: string;     // Mastodon only (for revoke)
+    clientSecret?: string; // Mastodon only (for revoke)
+    label?: string;
+    createdAt: string;     // ISO 8601 (local record time; distinct from OAuth created_at)
+  }
+  ```
+
+- **API:** `load(): Promise<StoredAccount[]>`, `upsert(account)`, `remove(id)`,
+  `get(id)`. (No client-app cache — ephemeral ports make a fresh Mastodon app per login,
+  so `clientId/clientSecret` live on the account record only, for revoke.)
+- **Atomic, race-safe write:** create a temp file **in the same directory** with
+  `fs.open(tmp, 'wx', 0o600)` (`O_EXCL` + randomized suffix → no symlink/TOCTOU), write,
+  `fsync`, then `fs.rename` onto `accounts.json` (atomic, same filesystem). The directory
+  is created `0700`.
+- **Load-time hardening:** if `accounts.json` is a symlink, or the directory/file is
+  group/other-writable, **refuse** to read and log an error. If the file mode is more
+  permissive than `0600`, actively `chmod 0600` (not merely warn). Validate the resolved
+  config dir is owned by the current user.
+- **Malformed file:** a Zod schema validates on load. **Absent** file → empty store
+  (normal). **Present but invalid** → preserve it as `accounts.json.corrupt-<ts>`, log
+  loudly, and treat the store as empty (so the next `upsert` does not destroy a
+  recoverable file).
+
+**Security note (documented in README):** access tokens and Mastodon client secrets are
+stored in plaintext, protected only by filesystem permissions. This matches the
+ergonomics of `gh`/`npm` and is the chosen trade-off; users wanting stronger at-rest
+protection should use the env-var path with an external secret manager.
+
+## AccountManager integration & startup
+
+`node:fs` reads are asynchronous, but the `accountManager` singleton is constructed
+synchronously at import. Therefore:
+
+- The synchronous `loadFromEnvironment()` stays in the constructor (back-compat:
+  env-only deployments need no async step).
+- Add `async loadPersisted(): Promise<void>` that reads the store and, **for each
+  record, explicitly guards the collision rule** — `addAccount()` does an unconditional
+  `set()` and will **not** enforce precedence on its own:
+
+  ```text
+  loadPersisted():
+    for rec in store.load():
+      if accountManager.getAccount(rec.id):    // env-var account already holds this id
+        log.warn("persisted account shadowed by env account", { id }); continue   // env wins
+      accountManager.addAccount(rec)            // createdAt is regenerated in-memory; the
+                                                // on-disk record keeps its original createdAt
+  ```
+
+- `src/mcp-server.ts` awaits `accountManager.loadPersisted()` at the **very top of
+  `start()`**, before the `if (mode === 'http')` branch, so it precedes `connect()` for
+  **both** transports. A store failure is caught and logged (env accounts still load; the
+  server still starts), matching the "malformed store → warn + treat as empty" row.
+- **Collision rule:** env-var account wins on duplicate `id`. Default persisted `id` is
+  `username@instance` (both lowercased), which won't collide with common env ids
+  (`default`, or user-chosen `ACTIVITYPUB_ACCOUNTS` ids) in practice; the `--id` override
+  can collide, in which case env still wins and the persisted record is skipped+warned.
+- Persisted accounts then appear automatically in `list-accounts` / `switch-account` with
+  no change to those tools.
+
+## CLI surface (single bin)
+
+`src/mcp-main.ts` currently only handles `-h`/`-v` and drops non-flag positionals with no
+dispatch. The entry point gains **explicit subcommand dispatch at the top of `main()`** —
+before `validateConfiguration()` and `new ActivityPubMCPServer()` — so the CLI paths
+never construct a server/transport. If `argv[0]` is a known subcommand, route to
+`src/cli/*` and return; otherwise the no-arg/flags-only path starts the server
+**unchanged**.
+
+| Command | Behavior |
+|---------|----------|
+| `activitypub-mcp login <instance> [--port N] [--id ID] [--label L]` | Run the resolved login flow; map `LoginResult → StoredAccount`; `store.upsert`; print `Authorized as @user@instance`. |
+| `activitypub-mcp logout <id>` | If the stored account has `clientId/clientSecret` (Mastodon), call `revoke()`; then `store.remove(id)`. Misskey: remove locally + print the instance-UI note. Env-var accounts have no on-disk record and cannot be logged out this way (clear error). |
+| `activitypub-mcp accounts` | Call `loadPersisted()` and print the **same merged view** as `list-accounts` (env + persisted, marking the source), **no secrets**, so the two surfaces agree. |
+| *(no subcommand / only flags)* | Start the MCP server exactly as today. **Unchanged default.** |
+
+Subcommand parsing is a small hand-rolled parser (no new dependency). Unknown subcommands
+print usage and exit non-zero.
+
+## Re-authentication guidance
+
+No automatic refresh. The hint attaches at the seam that **actually observes** the
+failure — not the pre-request account-presence guards:
+
+- **Token rejected (revoked/expired):** the shared `guardedFetch` / `authenticatedFetch`
+  throws a typed `TokenRejectedError` (new, in `utils/errors.ts`, carrying
+  `instance` + `username`) on HTTP **401/403**. The write tools' existing error
+  formatting (`formatErrorWithSuggestion(getErrorMessage(error))`, used by all ~28 catch
+  blocks) renders its message: *"The token for @user@instance was rejected (revoked or
+  expired). Run `activitypub-mcp login <instance>` to re-authorize."* The
+  `verifyAccount() == null` branch (and the `verify-account` tool's "invalid or expired"
+  message) carry the same hint as a second hook.
+- **No account configured at all:** the existing `requireWriteEnabled` /
+  `requireAuthEnabled` messages (which fire when `hasAccounts()` is false, before any
+  HTTP) gain an **additive** clause pointing at `login`, alongside the current env-var
+  guidance. These guards never see a 401, so they only own the "never logged in" case.
+
+## Token lifetime
+
+Mastodon OAuth access tokens do not expire by default and no refresh token is issued in
+this flow (Doorkeeper `access_token_expires_in` is nil; `use_refresh_token` off); Misskey
+MiAuth tokens have no expiry column. The design stores only the access token and treats
+re-login as the renewal path. **Forward-looking note:** Mastodon plans conditional
+expiry/refresh for public clients / `offline_access` (~5.0); we deliberately do **not**
+request `offline_access`, and some Mastodon-compatible forks may already expire tokens —
+the re-auth guidance above covers all of these without refresh machinery.
+
+## Security model (RFC 8252 / 7636 / 9700)
+
+- **Loopback:** `127.0.0.1`-only, **ephemeral** OS-assigned port (anti port-stealing),
+  one-shot, 300s timeout, static 404 on unexpected paths/params, size caps.
+- **PKCE** S256 is the primary native-app code-interception defense; verifier
+  base64url(32 CSPRNG bytes); challenge base64url(sha256). The Mastodon `client_secret`
+  is treated as a non-confidential registration artifact.
+- **CSRF / replay:** `state` (Mastodon) and `session` (Misskey) are CSPRNG values,
+  compared length-safe with `crypto.timingSafeEqual`; absent/mismatch aborts with nothing
+  persisted.
+- **Mix-up:** the token exchange targets only the originally-resolved, guarded instance
+  origin (never an origin derived from the callback); verify `iss` when present. The
+  browser leg is unguarded by design, so the loopback must not infer any endpoint from
+  callback contents.
+- **SSRF:** instance validated (`DomainSchema`) + blocklist before the browser opens and
+  before every server→instance fetch; redirect guard re-validates each hop. The loopback
+  (`127.0.0.1`) is intentionally exempt from those instance guards.
+- **Secret hygiene:** `login/*`, `credential-store`, and the CLI **never** log
+  `accessToken`, `clientSecret`, `code`, `code_verifier`, the MiAuth `session`/`token`, or
+  raw platform error bodies that might echo them — only `instance` + `username` + `scopes`.
+  Error bodies are scrubbed (strip query strings / known secret fields) before printing. A
+  unit test asserts no secret substring appears in captured stdout/log output for a full
+  login.
+- **At rest:** `0600` file / `0700` dir, atomic `O_EXCL` write, symlink/permission
+  refusal on load (see Credential store).
+
+## Configuration
+
+New env var, registered in `src/config.ts` (mirroring how v2.1 added
+`MCP_INSTANCE_SOFTWARE_TTL_MS`) and documented in `.env.example` /
+`.env.production.example`:
+
+| Var | Default | Description |
+|-----|---------|-------------|
+| `ACTIVITYPUB_CONFIG_DIR` | `${XDG_CONFIG_HOME:-~/.config}/activitypub-mcp` | Directory for the persisted credential store (`accounts.json`). |
+
+Scope constants live in `login/scopes.ts` (single source of truth, referenced by both app
+registration and the authorize URL): Mastodon `MASTODON_SCOPES = "read write follow"`
+(broad and maximally compatible; `follow` is deprecated since 3.5.0 and redundant with
+`write`, but kept for compatibility and to match the existing `StoredAccount.scopes`
+default — narrowing to granular `write:*` sub-scopes is a possible future refinement given
+the plaintext-storage blast radius), and the trimmed Misskey permission list above.
+
+## Build sequence (foundation-first, single plan)
+
+Land the offline-testable core before the browser-dependent parts:
+
+1. **`credential-store.ts`** + `TokenRejectedError` — fully unit-testable (temp dir,
+   perms, atomic write, malformed-file tolerance).
+2. **`AccountManager.loadPersisted()`** + the `start()` await + collision rule — unblocks
+   list/switch integration; testable with a seeded store.
+3. **`guardedFetch`** helper + `nodeinfo.ts` refactor — shared plumbing, regression-tested
+   against existing nodeinfo tests.
+4. **`loopback-server.ts`** + **`browser.ts`** shared mechanics (injected/mocked).
+5. **`mastodon-oauth.ts`** + **`miauth.ts`** strategies + **`resolve.ts`** (MSW-mocked).
+6. **`src/cli/*`** + `mcp-main.ts` dispatch.
+7. **Re-auth hint** wiring in `tools-write.ts` / error formatting (last; additive text).
+
+## Testing (TDD)
+
+**Unit (Vitest + MSW), all offline:**
+
+- `mastodon-oauth.test.ts` — MSW for `/api/v1/apps`, `/oauth/token`,
+  `/api/v1/accounts/verify_credentials`, `/oauth/revoke`. Assert form-encoded bodies, PKCE
+  params, exact `redirect_uri`, fresh app per login, `state` verification, granted-scope
+  parsing, error extraction.
+- `miauth.test.ts` — MSW for `/api/miauth/<uuid>/check`. Assert authorize URL composition
+  (trimmed permissions, callback), session match, token/user mapping, error extraction.
+- `login-resolve.test.ts` — routing matrix mirroring `adapters/resolve.test.ts`.
+- `loopback-server.test.ts` — ephemeral bind, `/callback` resolves only on valid
+  state/session, 404 + no-resolve on junk/other paths, timeout, `127.0.0.1`-only.
+- `credential-store.test.ts` — temp `ACTIVITYPUB_CONFIG_DIR`: CRUD, `0600`/`0700`, atomic
+  + `O_EXCL` write, symlink/permission refusal, malformed→`.corrupt-<ts>` preservation.
+- `guarded-fetch.test.ts` — SSRF/blocklist rejection for each method; form vs JSON bodies.
+- Secret-hygiene test — a full mocked login leaks no token/secret/verifier/session to
+  captured stdout or logger output.
+- `browser.ts` — opener injected/mocked; a URL containing `&`/`%`/`^` causes no command
+  injection (argv-array).
+
+**Regression:** existing `account-manager` env-var tests pass unchanged; `loadPersisted`
+with an empty/absent store is a no-op; `nodeinfo` tests pass after the `guardedFetch`
+refactor; write-tool tests still pass (re-auth hint is additive text).
+
+**No live integration tests** (real OAuth needs a real account/instance).
+
+## Dependency / cycle note
+
+`login/*` imports `config`, `utils/fetch-helpers` (`guardedFetch`), `validation/url`,
+`validation/schemas` (`DomainSchema`), `policy/instance-blocklist`, `discovery/nodeinfo`,
+the SP1 `authenticatedFetch` (whoami only), and the **type-only**
+`StoredAccount`/`AccountCredentials`. `credential-store` imports only `node:*` + `zod` +
+`config`. `account-manager` imports the store at runtime; `login/*` is imported by
+`src/cli/*` and never by `account-manager`, so there is no cycle.
+
+## Out of scope (later sub-projects)
+
+- Token refresh / short-lived-token rotation; `offline_access`.
+- OS keychain / at-rest encryption; granular Mastodon `write:*` scope narrowing.
+- MCP-tool-driven (in-conversation) login; HTTP-transport OAuth callback route.
+- Out-of-band (paste-the-code) headless onboarding.
+- A `features.miauth` capability probe for Foundkey / Sharkey-Firefish OAuth detection.
+- New feature tools (SP3); per-instance circuit breaker / persistent cache (SP4).
+
+## Open questions
+
+None. All forks were resolved during brainstorming and the adversarial review:
+CLI + **ephemeral-port** loopback; **`node:fs`** `0600` persistence (corrected from the
+"unstorage" option label once confirmed it is not a project dependency); both platforms
+via a strategy interface; env-wins-on-collision (explicitly guarded in `loadPersisted`);
+single-bin argv dispatch; a new guarded **unauthenticated** fetch helper (not
+`authenticatedFetch`) for pre-token calls; the re-auth hint at the 401-observing seam
+(not the presence guards); and the full scope set (logout/revoke, list/switch
+integration, re-auth prompt, `accounts` subcommand).

--- a/src/auth/account-manager.ts
+++ b/src/auth/account-manager.ts
@@ -9,6 +9,7 @@ import { getLogger } from "@logtape/logtape";
 import { z } from "zod";
 import { resolveWriteAdapter } from "./adapters/resolve.js";
 import type { AccountInfo } from "./adapters/write-adapter.js";
+import type { CredentialStore } from "./credential-store.js";
 
 const logger = getLogger("activitypub-mcp:account-manager");
 
@@ -277,6 +278,39 @@ export class AccountManager {
         error: error instanceof Error ? error.message : String(error),
       });
       return null;
+    }
+  }
+
+  /**
+   * Merge on-disk persisted accounts into the manager. Env-var accounts (loaded
+   * in the constructor) WIN on id collision — deploy-time config is authoritative.
+   * Never throws: a store failure logs and leaves env accounts intact.
+   *
+   * @param store - injected for testability; defaults to the shared singleton.
+   */
+  async loadPersisted(store?: CredentialStore): Promise<void> {
+    try {
+      const resolved = store ?? (await import("./credential-store.js")).credentialStore;
+      const records = await resolved.loadAccounts();
+      for (const rec of records) {
+        if (this.accounts.has(rec.id)) {
+          logger.warn("Persisted account shadowed by env account; skipping", { id: rec.id });
+          continue;
+        }
+        this.addAccount({
+          id: rec.id,
+          instance: rec.instance,
+          username: rec.username,
+          accessToken: rec.accessToken,
+          tokenType: rec.tokenType,
+          scopes: rec.scopes,
+          label: rec.label,
+        });
+      }
+    } catch (error) {
+      logger.error("Failed to load persisted accounts (env accounts unaffected)", {
+        error: error instanceof Error ? error.message : String(error),
+      });
     }
   }
 

--- a/src/auth/adapters/write-adapter.ts
+++ b/src/auth/adapters/write-adapter.ts
@@ -10,6 +10,7 @@
 import { z } from "zod";
 import { REQUEST_TIMEOUT, USER_AGENT } from "../../config.js";
 import { instanceBlocklist } from "../../policy/instance-blocklist.js";
+import { TokenRejectedError } from "../../utils/errors.js";
 import { fetchWithRedirectGuard } from "../../utils/fetch-helpers.js";
 import { validateExternalUrl } from "../../validation/url.js";
 import type { AccountCredentials } from "../account-manager.js";
@@ -225,6 +226,9 @@ export async function authenticatedFetch(
       },
     );
     clearTimeout(timeoutId);
+    if (response.status === 401) {
+      throw new TokenRejectedError(account.instance, account.username);
+    }
     return response;
   } catch (error) {
     clearTimeout(timeoutId);

--- a/src/auth/credential-store.ts
+++ b/src/auth/credential-store.ts
@@ -1,0 +1,114 @@
+/**
+ * On-disk credential store for accounts acquired via `activitypub-mcp login`.
+ *
+ * Plain node:fs JSON file at CONFIG_DIR/accounts.json. Secrets are protected by
+ * filesystem permissions (0600 file / 0700 dir) — the chosen trade-off (no
+ * keychain/encryption). Writes are atomic (temp + rename) so a crash never
+ * leaves a half-written file.
+ */
+
+import { randomBytes } from "node:crypto";
+import { chmodSync, mkdirSync } from "node:fs";
+import { open, readFile, rename, stat } from "node:fs/promises";
+import { join } from "node:path";
+import { getLogger } from "@logtape/logtape";
+import { z } from "zod";
+import { CONFIG_DIR } from "../config.js";
+
+const logger = getLogger("activitypub-mcp:credential-store");
+
+export const StoredAccountSchema = z.object({
+  id: z.string(),
+  instance: z.string(),
+  username: z.string(),
+  accessToken: z.string(),
+  tokenType: z.string().default("Bearer"),
+  scopes: z.array(z.string()),
+  clientId: z.string().optional(),
+  clientSecret: z.string().optional(),
+  label: z.string().optional(),
+  createdAt: z.string(),
+});
+export type StoredAccount = z.infer<typeof StoredAccountSchema>;
+
+const FileSchema = z.object({
+  version: z.literal(1),
+  accounts: z.array(StoredAccountSchema),
+});
+
+export class CredentialStore {
+  private readonly dir: string;
+  private readonly file: string;
+
+  constructor(dir: string = CONFIG_DIR) {
+    this.dir = dir;
+    this.file = join(dir, "accounts.json");
+  }
+
+  /** Load all persisted accounts. Absent file → []. */
+  async loadAccounts(): Promise<StoredAccount[]> {
+    let raw: string;
+    try {
+      raw = await readFile(this.file, "utf-8");
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
+      throw error;
+    }
+    const parsed = FileSchema.parse(JSON.parse(raw));
+    return parsed.accounts;
+  }
+
+  async getAccount(id: string): Promise<StoredAccount | undefined> {
+    return (await this.loadAccounts()).find((a) => a.id === id);
+  }
+
+  /** Insert or replace an account by id. */
+  async upsert(account: StoredAccount): Promise<void> {
+    const accounts = await this.loadAccounts();
+    const next = accounts.filter((a) => a.id !== account.id);
+    next.push(StoredAccountSchema.parse(account));
+    await this.write(next);
+    logger.info("Persisted account", { id: account.id, instance: account.instance });
+  }
+
+  /** Remove an account by id; returns whether it existed. */
+  async remove(id: string): Promise<boolean> {
+    const accounts = await this.loadAccounts();
+    const next = accounts.filter((a) => a.id !== id);
+    if (next.length === accounts.length) return false;
+    await this.write(next);
+    logger.info("Removed persisted account", { id });
+    return true;
+  }
+
+  /** Atomic write: temp file (0600, O_EXCL) in the same dir, then rename. */
+  private async write(accounts: StoredAccount[]): Promise<void> {
+    mkdirSync(this.dir, { recursive: true, mode: 0o700 });
+    const body = `${JSON.stringify({ version: 1, accounts }, null, 2)}\n`;
+    const tmp = join(this.dir, `accounts.json.${randomBytes(6).toString("hex")}.tmp`);
+    const handle = await open(tmp, "wx", 0o600);
+    try {
+      await handle.writeFile(body);
+      await handle.sync();
+    } finally {
+      await handle.close();
+    }
+    await rename(tmp, this.file);
+    chmodSync(this.file, 0o600);
+  }
+
+  /** Exposed for the loader's permission hardening (Task 2). */
+  get filePath(): string {
+    return this.file;
+  }
+  get dirPath(): string {
+    return this.dir;
+  }
+
+  // `stat` is imported for Task 2; referenced here to keep the import used.
+  protected statFile(): ReturnType<typeof stat> {
+    return stat(this.file);
+  }
+}
+
+export const credentialStore = new CredentialStore();

--- a/src/auth/credential-store.ts
+++ b/src/auth/credential-store.ts
@@ -8,8 +8,8 @@
  */
 
 import { randomBytes } from "node:crypto";
-import { chmodSync, mkdirSync } from "node:fs";
-import { lstat, open, readFile, rename, unlink } from "node:fs/promises";
+import { chmodSync, constants, mkdirSync } from "node:fs";
+import { lstat, open, rename, unlink } from "node:fs/promises";
 import { join } from "node:path";
 import { getLogger } from "@logtape/logtape";
 import { z } from "zod";
@@ -72,17 +72,42 @@ export class CredentialStore {
       chmodSync(this.file, 0o600);
     }
 
-    const raw = await readFile(this.file, "utf-8");
+    // Read through O_NOFOLLOW to close the lstat→read TOCTOU: if a symlink is
+    // swapped in after the lstat above, open() fails ELOOP rather than following it.
+    let raw: string;
+    const handle = await open(this.file, constants.O_RDONLY | constants.O_NOFOLLOW).catch(
+      (error: NodeJS.ErrnoException) => {
+        if (error.code === "ELOOP") {
+          throw new Error(`Refusing to read credential file: ${this.file} is a symlink`);
+        }
+        throw error;
+      },
+    );
+    try {
+      raw = await handle.readFile("utf-8");
+    } finally {
+      await handle.close();
+    }
+
     try {
       return FileSchema.parse(JSON.parse(raw)).accounts;
-    } catch (error) {
+    } catch (parseError) {
+      // Preserve the unreadable file for recovery, then treat the store as empty.
+      // Never throw on a malformed file — even if the rename itself fails.
       const corrupt = `${this.file}.corrupt-${Date.now()}`;
-      await rename(this.file, corrupt);
-      logger.error("Credential file invalid; preserved and treating store as empty", {
-        file: this.file,
-        preservedAs: corrupt,
-        error: error instanceof Error ? error.message : String(error),
-      });
+      try {
+        await rename(this.file, corrupt);
+        logger.error("Credential file invalid; preserved and treating store as empty", {
+          file: this.file,
+          preservedAs: corrupt,
+          error: parseError instanceof Error ? parseError.message : String(parseError),
+        });
+      } catch {
+        logger.error("Credential file invalid and could not be preserved; treating as empty", {
+          file: this.file,
+          error: parseError instanceof Error ? parseError.message : String(parseError),
+        });
+      }
       return [];
     }
   }

--- a/src/auth/credential-store.ts
+++ b/src/auth/credential-store.ts
@@ -9,7 +9,7 @@
 
 import { randomBytes } from "node:crypto";
 import { chmodSync, mkdirSync } from "node:fs";
-import { open, readFile, rename, stat, unlink } from "node:fs/promises";
+import { lstat, open, readFile, rename, unlink } from "node:fs/promises";
 import { join } from "node:path";
 import { getLogger } from "@logtape/logtape";
 import { z } from "zod";
@@ -47,15 +47,44 @@ export class CredentialStore {
 
   /** Load all persisted accounts. Absent file → []. */
   async loadAccounts(): Promise<StoredAccount[]> {
-    let raw: string;
+    let info: Awaited<ReturnType<typeof lstat>>;
     try {
-      raw = await readFile(this.file, "utf-8");
+      info = await lstat(this.file);
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
       throw error;
     }
-    const parsed = FileSchema.parse(JSON.parse(raw));
-    return parsed.accounts;
+    if (info.isSymbolicLink()) {
+      throw new Error(`Refusing to read credential file: ${this.file} is a symlink`);
+    }
+    // Refuse a file owned by another user (POSIX only; getuid is undefined on Windows).
+    // Not unit-tested: chown to a foreign uid needs root, so this is impl-only defense.
+    if (typeof process.getuid === "function" && info.uid !== process.getuid()) {
+      throw new Error(
+        `Refusing to read credential file: ${this.file} is not owned by the current user`,
+      );
+    }
+    // Relax over-permissive files back to 0600 rather than only warning.
+    if ((info.mode & 0o077) !== 0) {
+      logger.warn("Credential file was group/other-accessible; tightening to 0600", {
+        file: this.file,
+      });
+      chmodSync(this.file, 0o600);
+    }
+
+    const raw = await readFile(this.file, "utf-8");
+    try {
+      return FileSchema.parse(JSON.parse(raw)).accounts;
+    } catch (error) {
+      const corrupt = `${this.file}.corrupt-${Date.now()}`;
+      await rename(this.file, corrupt);
+      logger.error("Credential file invalid; preserved and treating store as empty", {
+        file: this.file,
+        preservedAs: corrupt,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return [];
+    }
   }
 
   async getAccount(id: string): Promise<StoredAccount | undefined> {
@@ -108,11 +137,6 @@ export class CredentialStore {
   }
   get dirPath(): string {
     return this.dir;
-  }
-
-  // `stat` is imported for Task 2; referenced here to keep the import used.
-  protected statFile(): ReturnType<typeof stat> {
-    return stat(this.file);
   }
 }
 

--- a/src/auth/credential-store.ts
+++ b/src/auth/credential-store.ts
@@ -9,7 +9,7 @@
 
 import { randomBytes } from "node:crypto";
 import { chmodSync, mkdirSync } from "node:fs";
-import { open, readFile, rename, stat } from "node:fs/promises";
+import { open, readFile, rename, stat, unlink } from "node:fs/promises";
 import { join } from "node:path";
 import { getLogger } from "@logtape/logtape";
 import { z } from "zod";
@@ -93,7 +93,12 @@ export class CredentialStore {
     } finally {
       await handle.close();
     }
-    await rename(tmp, this.file);
+    try {
+      await rename(tmp, this.file);
+    } catch (error) {
+      await unlink(tmp).catch(() => {}); // best-effort cleanup; don't mask the original error
+      throw error;
+    }
     chmodSync(this.file, 0o600);
   }
 

--- a/src/auth/login/browser.ts
+++ b/src/auth/login/browser.ts
@@ -27,9 +27,14 @@ export function openBrowser(url: string): Promise<void> {
     }
     try {
       const child = spawn(command, args, { stdio: "ignore", detached: true });
-      child.on("error", reject);
-      child.unref();
-      resolve();
+      // Resolve only once the child actually spawns; reject if the OS can't exec
+      // the opener (e.g. the binary is missing) so the caller can fall back to
+      // printing the URL. Resolving eagerly would swallow that async failure.
+      child.once("error", reject);
+      child.once("spawn", () => {
+        child.unref();
+        resolve();
+      });
     } catch (error) {
       reject(error instanceof Error ? error : new Error(String(error)));
     }

--- a/src/auth/login/browser.ts
+++ b/src/auth/login/browser.ts
@@ -1,0 +1,37 @@
+/**
+ * Opens the system browser to a URL using an argv-array spawn (never a shell
+ * string), so query values containing &, %, ^ cannot be interpreted by a shell.
+ * On failure the caller falls back to printing the URL.
+ */
+
+import { spawn } from "node:child_process";
+
+export function openBrowser(url: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    let command: string;
+    let args: string[];
+    switch (process.platform) {
+      case "darwin":
+        command = "open";
+        args = [url];
+        break;
+      case "win32":
+        // `start` is a cmd builtin; "" is the (empty) window title, url is a discrete arg.
+        command = "cmd";
+        args = ["/c", "start", "", url];
+        break;
+      default:
+        command = "xdg-open";
+        args = [url];
+        break;
+    }
+    try {
+      const child = spawn(command, args, { stdio: "ignore", detached: true });
+      child.on("error", reject);
+      child.unref();
+      resolve();
+    } catch (error) {
+      reject(error instanceof Error ? error : new Error(String(error)));
+    }
+  });
+}

--- a/src/auth/login/login-strategy.ts
+++ b/src/auth/login/login-strategy.ts
@@ -1,0 +1,35 @@
+/**
+ * Contracts for platform login strategies. The CLI orchestrator owns the shared
+ * mechanics (loopback server, browser opener, timeout) and injects them via
+ * AuthorizeContext; each strategy implements only its platform's protocol.
+ */
+
+import type { StoredAccount } from "../credential-store.js";
+
+export interface AuthorizeContext {
+  /** Validated bare domain (DomainSchema), lowercased. */
+  instance: string;
+  /** http://127.0.0.1:<ephemeral-port>/callback */
+  redirectUri: string;
+  /** Platform-appropriate scope/permission list (from scopes.ts). */
+  scopes: string[];
+  openBrowser: (url: string) => Promise<void>;
+  waitForCallback: (expected: { state?: string; session?: string }) => Promise<URLSearchParams>;
+}
+
+export interface LoginResult {
+  instance: string;
+  username: string;
+  accessToken: string;
+  tokenType: string;
+  scopes: string[];
+  clientId?: string;
+  clientSecret?: string;
+}
+
+export interface LoginStrategy {
+  readonly kind: "mastodon" | "misskey";
+  authorize(ctx: AuthorizeContext): Promise<LoginResult>;
+  /** Revoke the token server-side. Unimplemented on Misskey (no MiAuth revoke). */
+  revoke?(account: StoredAccount): Promise<void>;
+}

--- a/src/auth/login/loopback-server.ts
+++ b/src/auth/login/loopback-server.ts
@@ -1,0 +1,112 @@
+/**
+ * One-shot OAuth loopback callback server (RFC 8252 §7.3).
+ *
+ * Binds to 127.0.0.1 on an OS-assigned EPHEMERAL port (never a fixed/predictable
+ * one, never 0.0.0.0) so a co-resident local process cannot pre-bind and steal
+ * the authorization code / MiAuth session. Resolves only when /callback carries
+ * the exact expected `state` (Mastodon) or `session` (Misskey), compared in
+ * constant time; everything else gets a static 404 and does not resolve.
+ */
+
+import { timingSafeEqual } from "node:crypto";
+import { createServer, type Server } from "node:http";
+
+const SUCCESS_PAGE =
+  "<!doctype html><meta charset=utf-8><title>activitypub-mcp</title>" +
+  '<body style="font-family:sans-serif;padding:2rem">' +
+  "<h1>Authorized</h1><p>You can close this window and return to the terminal.</p>";
+
+function safeEqual(a: string, b: string): boolean {
+  const ab = Buffer.from(a);
+  const bb = Buffer.from(b);
+  if (ab.length !== bb.length) return false;
+  return timingSafeEqual(ab, bb);
+}
+
+export interface CallbackExpectation {
+  state?: string;
+  session?: string;
+  timeoutMs?: number;
+}
+
+export interface LoopbackServer {
+  /** http://127.0.0.1:<port>/callback */
+  redirectUri: string;
+  /** Resolves once with the callback query params, or rejects on timeout. */
+  waitForCallback(expected: CallbackExpectation): Promise<URLSearchParams>;
+  close(): void;
+}
+
+const DEFAULT_TIMEOUT_MS = 300_000; // 5 minutes
+
+export function createLoopbackServer(port = 0): Promise<LoopbackServer> {
+  return new Promise((resolveServer, rejectServer) => {
+    let resolveCb: ((params: URLSearchParams) => void) | null = null;
+    let expectation: CallbackExpectation | null = null;
+    let activeTimer: ReturnType<typeof setTimeout> | null = null;
+
+    const server: Server = createServer((req, res) => {
+      const url = new URL(req.url ?? "/", "http://127.0.0.1");
+      if (url.pathname !== "/callback" || !resolveCb || !expectation) {
+        res.writeHead(404).end();
+        return;
+      }
+      const params = url.searchParams;
+      const okState = expectation.state
+        ? safeEqual(params.get("state") ?? "", expectation.state)
+        : true;
+      const okSession = expectation.session
+        ? safeEqual(params.get("session") ?? "", expectation.session)
+        : true;
+      if (!okState || !okSession) {
+        res.writeHead(404).end();
+        return;
+      }
+      res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" }).end(SUCCESS_PAGE);
+      const done = resolveCb;
+      resolveCb = null;
+      done(params);
+    });
+
+    server.on("error", rejectServer);
+    server.listen(port, "127.0.0.1", () => {
+      const addr = server.address();
+      if (!addr || typeof addr === "string") {
+        server.close();
+        rejectServer(new Error("Failed to bind loopback server"));
+        return;
+      }
+      const redirectUri = `http://127.0.0.1:${addr.port}/callback`;
+
+      resolveServer({
+        redirectUri,
+        waitForCallback(expected) {
+          expectation = expected;
+          return new Promise<URLSearchParams>((resolve, reject) => {
+            const ms = expected.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+            const timer = setTimeout(() => {
+              resolveCb = null;
+              activeTimer = null;
+              reject(new Error(`Authorization timed out after ${ms}ms`));
+            }, ms);
+            timer.unref(); // never keep the process alive waiting on a callback
+            activeTimer = timer;
+            resolveCb = (params) => {
+              clearTimeout(timer);
+              activeTimer = null;
+              resolve(params);
+            };
+          });
+        },
+        close() {
+          if (activeTimer) {
+            clearTimeout(activeTimer);
+            activeTimer = null;
+          }
+          resolveCb = null;
+          server.close();
+        },
+      });
+    });
+  });
+}

--- a/src/auth/login/loopback-server.ts
+++ b/src/auth/login/loopback-server.ts
@@ -81,6 +81,14 @@ export function createLoopbackServer(port = 0): Promise<LoopbackServer> {
       resolveServer({
         redirectUri,
         waitForCallback(expected) {
+          if (!expected.state && !expected.session) {
+            return Promise.reject(
+              new Error("waitForCallback requires at least one of state or session"),
+            );
+          }
+          if (resolveCb !== null) {
+            return Promise.reject(new Error("waitForCallback is already pending"));
+          }
           expectation = expected;
           return new Promise<URLSearchParams>((resolve, reject) => {
             const ms = expected.timeoutMs ?? DEFAULT_TIMEOUT_MS;

--- a/src/auth/login/mastodon-oauth.ts
+++ b/src/auth/login/mastodon-oauth.ts
@@ -1,0 +1,136 @@
+/**
+ * Mastodon-family OAuth2 login (also Pleroma/Akkoma/GotoSocial/Sharkey/Firefish
+ * where they expose the Mastodon OAuth API). Loopback redirect + always-on PKCE
+ * S256. A fresh client app is registered per login because the ephemeral
+ * redirect port changes and Mastodon matches redirect_uri exactly.
+ */
+
+import { createHash, randomBytes } from "node:crypto";
+import { guardedFetch } from "../../utils/fetch-helpers.js";
+import type { StoredAccount } from "../credential-store.js";
+import type { AuthorizeContext, LoginResult, LoginStrategy } from "./login-strategy.js";
+
+const FORM = { "Content-Type": "application/x-www-form-urlencoded" };
+
+function base64url(buf: Buffer): string {
+  return buf.toString("base64url");
+}
+
+function platformError(data: unknown, status: number): string {
+  const d = data as { error_description?: string; error?: string } | undefined;
+  return d?.error_description || d?.error || `HTTP ${status}`;
+}
+
+export class MastodonOAuthStrategy implements LoginStrategy {
+  readonly kind = "mastodon" as const;
+
+  async authorize(ctx: AuthorizeContext): Promise<LoginResult> {
+    const base = `https://${ctx.instance}`;
+    const scope = ctx.scopes.join(" ");
+
+    // 1. Register a fresh client app for this exact redirect_uri.
+    const appRes = await guardedFetch<{ client_id: string; client_secret: string }>(
+      `${base}/api/v1/apps`,
+      {
+        method: "POST",
+        headers: FORM,
+        body: new URLSearchParams({
+          client_name: "activitypub-mcp",
+          redirect_uris: ctx.redirectUri,
+          scopes: scope,
+          website: "https://github.com/cameronrye/activitypub-mcp",
+        }).toString(),
+      },
+    );
+    if (!appRes.ok || !appRes.data) {
+      throw new Error(`Failed to register app: ${platformError(appRes.data, appRes.status)}`);
+    }
+    const { client_id, client_secret } = appRes.data;
+
+    // 2. PKCE + state.
+    const verifier = base64url(randomBytes(32));
+    const challenge = base64url(createHash("sha256").update(verifier).digest());
+    const state = base64url(randomBytes(32));
+
+    // 3. Authorize in the browser.
+    const authorizeUrl =
+      `${base}/oauth/authorize?` +
+      new URLSearchParams({
+        response_type: "code",
+        client_id,
+        redirect_uri: ctx.redirectUri,
+        scope,
+        state,
+        code_challenge: challenge,
+        code_challenge_method: "S256",
+      }).toString();
+    await ctx.openBrowser(authorizeUrl);
+
+    // 4. Capture the code (loopback verifies state).
+    const params = await ctx.waitForCallback({ state });
+    // Mix-up defense (RFC 9700 §4.4): if the AS returned an `iss`, it must be our instance.
+    const iss = params.get("iss");
+    if (iss && new URL(iss).host !== ctx.instance) {
+      throw new Error("Authorization issuer mismatch (possible mix-up attack)");
+    }
+    const code = params.get("code");
+    if (!code) throw new Error("Authorization callback returned no code");
+
+    // 5. Exchange the code for a token (always send code_verifier).
+    const tokenRes = await guardedFetch<{
+      access_token: string;
+      token_type: string;
+      scope?: string;
+    }>(`${base}/oauth/token`, {
+      method: "POST",
+      headers: FORM,
+      body: new URLSearchParams({
+        grant_type: "authorization_code",
+        code,
+        client_id,
+        client_secret,
+        redirect_uri: ctx.redirectUri,
+        code_verifier: verifier,
+        scope,
+      }).toString(),
+    });
+    if (!tokenRes.ok || !tokenRes.data?.access_token) {
+      throw new Error(`Token exchange failed: ${platformError(tokenRes.data, tokenRes.status)}`);
+    }
+    const granted = tokenRes.data.scope ? tokenRes.data.scope.split(" ") : ctx.scopes;
+
+    // 6. Whoami.
+    const whoami = await guardedFetch<{ username: string }>(
+      `${base}/api/v1/accounts/verify_credentials`,
+      { headers: { Authorization: `Bearer ${tokenRes.data.access_token}` } },
+    );
+    if (!whoami.ok || !whoami.data?.username) {
+      throw new Error(`Could not read account: ${platformError(whoami.data, whoami.status)}`);
+    }
+
+    return {
+      instance: ctx.instance,
+      username: whoami.data.username,
+      accessToken: tokenRes.data.access_token,
+      tokenType: tokenRes.data.token_type || "Bearer",
+      scopes: granted,
+      clientId: client_id,
+      clientSecret: client_secret,
+    };
+  }
+
+  async revoke(account: StoredAccount): Promise<void> {
+    if (!account.clientId || !account.clientSecret) return;
+    await guardedFetch(`https://${account.instance}/oauth/revoke`, {
+      method: "POST",
+      headers: FORM,
+      body: new URLSearchParams({
+        client_id: account.clientId,
+        client_secret: account.clientSecret,
+        token: account.accessToken,
+      }).toString(),
+    });
+  }
+}
+
+export const mastodonOAuthStrategy = new MastodonOAuthStrategy();

--- a/src/auth/login/mastodon-oauth.ts
+++ b/src/auth/login/mastodon-oauth.ts
@@ -97,7 +97,7 @@ export class MastodonOAuthStrategy implements LoginStrategy {
     if (!tokenRes.ok || !tokenRes.data?.access_token) {
       throw new Error(`Token exchange failed: ${platformError(tokenRes.data, tokenRes.status)}`);
     }
-    const granted = tokenRes.data.scope ? tokenRes.data.scope.split(" ") : ctx.scopes;
+    const granted = tokenRes.data?.scope ? tokenRes.data.scope.split(" ") : ctx.scopes;
 
     // 6. Whoami.
     const whoami = await guardedFetch<{ username: string }>(

--- a/src/auth/login/miauth.ts
+++ b/src/auth/login/miauth.ts
@@ -16,6 +16,7 @@ interface MiAuthCheck {
   ok: boolean;
   token?: string;
   user?: { username?: string };
+  error?: { message?: string };
 }
 
 export class MisskeyMiAuthStrategy implements LoginStrategy {
@@ -43,7 +44,10 @@ export class MisskeyMiAuthStrategy implements LoginStrategy {
       body: "{}",
     });
     if (!res.ok || !res.data?.ok || !res.data.token) {
-      throw new Error("MiAuth authorization was not approved");
+      const detail = res.data?.error?.message
+        ? `: ${res.data.error.message}`
+        : ` (HTTP ${res.status})`;
+      throw new Error(`MiAuth authorization was not approved${detail}`);
     }
     const username = res.data.user?.username;
     if (!username) throw new Error("MiAuth check returned no user identity");

--- a/src/auth/login/miauth.ts
+++ b/src/auth/login/miauth.ts
@@ -1,0 +1,61 @@
+/**
+ * Misskey / Foundkey MiAuth login. The user approves a session UUID in the
+ * browser; the callback returns ?session=<uuid>, then POST /api/miauth/<uuid>/check
+ * yields the access token + user inline (no app registration, no client secret,
+ * no separate whoami). The session UUID is a secret (its bearer can call /check).
+ *
+ * Note: Foundkey is deprecating MiAuth in favor of OAuth2 — on a build where
+ * /miauth is unavailable this surfaces a clear error.
+ */
+
+import { randomUUID } from "node:crypto";
+import { guardedFetch } from "../../utils/fetch-helpers.js";
+import type { AuthorizeContext, LoginResult, LoginStrategy } from "./login-strategy.js";
+
+interface MiAuthCheck {
+  ok: boolean;
+  token?: string;
+  user?: { username?: string };
+}
+
+export class MisskeyMiAuthStrategy implements LoginStrategy {
+  readonly kind = "misskey" as const;
+
+  async authorize(ctx: AuthorizeContext): Promise<LoginResult> {
+    const session = randomUUID();
+    const base = `https://${ctx.instance}`;
+
+    const consentUrl =
+      `${base}/miauth/${session}?` +
+      new URLSearchParams({
+        name: "activitypub-mcp",
+        callback: ctx.redirectUri,
+        permission: ctx.scopes.join(","),
+      }).toString();
+    await ctx.openBrowser(consentUrl);
+
+    // Loopback verifies the returned session matches.
+    await ctx.waitForCallback({ session });
+
+    const res = await guardedFetch<MiAuthCheck>(`${base}/api/miauth/${session}/check`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{}",
+    });
+    if (!res.ok || !res.data?.ok || !res.data.token) {
+      throw new Error("MiAuth authorization was not approved");
+    }
+    const username = res.data.user?.username;
+    if (!username) throw new Error("MiAuth check returned no user identity");
+
+    return {
+      instance: ctx.instance,
+      username, // bare local handle from /check; never falls back to the domain
+      accessToken: res.data.token,
+      tokenType: "Bearer",
+      scopes: ctx.scopes, // /check does not report the granted subset
+    };
+  }
+}
+
+export const misskeyMiAuthStrategy = new MisskeyMiAuthStrategy();

--- a/src/auth/login/resolve.ts
+++ b/src/auth/login/resolve.ts
@@ -1,0 +1,18 @@
+/**
+ * Picks the login strategy for an instance from detected software, mirroring
+ * adapters/resolve.ts: only Misskey-family software uses MiAuth; everything else
+ * (including detection failure / unknown) defaults to Mastodon OAuth2.
+ */
+
+import { getInstanceSoftware } from "../../discovery/nodeinfo.js";
+import type { LoginStrategy } from "./login-strategy.js";
+import { mastodonOAuthStrategy } from "./mastodon-oauth.js";
+import { misskeyMiAuthStrategy } from "./miauth.js";
+
+const MISSKEY_FAMILY = new Set(["misskey", "foundkey"]);
+
+export async function resolveLoginStrategy(instance: string): Promise<LoginStrategy> {
+  const info = await getInstanceSoftware(instance);
+  const name = info.software?.name?.toLowerCase();
+  return name && MISSKEY_FAMILY.has(name) ? misskeyMiAuthStrategy : mastodonOAuthStrategy;
+}

--- a/src/auth/login/scopes.ts
+++ b/src/auth/login/scopes.ts
@@ -1,0 +1,29 @@
+/**
+ * Single source of truth for the OAuth scopes / MiAuth permissions requested
+ * during login. Referenced by both app registration and the authorize URL.
+ */
+
+/**
+ * Mastodon-family top-level scopes covering the SP1 write surface. Broad but
+ * maximally compatible; `follow` is deprecated since 3.5.0 (redundant with
+ * `write`) but kept for compatibility and to match the legacy default.
+ */
+export const MASTODON_SCOPES = "read write follow";
+
+/**
+ * Misskey/Foundkey permissions, trimmed to least-privilege for the SP1 write
+ * surface. `read:account` covers whoami + home timeline + relationship reads
+ * (Misskey has no separate read-timeline scope). Poll-voting and notification
+ * writes are intentionally omitted (SP1 makes those Mastodon-only / read-only).
+ */
+export const MISSKEY_PERMISSIONS = [
+  "read:account",
+  "read:following",
+  "write:notes",
+  "write:reactions",
+  "write:following",
+  "write:blocks",
+  "write:mutes",
+  "write:drive",
+  "read:notifications",
+] as const;

--- a/src/cli/accounts.ts
+++ b/src/cli/accounts.ts
@@ -1,0 +1,27 @@
+/**
+ * `activitypub-mcp accounts` — list ALL configured accounts (env + persisted),
+ * matching the in-conversation `list-accounts` tool so the two surfaces agree.
+ * Each row is tagged with its source; no secrets are printed.
+ */
+
+import { accountManager } from "../auth/account-manager.js";
+import { credentialStore } from "../auth/credential-store.js";
+
+export async function runAccounts(): Promise<void> {
+  await accountManager.loadPersisted();
+  const persistedIds = new Set((await credentialStore.loadAccounts()).map((a) => a.id));
+  const accounts = accountManager.listAccounts();
+  if (accounts.length === 0) {
+    process.stdout.write("No accounts. Run `activitypub-mcp login <instance>` to sign in.\n");
+    return;
+  }
+  process.stdout.write(`Accounts (${accounts.length}):\n`);
+  for (const a of accounts) {
+    const source = persistedIds.has(a.id) ? "persisted" : "env";
+    const label = a.label ? ` "${a.label}"` : "";
+    const active = a.isActive ? " (active)" : "";
+    process.stdout.write(
+      `  • ${a.id}${label} — @${a.username}@${a.instance} [${a.scopes.join(", ")}] (${source})${active}\n`,
+    );
+  }
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,0 +1,30 @@
+/**
+ * Subcommand router for the activitypub-mcp bin. Returns true if a subcommand
+ * was handled (caller must then exit/return instead of starting the server),
+ * false if there was no subcommand (start the MCP server as usual).
+ */
+
+import { runAccounts } from "./accounts.js";
+import { runLogin } from "./login.js";
+import { runLogout } from "./logout.js";
+
+const COMMANDS = new Set(["login", "logout", "accounts"]);
+
+export async function dispatchCli(argv: string[]): Promise<boolean> {
+  const [command, ...rest] = argv;
+  if (!command || !COMMANDS.has(command)) return false;
+
+  switch (command) {
+    case "login":
+      await runLogin(rest);
+      return true;
+    case "logout":
+      await runLogout(rest);
+      return true;
+    case "accounts":
+      await runAccounts();
+      return true;
+    default:
+      return false;
+  }
+}

--- a/src/cli/login.ts
+++ b/src/cli/login.ts
@@ -24,8 +24,13 @@ function parseFlags(rest: string[]): LoginFlags {
   const flags: LoginFlags = {};
   for (let i = 0; i < rest.length; i++) {
     const arg = rest[i];
-    if (arg === "--port") flags.port = Number.parseInt(rest[++i] ?? "", 10);
-    else if (arg === "--id") flags.id = rest[++i];
+    if (arg === "--port") {
+      const port = Number.parseInt(rest[++i] ?? "", 10);
+      if (!Number.isInteger(port) || port < 0 || port > 65535) {
+        throw new Error("--port must be an integer between 0 and 65535");
+      }
+      flags.port = port;
+    } else if (arg === "--id") flags.id = rest[++i];
     else if (arg === "--label") flags.label = rest[++i];
   }
   return flags;

--- a/src/cli/login.ts
+++ b/src/cli/login.ts
@@ -1,0 +1,84 @@
+/**
+ * `activitypub-mcp login <instance> [--port N] [--id ID] [--label L]`
+ *
+ * Validates the instance, resolves the platform login strategy, runs the
+ * interactive flow against an ephemeral loopback callback, and persists the
+ * resulting token. Never logs secrets.
+ */
+
+import { credentialStore, type StoredAccount } from "../auth/credential-store.js";
+import { openBrowser } from "../auth/login/browser.js";
+import { createLoopbackServer } from "../auth/login/loopback-server.js";
+import { resolveLoginStrategy } from "../auth/login/resolve.js";
+import { MASTODON_SCOPES, MISSKEY_PERMISSIONS } from "../auth/login/scopes.js";
+import { instanceBlocklist } from "../policy/instance-blocklist.js";
+import { DomainSchema } from "../validation/schemas.js";
+
+interface LoginFlags {
+  port?: number;
+  id?: string;
+  label?: string;
+}
+
+function parseFlags(rest: string[]): LoginFlags {
+  const flags: LoginFlags = {};
+  for (let i = 0; i < rest.length; i++) {
+    const arg = rest[i];
+    if (arg === "--port") flags.port = Number.parseInt(rest[++i] ?? "", 10);
+    else if (arg === "--id") flags.id = rest[++i];
+    else if (arg === "--label") flags.label = rest[++i];
+  }
+  return flags;
+}
+
+export async function runLogin(argv: string[]): Promise<void> {
+  const [rawInstance, ...rest] = argv;
+  if (!rawInstance) {
+    throw new Error("Usage: activitypub-mcp login <instance> [--port N] [--id ID] [--label L]");
+  }
+
+  const instance = DomainSchema.parse(rawInstance).toLowerCase();
+  instanceBlocklist.validateNotBlocked(instance);
+  const flags = parseFlags(rest);
+
+  const strategy = await resolveLoginStrategy(instance);
+  const scopes =
+    strategy.kind === "misskey" ? [...MISSKEY_PERMISSIONS] : MASTODON_SCOPES.split(" ");
+
+  const loopback = await createLoopbackServer(flags.port ?? 0);
+  try {
+    const result = await strategy.authorize({
+      instance,
+      redirectUri: loopback.redirectUri,
+      scopes,
+      openBrowser: async (url) => {
+        try {
+          await openBrowser(url);
+          process.stdout.write("→ Opening your browser to authorize…\n");
+        } catch {
+          process.stdout.write(`→ Open this URL to authorize:\n  ${url}\n`);
+        }
+      },
+      waitForCallback: (expected) => loopback.waitForCallback(expected),
+    });
+
+    const account: StoredAccount = {
+      id: flags.id ?? `${result.username.toLowerCase()}@${instance}`,
+      instance: result.instance,
+      username: result.username,
+      accessToken: result.accessToken,
+      tokenType: result.tokenType,
+      scopes: result.scopes,
+      clientId: result.clientId,
+      clientSecret: result.clientSecret,
+      label: flags.label,
+      createdAt: new Date().toISOString(),
+    };
+    await credentialStore.upsert(account);
+    process.stdout.write(
+      `✓ Authorized as @${account.username}@${account.instance} (id: ${account.id})\n`,
+    );
+  } finally {
+    loopback.close();
+  }
+}

--- a/src/cli/logout.ts
+++ b/src/cli/logout.ts
@@ -1,0 +1,37 @@
+/**
+ * `activitypub-mcp logout <id>` — revoke (Mastodon) + remove from the store.
+ */
+
+import { credentialStore } from "../auth/credential-store.js";
+import { resolveLoginStrategy } from "../auth/login/resolve.js";
+
+export async function runLogout(argv: string[]): Promise<void> {
+  const id = argv[0];
+  if (!id) throw new Error("Usage: activitypub-mcp logout <id>");
+
+  const account = await credentialStore.getAccount(id);
+  if (!account) {
+    throw new Error(
+      `No persisted account found with id "${id}". Run \`activitypub-mcp accounts\` to list.`,
+    );
+  }
+
+  const strategy = await resolveLoginStrategy(account.instance);
+  if (strategy.revoke && account.clientId && account.clientSecret) {
+    try {
+      await strategy.revoke(account);
+    } catch {
+      process.stdout.write(
+        "⚠ Server-side token revoke failed; removing the local record anyway.\n",
+      );
+    }
+  } else if (strategy.kind === "misskey") {
+    process.stdout.write(
+      "ℹ Misskey has no app-revoke endpoint; removing the local record. " +
+        "To fully revoke, delete the app token in your instance's Settings → API.\n",
+    );
+  }
+
+  await credentialStore.remove(id);
+  process.stdout.write(`✓ Logged out @${account.username}@${account.instance} (id: ${id})\n`);
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,6 +5,9 @@
  * Values can be overridden via environment variables.
  */
 
+import { homedir } from "node:os";
+import { join } from "node:path";
+
 // =============================================================================
 // Helper Functions
 // =============================================================================
@@ -38,6 +41,14 @@ export const SERVER_NAME = process.env.MCP_SERVER_NAME || "activitypub-mcp";
 
 /** MCP Server version */
 export const SERVER_VERSION = process.env.MCP_SERVER_VERSION || "2.2.0";
+
+/**
+ * Directory for the persisted credential store (accounts.json).
+ * Precedence: ACTIVITYPUB_CONFIG_DIR → $XDG_CONFIG_HOME/activitypub-mcp → ~/.config/activitypub-mcp.
+ */
+export const CONFIG_DIR =
+  process.env.ACTIVITYPUB_CONFIG_DIR ||
+  join(process.env.XDG_CONFIG_HOME || join(homedir(), ".config"), "activitypub-mcp");
 
 /** Log level for the application */
 export const LOG_LEVEL = process.env.LOG_LEVEL || "info";

--- a/src/discovery/nodeinfo.ts
+++ b/src/discovery/nodeinfo.ts
@@ -1,14 +1,8 @@
 import { getLogger } from "@logtape/logtape";
 import { z } from "zod";
-import {
-  CACHE_MAX_SIZE,
-  INSTANCE_SOFTWARE_TTL,
-  MAX_RESPONSE_SIZE,
-  REQUEST_TIMEOUT,
-  USER_AGENT,
-} from "../config.js";
+import { CACHE_MAX_SIZE, INSTANCE_SOFTWARE_TTL } from "../config.js";
 import { instanceBlocklist } from "../policy/instance-blocklist.js";
-import { fetchWithRedirectGuard, readJsonWithLimit } from "../utils/fetch-helpers.js";
+import { guardedFetch } from "../utils/fetch-helpers.js";
 import { LRUCache } from "../utils/lru-cache.js";
 import { validateExternalUrl } from "../validation/url.js";
 
@@ -214,28 +208,9 @@ export function formatInstanceSoftware(info: InstanceSoftwareInfo): string {
 }
 
 async function fetchJson(url: string): Promise<unknown> {
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), REQUEST_TIMEOUT);
-
-  try {
-    const response = await fetchWithRedirectGuard(
-      url,
-      {
-        method: "GET",
-        headers: { Accept: "application/json", "User-Agent": USER_AGENT },
-        signal: controller.signal,
-      },
-      async (target) => {
-        await validateExternalUrl(target);
-        const targetHost = new URL(target).hostname;
-        instanceBlocklist.validateNotBlocked(targetHost);
-      },
-    );
-    if (!response.ok) {
-      throw new Error(`HTTP ${response.status} ${response.statusText}`);
-    }
-    return await readJsonWithLimit(response, MAX_RESPONSE_SIZE);
-  } finally {
-    clearTimeout(timeoutId);
+  const res = await guardedFetch(url);
+  if (!res.ok) {
+    throw new Error(`HTTP ${res.status} ${res.statusText}`);
   }
+  return res.data;
 }

--- a/src/mcp-main.ts
+++ b/src/mcp-main.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { getLogger } from "@logtape/logtape";
+import { dispatchCli } from "./cli/index.js";
 import { SERVER_NAME, SERVER_VERSION, validateConfiguration } from "./config.js";
 import ActivityPubMCPServer from "./mcp-server.js";
 import "./telemetry/logging.js";
@@ -90,7 +91,17 @@ function parseArgs(): void {
  * through the Model Context Protocol.
  */
 async function main() {
-  // Parse CLI arguments first
+  // Subcommands (login/logout/accounts) run instead of the server.
+  try {
+    if (await dispatchCli(process.argv.slice(2))) {
+      return;
+    }
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+
+  // Parse remaining CLI flags (-h/-v) for the server path.
   parseArgs();
 
   try {

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -11,6 +11,7 @@
 import { getLogger } from "@logtape/logtape";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { accountManager } from "./auth/account-manager.js";
 import {
   HTTP_HOST,
   HTTP_PORT,
@@ -170,6 +171,9 @@ class ActivityPubMCPServer {
    */
   async start(transportMode?: "stdio" | "http"): Promise<void> {
     const mode = transportMode ?? CONFIG.transportMode;
+
+    // Load persisted (logged-in) accounts before serving. Never throws.
+    await accountManager.loadPersisted();
 
     if (mode === "http") {
       await this.startHttpTransport();

--- a/src/mcp/tools-write.ts
+++ b/src/mcp/tools-write.ts
@@ -88,7 +88,8 @@ function requireWriteEnabled(): void {
   if (!authenticatedClient.isWriteEnabled()) {
     throw new McpError(
       ErrorCode.InternalError,
-      "This write operation requires authentication. Configure ACTIVITYPUB_DEFAULT_INSTANCE and ACTIVITYPUB_DEFAULT_TOKEN environment variables.",
+      "This write operation requires authentication. Run `activitypub-mcp login <instance>` to sign in, " +
+        "or set ACTIVITYPUB_DEFAULT_INSTANCE and ACTIVITYPUB_DEFAULT_TOKEN environment variables.",
     );
   }
 }
@@ -102,7 +103,8 @@ function requireAuthEnabled(): void {
   if (!authenticatedClient.isWriteEnabled()) {
     throw new McpError(
       ErrorCode.InternalError,
-      "This tool requires an authenticated account. Configure ACTIVITYPUB_DEFAULT_INSTANCE and ACTIVITYPUB_DEFAULT_TOKEN environment variables.",
+      "This tool requires an authenticated account. Run `activitypub-mcp login <instance>` to sign in, " +
+        "or set ACTIVITYPUB_DEFAULT_INSTANCE and ACTIVITYPUB_DEFAULT_TOKEN environment variables.",
     );
   }
 }
@@ -308,7 +310,7 @@ function registerVerifyAccountTool(mcpServer: McpServer, rateLimiter: RateLimite
 
 Account credentials for \`${targetId}\` (@${account.username}@${account.instance}) are invalid or expired.
 
-Please update your access token.`,
+Run \`activitypub-mcp login ${account.instance}\` to re-authorize.`,
               },
             ],
             isError: true,

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -145,3 +145,23 @@ export class UnsupportedOnPlatformError extends Error {
     this.name = "UnsupportedOnPlatformError";
   }
 }
+
+/**
+ * Thrown when an authenticated request is rejected with HTTP 401 — the token was
+ * revoked or expired. (403 is NOT treated as token rejection: it is also used for
+ * per-operation permission/scope errors that adapters must surface verbatim, e.g.
+ * Misskey's `{error:{message}}` body.) Carries the account identity so the message
+ * can point the user at the exact re-login command.
+ */
+export class TokenRejectedError extends Error {
+  constructor(
+    public readonly instance: string,
+    public readonly username: string,
+  ) {
+    super(
+      `The token for @${username}@${instance} was rejected (revoked or expired). ` +
+        `Run \`activitypub-mcp login ${instance}\` to re-authorize.`,
+    );
+    this.name = "TokenRejectedError";
+  }
+}

--- a/src/utils/fetch-helpers.ts
+++ b/src/utils/fetch-helpers.ts
@@ -184,8 +184,11 @@ export async function guardedFetch<T = unknown>(
     if (response.status !== 204) {
       try {
         data = await readJsonWithLimit<T>(response, MAX_RESPONSE_SIZE);
-      } catch {
-        data = undefined; // empty / non-JSON body
+      } catch (error) {
+        // A too-large body is a real failure callers must see — don't mask it as
+        // a successful empty response. Only an empty / non-JSON body → undefined.
+        if (error instanceof ResponseTooLargeError) throw error;
+        data = undefined;
       }
     }
     return { ok: response.ok, status: response.status, statusText: response.statusText, data };

--- a/src/utils/fetch-helpers.ts
+++ b/src/utils/fetch-helpers.ts
@@ -7,6 +7,10 @@
  * whether the server sent an accurate Content-Length header.
  */
 
+import { MAX_RESPONSE_SIZE, REQUEST_TIMEOUT, USER_AGENT } from "../config.js";
+import { instanceBlocklist } from "../policy/instance-blocklist.js";
+import { validateExternalUrl } from "../validation/url.js";
+
 /**
  * Fetch wrapper that follows up to `maxHops` redirects, but re-runs the
  * caller-supplied `validate` function on every redirect target before
@@ -124,4 +128,68 @@ export async function readJsonWithLimit<T = unknown>(
   }
   const text = new TextDecoder("utf-8").decode(merged);
   return JSON.parse(text) as T;
+}
+
+export interface GuardedFetchOptions {
+  method?: string;
+  headers?: Record<string, string>;
+  body?: string;
+  timeoutMs?: number;
+}
+
+export interface GuardedResponse<T> {
+  ok: boolean;
+  status: number;
+  statusText: string;
+  /** Parsed JSON body, or undefined if the body was empty / not JSON. */
+  data: T | undefined;
+}
+
+/**
+ * Guarded UNauthenticated fetch: SSRF allow-list + operator blocklist on the
+ * initial URL and every redirect hop, abort/timeout, streaming size cap, and
+ * best-effort JSON parsing. Used by NodeInfo discovery and the login flows'
+ * pre-token calls (which have no Bearer token, so they can't use
+ * authenticatedFetch).
+ */
+export async function guardedFetch<T = unknown>(
+  url: string,
+  options: GuardedFetchOptions = {},
+): Promise<GuardedResponse<T>> {
+  await validateExternalUrl(url);
+  instanceBlocklist.validateNotBlocked(new URL(url).hostname);
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), options.timeoutMs ?? REQUEST_TIMEOUT);
+  try {
+    const response = await fetchWithRedirectGuard(
+      url,
+      {
+        method: options.method ?? "GET",
+        headers: {
+          Accept: "application/json",
+          "User-Agent": USER_AGENT,
+          ...options.headers,
+        },
+        body: options.body,
+        signal: controller.signal,
+      },
+      async (target) => {
+        await validateExternalUrl(target);
+        instanceBlocklist.validateNotBlocked(new URL(target).hostname);
+      },
+    );
+
+    let data: T | undefined;
+    if (response.status !== 204) {
+      try {
+        data = await readJsonWithLimit<T>(response, MAX_RESPONSE_SIZE);
+      } catch {
+        data = undefined; // empty / non-JSON body
+      }
+    }
+    return { ok: response.ok, status: response.status, statusText: response.statusText, data };
+  } finally {
+    clearTimeout(timeoutId);
+  }
 }

--- a/tests/unit/account-manager.test.ts
+++ b/tests/unit/account-manager.test.ts
@@ -356,7 +356,11 @@ describe("AccountManager.loadPersisted", () => {
     const { AccountManager } = await import("../../src/auth/account-manager.js");
     const manager = new AccountManager();
     await manager.loadPersisted(store);
-    expect(manager.getAccount("bob@misskey.test")?.username).toBe("bob");
+    const acct = manager.getAccount("bob@misskey.test");
+    expect(acct?.username).toBe("bob");
+    expect(acct?.instance).toBe("misskey.test");
+    expect(acct?.accessToken).toBe("tok");
+    expect(acct?.scopes).toEqual(["read:account"]);
   });
 
   it("env-var account wins on id collision (persisted skipped)", async () => {

--- a/tests/unit/account-manager.test.ts
+++ b/tests/unit/account-manager.test.ts
@@ -317,6 +317,77 @@ describe("verifyAccount SSRF protection (M8)", () => {
   });
 });
 
+describe("AccountManager.loadPersisted", () => {
+  const originalEnv = process.env;
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = { ...originalEnv };
+    delete process.env.ACTIVITYPUB_DEFAULT_INSTANCE;
+    delete process.env.ACTIVITYPUB_DEFAULT_TOKEN;
+    delete process.env.ACTIVITYPUB_ACCOUNTS;
+  });
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  async function withStore() {
+    const { mkdtempSync } = await import("node:fs");
+    const { tmpdir } = await import("node:os");
+    const { join } = await import("node:path");
+    const dir = mkdtempSync(join(tmpdir(), "apmcp-lp-"));
+    process.env.ACTIVITYPUB_CONFIG_DIR = join(dir, "cfg");
+    const { CredentialStore } = await import(
+      /* @vite-ignore */ `../../src/auth/credential-store.js?ts=${Date.now()}-${Math.random().toString(36).slice(2)}`
+    );
+    return new CredentialStore();
+  }
+
+  it("loads persisted accounts into the manager", async () => {
+    const store = await withStore();
+    await store.upsert({
+      id: "bob@misskey.test",
+      instance: "misskey.test",
+      username: "bob",
+      accessToken: "tok",
+      tokenType: "Bearer",
+      scopes: ["read:account"],
+      createdAt: "2026-01-01T00:00:00.000Z",
+    });
+    const { AccountManager } = await import("../../src/auth/account-manager.js");
+    const manager = new AccountManager();
+    await manager.loadPersisted(store);
+    expect(manager.getAccount("bob@misskey.test")?.username).toBe("bob");
+  });
+
+  it("env-var account wins on id collision (persisted skipped)", async () => {
+    process.env.ACTIVITYPUB_DEFAULT_INSTANCE = "env.test";
+    process.env.ACTIVITYPUB_DEFAULT_TOKEN = "env-token";
+    const store = await withStore();
+    await store.upsert({
+      id: "default",
+      instance: "persisted.test",
+      username: "persisted",
+      accessToken: "persisted-token",
+      tokenType: "Bearer",
+      scopes: ["read"],
+      createdAt: "2026-01-01T00:00:00.000Z",
+    });
+    const { AccountManager } = await import("../../src/auth/account-manager.js");
+    const manager = new AccountManager();
+    await manager.loadPersisted(store);
+    expect(manager.getAccount("default")?.instance).toBe("env.test");
+  });
+
+  it("never throws if the store read fails", async () => {
+    const { AccountManager } = await import("../../src/auth/account-manager.js");
+    const manager = new AccountManager();
+    const brokenStore = {
+      loadAccounts: () => Promise.reject(new Error("disk gone")),
+    } as unknown as { loadAccounts: () => Promise<never> };
+    await expect(manager.loadPersisted(brokenStore as never)).resolves.toBeUndefined();
+  });
+});
+
 describe("verifyAccount delegates to the platform adapter", () => {
   const originalEnv = process.env;
   beforeEach(() => {

--- a/tests/unit/authenticated-client.test.ts
+++ b/tests/unit/authenticated-client.test.ts
@@ -6,9 +6,10 @@ import { HttpResponse, http } from "msw";
 import { setupServer } from "msw/node";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { accountManager } from "../../src/auth/account-manager.js";
+import { authenticatedFetch } from "../../src/auth/adapters/write-adapter.js";
 import { AuthenticatedClient } from "../../src/auth/authenticated-client.js";
 import { getInstanceSoftware } from "../../src/discovery/nodeinfo.js";
-import { UnsupportedOnPlatformError } from "../../src/utils/errors.js";
+import { TokenRejectedError, UnsupportedOnPlatformError } from "../../src/utils/errors.js";
 
 // Mock logtape
 vi.mock("@logtape/logtape", () => ({
@@ -1115,5 +1116,27 @@ describe("AuthenticatedClient response size cap (M2)", () => {
     await expect(client.createPost({ content: "hi", visibility: "public" })).rejects.toBeInstanceOf(
       ResponseTooLargeError,
     );
+  });
+});
+
+describe("authenticatedFetch token rejection", () => {
+  const account = {
+    id: "a",
+    instance: "example.social",
+    username: "alice",
+    accessToken: "tok",
+    tokenType: "Bearer",
+    scopes: ["read", "write"],
+    createdAt: "2026-01-01T00:00:00.000Z",
+  };
+
+  it("throws TokenRejectedError on HTTP 401", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response("nope", { status: 401 }));
+    await expect(
+      authenticatedFetch(account, "/api/v1/accounts/verify_credentials"),
+    ).rejects.toBeInstanceOf(TokenRejectedError);
+    fetchSpy.mockRestore();
   });
 });

--- a/tests/unit/browser.test.ts
+++ b/tests/unit/browser.test.ts
@@ -1,14 +1,31 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const spawnMock = vi.fn();
+// Controls which lifecycle event the fake child emits (set per test).
+let childEvent: { type: "spawn" } | { type: "error"; error: Error } = { type: "spawn" };
+
 vi.mock("node:child_process", () => ({
   spawn: (...args: unknown[]) => {
     spawnMock(...args);
-    return { on: vi.fn(), unref: vi.fn() };
+    const handlers: Record<string, (a?: unknown) => void> = {};
+    // Fire the configured event asynchronously, like a real child process.
+    queueMicrotask(() => {
+      if (childEvent.type === "error") handlers.error?.(childEvent.error);
+      else handlers.spawn?.();
+    });
+    return {
+      once: (event: string, cb: (a?: unknown) => void) => {
+        handlers[event] = cb;
+      },
+      unref: vi.fn(),
+    };
   },
 }));
 
 describe("openBrowser", () => {
+  beforeEach(() => {
+    childEvent = { type: "spawn" };
+  });
   afterEach(() => {
     spawnMock.mockReset();
     vi.unstubAllGlobals();
@@ -33,5 +50,25 @@ describe("openBrowser", () => {
     );
     await openBrowser("https://x.test/");
     expect(spawnMock.mock.calls[0][0]).toBe("xdg-open");
+  });
+
+  it("uses cmd /c start on win32 with the URL as a discrete arg", async () => {
+    vi.stubGlobal("process", { ...process, platform: "win32" });
+    const { openBrowser } = await import(
+      /* @vite-ignore */ `../../src/auth/login/browser.js?ts=${Date.now()}`
+    );
+    await openBrowser("https://x.test/?a=1&b=2");
+    const [cmd, args] = spawnMock.mock.calls[0];
+    expect(cmd).toBe("cmd");
+    expect(args).toEqual(["/c", "start", "", "https://x.test/?a=1&b=2"]);
+  });
+
+  it("rejects when the opener cannot be spawned (so the caller can fall back)", async () => {
+    vi.stubGlobal("process", { ...process, platform: "linux" });
+    childEvent = { type: "error", error: new Error("ENOENT xdg-open") };
+    const { openBrowser } = await import(
+      /* @vite-ignore */ `../../src/auth/login/browser.js?ts=${Date.now()}`
+    );
+    await expect(openBrowser("https://x.test/")).rejects.toThrow(/ENOENT/);
   });
 });

--- a/tests/unit/browser.test.ts
+++ b/tests/unit/browser.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const spawnMock = vi.fn();
+vi.mock("node:child_process", () => ({
+  spawn: (...args: unknown[]) => {
+    spawnMock(...args);
+    return { on: vi.fn(), unref: vi.fn() };
+  },
+}));
+
+describe("openBrowser", () => {
+  afterEach(() => {
+    spawnMock.mockReset();
+    vi.unstubAllGlobals();
+  });
+
+  it("passes the URL as a discrete argv item (no shell string)", async () => {
+    vi.stubGlobal("process", { ...process, platform: "darwin" });
+    const { openBrowser } = await import(
+      /* @vite-ignore */ `../../src/auth/login/browser.js?ts=${Date.now()}`
+    );
+    const url = "https://x.test/oauth/authorize?state=a&scope=read%20write&x=^%";
+    await openBrowser(url);
+    const [cmd, args] = spawnMock.mock.calls[0];
+    expect(cmd).toBe("open");
+    expect(args).toContain(url); // exact URL, never interpolated into a shell string
+  });
+
+  it("uses xdg-open on linux", async () => {
+    vi.stubGlobal("process", { ...process, platform: "linux" });
+    const { openBrowser } = await import(
+      /* @vite-ignore */ `../../src/auth/login/browser.js?ts=${Date.now()}`
+    );
+    await openBrowser("https://x.test/");
+    expect(spawnMock.mock.calls[0][0]).toBe("xdg-open");
+  });
+});

--- a/tests/unit/cli-accounts.test.ts
+++ b/tests/unit/cli-accounts.test.ts
@@ -1,0 +1,80 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("runLogout / runAccounts", () => {
+  const originalEnv = process.env;
+  let out: string;
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = { ...originalEnv };
+    const dir = mkdtempSync(join(tmpdir(), "apmcp-acc-"));
+    process.env.ACTIVITYPUB_CONFIG_DIR = join(dir, "cfg");
+    delete process.env.ACTIVITYPUB_DEFAULT_INSTANCE;
+    delete process.env.ACTIVITYPUB_DEFAULT_TOKEN;
+    delete process.env.ACTIVITYPUB_ACCOUNTS;
+    out = "";
+    vi.spyOn(process.stdout, "write").mockImplementation((chunk: string | Uint8Array) => {
+      out += chunk.toString();
+      return true;
+    });
+  });
+  afterEach(() => {
+    process.env = originalEnv;
+    vi.restoreAllMocks();
+  });
+
+  const mastodonAccount = {
+    id: "alice@mastodon.test",
+    instance: "mastodon.test",
+    username: "alice",
+    accessToken: "tok",
+    tokenType: "Bearer",
+    scopes: ["read", "write"],
+    clientId: "cid",
+    clientSecret: "csecret",
+    createdAt: "2026-01-01T00:00:00.000Z",
+  };
+
+  it("logout revokes (Mastodon) and removes the account", async () => {
+    const { credentialStore } = await import("../../src/auth/credential-store.js");
+    await credentialStore.upsert(mastodonAccount);
+
+    const revoke = vi.fn().mockResolvedValue(undefined);
+    vi.doMock("../../src/auth/login/resolve.js", () => ({
+      resolveLoginStrategy: vi.fn().mockResolvedValue({ kind: "mastodon", revoke }),
+    }));
+    const { runLogout } = await import("../../src/cli/logout.js");
+    await runLogout(["alice@mastodon.test"]);
+
+    expect(revoke).toHaveBeenCalledTimes(1);
+    expect(await credentialStore.getAccount("alice@mastodon.test")).toBeUndefined();
+  });
+
+  it("logout errors clearly for an unknown id", async () => {
+    const { runLogout } = await import("../../src/cli/logout.js");
+    await expect(runLogout(["nope"])).rejects.toThrow(/not found|no persisted/i);
+  });
+
+  it("accounts lists persisted accounts (tagged) without secrets", async () => {
+    const { credentialStore } = await import("../../src/auth/credential-store.js");
+    await credentialStore.upsert(mastodonAccount);
+    const { runAccounts } = await import("../../src/cli/accounts.js");
+    await runAccounts();
+    expect(out).toContain("alice@mastodon.test");
+    expect(out).toContain("(persisted)");
+    expect(out).not.toContain("tok");
+    expect(out).not.toContain("csecret");
+  });
+
+  it("accounts merges env accounts, tagged (env)", async () => {
+    process.env.ACTIVITYPUB_DEFAULT_INSTANCE = "env.test";
+    process.env.ACTIVITYPUB_DEFAULT_TOKEN = "env-token";
+    const { runAccounts } = await import("../../src/cli/accounts.js");
+    await runAccounts();
+    expect(out).toContain("env.test");
+    expect(out).toContain("(env)");
+    expect(out).not.toContain("env-token");
+  });
+});

--- a/tests/unit/cli-dispatch.test.ts
+++ b/tests/unit/cli-dispatch.test.ts
@@ -1,0 +1,28 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../src/cli/login.js", () => ({ runLogin: vi.fn().mockResolvedValue(undefined) }));
+vi.mock("../../src/cli/logout.js", () => ({ runLogout: vi.fn().mockResolvedValue(undefined) }));
+vi.mock("../../src/cli/accounts.js", () => ({ runAccounts: vi.fn().mockResolvedValue(undefined) }));
+
+import { runAccounts } from "../../src/cli/accounts.js";
+import { dispatchCli } from "../../src/cli/index.js";
+import { runLogin } from "../../src/cli/login.js";
+
+afterEach(() => vi.clearAllMocks());
+
+describe("dispatchCli", () => {
+  it("routes login and reports handled=true", async () => {
+    expect(await dispatchCli(["login", "mastodon.test"])).toBe(true);
+    expect(runLogin).toHaveBeenCalledWith(["mastodon.test"]);
+  });
+
+  it("routes accounts", async () => {
+    expect(await dispatchCli(["accounts"])).toBe(true);
+    expect(runAccounts).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns false for no subcommand (server should start)", async () => {
+    expect(await dispatchCli([])).toBe(false);
+    expect(await dispatchCli(["--version"])).toBe(false);
+  });
+});

--- a/tests/unit/cli-dispatch.test.ts
+++ b/tests/unit/cli-dispatch.test.ts
@@ -7,6 +7,7 @@ vi.mock("../../src/cli/accounts.js", () => ({ runAccounts: vi.fn().mockResolvedV
 import { runAccounts } from "../../src/cli/accounts.js";
 import { dispatchCli } from "../../src/cli/index.js";
 import { runLogin } from "../../src/cli/login.js";
+import { runLogout } from "../../src/cli/logout.js";
 
 afterEach(() => vi.clearAllMocks());
 
@@ -14,6 +15,11 @@ describe("dispatchCli", () => {
   it("routes login and reports handled=true", async () => {
     expect(await dispatchCli(["login", "mastodon.test"])).toBe(true);
     expect(runLogin).toHaveBeenCalledWith(["mastodon.test"]);
+  });
+
+  it("routes logout", async () => {
+    expect(await dispatchCli(["logout", "alice@mastodon.test"])).toBe(true);
+    expect(runLogout).toHaveBeenCalledWith(["alice@mastodon.test"]);
   });
 
   it("routes accounts", async () => {

--- a/tests/unit/cli-login.test.ts
+++ b/tests/unit/cli-login.test.ts
@@ -62,4 +62,9 @@ describe("runLogin", () => {
     await expect(runLogin(["not a domain"])).rejects.toThrow();
     expect(resolveLoginStrategy).not.toHaveBeenCalled();
   });
+
+  it("rejects a non-numeric --port", async () => {
+    const { runLogin } = await import(/* @vite-ignore */ "../../src/cli/login.js");
+    await expect(runLogin(["mastodon.test", "--port", "abc"])).rejects.toThrow(/--port must be/);
+  });
 });

--- a/tests/unit/cli-login.test.ts
+++ b/tests/unit/cli-login.test.ts
@@ -1,0 +1,65 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../src/auth/login/resolve.js", () => ({
+  resolveLoginStrategy: vi.fn(),
+}));
+vi.mock("../../src/auth/login/loopback-server.js", () => ({
+  createLoopbackServer: vi.fn(),
+}));
+vi.mock("../../src/auth/login/browser.js", () => ({
+  openBrowser: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { createLoopbackServer } from "../../src/auth/login/loopback-server.js";
+import { resolveLoginStrategy } from "../../src/auth/login/resolve.js";
+
+describe("runLogin", () => {
+  const originalEnv = process.env;
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = { ...originalEnv };
+    const dir = mkdtempSync(join(tmpdir(), "apmcp-cli-"));
+    process.env.ACTIVITYPUB_CONFIG_DIR = join(dir, "cfg");
+  });
+  afterEach(() => {
+    process.env = originalEnv;
+    vi.clearAllMocks();
+  });
+
+  it("runs the strategy and persists the resulting account", async () => {
+    vi.mocked(createLoopbackServer).mockResolvedValue({
+      redirectUri: "http://127.0.0.1:7777/callback",
+      waitForCallback: vi.fn(),
+      close: vi.fn(),
+    });
+    const authorize = vi.fn().mockResolvedValue({
+      instance: "mastodon.test",
+      username: "alice",
+      accessToken: "tok",
+      tokenType: "Bearer",
+      scopes: ["read", "write", "follow"],
+      clientId: "cid",
+      clientSecret: "csecret",
+    });
+    vi.mocked(resolveLoginStrategy).mockResolvedValue({ kind: "mastodon", authorize } as never);
+
+    const { runLogin } = await import(/* @vite-ignore */ "../../src/cli/login.js");
+    await runLogin(["mastodon.test"]);
+
+    const { credentialStore } = await import(
+      /* @vite-ignore */ "../../src/auth/credential-store.js"
+    );
+    const stored = await credentialStore.getAccount("alice@mastodon.test");
+    expect(stored?.accessToken).toBe("tok");
+    expect(stored?.instance).toBe("mastodon.test");
+  });
+
+  it("rejects an invalid instance domain before opening a browser", async () => {
+    const { runLogin } = await import(/* @vite-ignore */ "../../src/cli/login.js");
+    await expect(runLogin(["not a domain"])).rejects.toThrow();
+    expect(resolveLoginStrategy).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/credential-store.test.ts
+++ b/tests/unit/credential-store.test.ts
@@ -2,7 +2,16 @@
  * Unit tests for the on-disk credential store.
  */
 
-import { mkdtempSync, readFileSync, statSync } from "node:fs";
+import {
+  chmodSync,
+  existsSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  statSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -87,5 +96,59 @@ describe("CredentialStore", () => {
     expect(await store.remove("alice@mastodon.test")).toBe(true);
     expect(await store.remove("alice@mastodon.test")).toBe(false);
     expect(await store.loadAccounts()).toEqual([]);
+  });
+});
+
+describe("CredentialStore hardening", () => {
+  const originalEnv = process.env;
+  beforeEach(() => {
+    vi.resetModules(); // force config.js to re-read ACTIVITYPUB_CONFIG_DIR per test
+    process.env = { ...originalEnv };
+  });
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("relaxes an over-permissive file back to 0600 on load", async () => {
+    const { CredentialStore } = await freshStore();
+    const store = new CredentialStore();
+    await store.upsert(sample);
+    const filePath = join(process.env.ACTIVITYPUB_CONFIG_DIR as string, "accounts.json");
+    chmodSync(filePath, 0o644);
+
+    await store.loadAccounts();
+    const mode = statSync(filePath).mode & 0o777;
+    expect(mode).toBe(0o600);
+  });
+
+  it("refuses to read a symlinked accounts file", async () => {
+    const { CredentialStore } = await freshStore();
+    const cfg = process.env.ACTIVITYPUB_CONFIG_DIR as string;
+    mkdtempSync; // noop to keep import; real dir below
+    const target = join(dir, "evil.json");
+    writeFileSync(target, JSON.stringify({ version: 1, accounts: [] }));
+    // Build the config dir and symlink accounts.json -> evil.json.
+    const store = new CredentialStore();
+    await store.upsert(sample); // creates cfg + a real file
+    const filePath = join(cfg, "accounts.json");
+    // Replace with a symlink.
+    const { rmSync } = await import("node:fs");
+    rmSync(filePath);
+    symlinkSync(target, filePath);
+
+    await expect(store.loadAccounts()).rejects.toThrow(/symlink|refus/i);
+  });
+
+  it("preserves a malformed file as .corrupt and returns []", async () => {
+    const { CredentialStore } = await freshStore();
+    const store = new CredentialStore();
+    await store.upsert(sample);
+    const filePath = join(process.env.ACTIVITYPUB_CONFIG_DIR as string, "accounts.json");
+    writeFileSync(filePath, "{ this is not valid json");
+
+    expect(await store.loadAccounts()).toEqual([]);
+    const dirContents = readdirSync(process.env.ACTIVITYPUB_CONFIG_DIR as string);
+    expect(dirContents.some((f) => f.startsWith("accounts.json.corrupt-"))).toBe(true);
+    expect(existsSync(filePath)).toBe(false);
   });
 });

--- a/tests/unit/credential-store.test.ts
+++ b/tests/unit/credential-store.test.ts
@@ -16,6 +16,10 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+// Windows can't represent POSIX file modes — chmod() only toggles the read-only
+// bit, so a 0600 file reads back as 0666. The 0600 guarantee is POSIX-only.
+const isWindows = process.platform === "win32";
+
 let dir: string;
 
 function freshStore() {
@@ -65,8 +69,10 @@ describe("CredentialStore", () => {
     expect(loaded[0]).toEqual(sample);
 
     const filePath = join(process.env.ACTIVITYPUB_CONFIG_DIR as string, "accounts.json");
-    const mode = statSync(filePath).mode & 0o777;
-    expect(mode).toBe(0o600);
+    if (!isWindows) {
+      const mode = statSync(filePath).mode & 0o777;
+      expect(mode).toBe(0o600);
+    }
     // File must be parseable JSON.
     expect(() => JSON.parse(readFileSync(filePath, "utf-8"))).not.toThrow();
   });
@@ -109,7 +115,7 @@ describe("CredentialStore hardening", () => {
     process.env = originalEnv;
   });
 
-  it("relaxes an over-permissive file back to 0600 on load", async () => {
+  it.skipIf(isWindows)("relaxes an over-permissive file back to 0600 on load", async () => {
     const { CredentialStore } = await freshStore();
     const store = new CredentialStore();
     await store.upsert(sample);

--- a/tests/unit/credential-store.test.ts
+++ b/tests/unit/credential-store.test.ts
@@ -124,7 +124,6 @@ describe("CredentialStore hardening", () => {
   it("refuses to read a symlinked accounts file", async () => {
     const { CredentialStore } = await freshStore();
     const cfg = process.env.ACTIVITYPUB_CONFIG_DIR as string;
-    mkdtempSync; // noop to keep import; real dir below
     const target = join(dir, "evil.json");
     writeFileSync(target, JSON.stringify({ version: 1, accounts: [] }));
     // Build the config dir and symlink accounts.json -> evil.json.

--- a/tests/unit/credential-store.test.ts
+++ b/tests/unit/credential-store.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Unit tests for the on-disk credential store.
+ */
+
+import { mkdtempSync, readFileSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+let dir: string;
+
+function freshStore() {
+  // Re-import with a per-test CONFIG_DIR (config reads env at import time).
+  dir = mkdtempSync(join(tmpdir(), "apmcp-store-"));
+  process.env.ACTIVITYPUB_CONFIG_DIR = join(dir, "config");
+  return import(
+    /* @vite-ignore */ `../../src/auth/credential-store.js?ts=${Date.now()}-${Math.random().toString(36).slice(2)}`
+  );
+}
+
+const sample = {
+  id: "alice@mastodon.test",
+  instance: "mastodon.test",
+  username: "alice",
+  accessToken: "tok-123",
+  tokenType: "Bearer",
+  scopes: ["read", "write", "follow"],
+  clientId: "cid",
+  clientSecret: "csecret",
+  createdAt: "2026-01-01T00:00:00.000Z",
+};
+
+describe("CredentialStore", () => {
+  const originalEnv = process.env;
+  beforeEach(() => {
+    vi.resetModules(); // force config.js to re-read ACTIVITYPUB_CONFIG_DIR per test
+    process.env = { ...originalEnv };
+  });
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("returns an empty list when the file is absent", async () => {
+    const { CredentialStore } = await freshStore();
+    const store = new CredentialStore();
+    expect(await store.loadAccounts()).toEqual([]);
+  });
+
+  it("upserts and loads an account, writing the file 0600", async () => {
+    const { CredentialStore } = await freshStore();
+    const store = new CredentialStore();
+    await store.upsert(sample);
+
+    const loaded = await store.loadAccounts();
+    expect(loaded).toHaveLength(1);
+    expect(loaded[0]).toEqual(sample);
+
+    const filePath = join(process.env.ACTIVITYPUB_CONFIG_DIR as string, "accounts.json");
+    const mode = statSync(filePath).mode & 0o777;
+    expect(mode).toBe(0o600);
+    // File must be parseable JSON.
+    expect(() => JSON.parse(readFileSync(filePath, "utf-8"))).not.toThrow();
+  });
+
+  it("upsert replaces an existing id", async () => {
+    const { CredentialStore } = await freshStore();
+    const store = new CredentialStore();
+    await store.upsert(sample);
+    await store.upsert({ ...sample, accessToken: "tok-NEW" });
+    const loaded = await store.loadAccounts();
+    expect(loaded).toHaveLength(1);
+    expect(loaded[0].accessToken).toBe("tok-NEW");
+  });
+
+  it("get returns one account or undefined", async () => {
+    const { CredentialStore } = await freshStore();
+    const store = new CredentialStore();
+    await store.upsert(sample);
+    expect((await store.getAccount("alice@mastodon.test"))?.username).toBe("alice");
+    expect(await store.getAccount("nope")).toBeUndefined();
+  });
+
+  it("remove deletes by id and reports success", async () => {
+    const { CredentialStore } = await freshStore();
+    const store = new CredentialStore();
+    await store.upsert(sample);
+    expect(await store.remove("alice@mastodon.test")).toBe(true);
+    expect(await store.remove("alice@mastodon.test")).toBe(false);
+    expect(await store.loadAccounts()).toEqual([]);
+  });
+});

--- a/tests/unit/guarded-fetch.test.ts
+++ b/tests/unit/guarded-fetch.test.ts
@@ -1,0 +1,59 @@
+import { HttpResponse, http } from "msw";
+import { setupServer } from "msw/node";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { guardedFetch } from "../../src/utils/fetch-helpers.js";
+
+vi.mock("../../src/validation/url.js", () => ({
+  validateExternalUrl: vi.fn().mockResolvedValue(undefined),
+}));
+
+const server = setupServer();
+beforeAll(() => server.listen({ onUnhandledRequest: "bypass" }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+describe("guardedFetch", () => {
+  it("performs a GET and parses JSON by default", async () => {
+    server.use(http.get("https://x.test/thing", () => HttpResponse.json({ a: 1 })));
+    const res = await guardedFetch<{ a: number }>("https://x.test/thing");
+    expect(res.ok).toBe(true);
+    expect(res.status).toBe(200);
+    expect(res.data).toEqual({ a: 1 });
+  });
+
+  it("sends a form-encoded POST body and reads JSON", async () => {
+    let contentType: string | null = null;
+    let body = "";
+    server.use(
+      http.post("https://x.test/token", async ({ request }) => {
+        contentType = request.headers.get("content-type");
+        body = await request.text();
+        return HttpResponse.json({ access_token: "t" });
+      }),
+    );
+    const res = await guardedFetch<{ access_token: string }>("https://x.test/token", {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({ grant_type: "authorization_code", code: "c" }).toString(),
+    });
+    expect(contentType).toContain("application/x-www-form-urlencoded");
+    expect(body).toContain("grant_type=authorization_code");
+    expect(res.data?.access_token).toBe("t");
+  });
+
+  it("returns ok:false with parsed error body on 4xx", async () => {
+    server.use(
+      http.post("https://x.test/fail", () =>
+        HttpResponse.json({ error: { message: "nope" } }, { status: 403 }),
+      ),
+    );
+    const res = await guardedFetch<{ error: { message: string } }>("https://x.test/fail", {
+      method: "POST",
+      body: "{}",
+      headers: { "Content-Type": "application/json" },
+    });
+    expect(res.ok).toBe(false);
+    expect(res.status).toBe(403);
+    expect(res.data?.error.message).toBe("nope");
+  });
+});

--- a/tests/unit/login-resolve.test.ts
+++ b/tests/unit/login-resolve.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../src/discovery/nodeinfo.js", () => ({
+  getInstanceSoftware: vi.fn(),
+}));
+
+import { mastodonOAuthStrategy } from "../../src/auth/login/mastodon-oauth.js";
+import { misskeyMiAuthStrategy } from "../../src/auth/login/miauth.js";
+import { resolveLoginStrategy } from "../../src/auth/login/resolve.js";
+import { getInstanceSoftware } from "../../src/discovery/nodeinfo.js";
+
+function detected(name: string | null) {
+  return {
+    domain: "x.test",
+    detection: name ? "success" : "unavailable",
+    software: name ? { name, version: "1" } : null,
+    protocols: name ? ["activitypub"] : null,
+    openRegistrations: null,
+  };
+}
+
+afterEach(() => vi.clearAllMocks());
+
+describe("resolveLoginStrategy", () => {
+  it.each([
+    ["misskey", misskeyMiAuthStrategy],
+    ["Misskey", misskeyMiAuthStrategy],
+    ["foundkey", misskeyMiAuthStrategy],
+    ["mastodon", mastodonOAuthStrategy],
+    ["pleroma", mastodonOAuthStrategy],
+    ["sharkey", mastodonOAuthStrategy],
+    ["firefish", mastodonOAuthStrategy],
+    ["gotosocial", mastodonOAuthStrategy],
+    ["totally-unknown", mastodonOAuthStrategy],
+  ])("maps %s to the right strategy", async (name, expected) => {
+    vi.mocked(getInstanceSoftware).mockResolvedValue(detected(name) as never);
+    expect(await resolveLoginStrategy("x.test")).toBe(expected);
+  });
+
+  it("defaults to Mastodon when detection is unavailable", async () => {
+    vi.mocked(getInstanceSoftware).mockResolvedValue(detected(null) as never);
+    expect(await resolveLoginStrategy("x.test")).toBe(mastodonOAuthStrategy);
+  });
+});

--- a/tests/unit/loopback-server.test.ts
+++ b/tests/unit/loopback-server.test.ts
@@ -23,9 +23,11 @@ describe("createLoopbackServer", () => {
   it("does NOT resolve on a mismatched state (responds 404)", async () => {
     const lb = await createLoopbackServer();
     let resolved = false;
-    lb.waitForCallback({ state: "abc" }).then(() => {
-      resolved = true;
-    });
+    lb.waitForCallback({ state: "abc" })
+      .then(() => {
+        resolved = true;
+      })
+      .catch(() => {}); // close() doesn't reject today; stay unhandled-rejection-safe
     const res = await fetch(`${lb.redirectUri}?code=xyz&state=WRONG`);
     expect(res.status).toBe(404);
     await new Promise((r) => setTimeout(r, 20));

--- a/tests/unit/loopback-server.test.ts
+++ b/tests/unit/loopback-server.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { createLoopbackServer } from "../../src/auth/login/loopback-server.js";
+
+describe("createLoopbackServer", () => {
+  it("binds 127.0.0.1 with an ephemeral port and a /callback redirect URI", async () => {
+    const lb = await createLoopbackServer();
+    try {
+      expect(lb.redirectUri).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/callback$/);
+    } finally {
+      lb.close();
+    }
+  });
+
+  it("resolves with the query when state matches", async () => {
+    const lb = await createLoopbackServer();
+    const pending = lb.waitForCallback({ state: "abc" });
+    await fetch(`${lb.redirectUri}?code=xyz&state=abc`);
+    const params = await pending;
+    expect(params.get("code")).toBe("xyz");
+    lb.close();
+  });
+
+  it("does NOT resolve on a mismatched state (responds 404)", async () => {
+    const lb = await createLoopbackServer();
+    let resolved = false;
+    lb.waitForCallback({ state: "abc" }).then(() => {
+      resolved = true;
+    });
+    const res = await fetch(`${lb.redirectUri}?code=xyz&state=WRONG`);
+    expect(res.status).toBe(404);
+    await new Promise((r) => setTimeout(r, 20));
+    expect(resolved).toBe(false);
+    lb.close();
+  });
+
+  it("matches on session for the MiAuth flow", async () => {
+    const lb = await createLoopbackServer();
+    const pending = lb.waitForCallback({ session: "sess-1" });
+    await fetch(`${lb.redirectUri}?session=sess-1`);
+    const params = await pending;
+    expect(params.get("session")).toBe("sess-1");
+    lb.close();
+  });
+
+  it("rejects after the timeout", async () => {
+    const lb = await createLoopbackServer();
+    await expect(lb.waitForCallback({ state: "abc", timeoutMs: 30 })).rejects.toThrow(/timed out/i);
+    lb.close();
+  });
+});

--- a/tests/unit/mastodon-oauth.test.ts
+++ b/tests/unit/mastodon-oauth.test.ts
@@ -91,6 +91,27 @@ describe("MastodonOAuthStrategy.authorize", () => {
     );
     await expect(strategy.authorize(ctx())).rejects.toThrow(/bad client|422/);
   });
+
+  it("rejects on an issuer (iss) mismatch (mix-up defense)", async () => {
+    server.use(
+      http.post("https://mastodon.test/api/v1/apps", () =>
+        HttpResponse.json({ client_id: "cid", client_secret: "csecret" }),
+      ),
+    );
+    await expect(
+      strategy.authorize(
+        ctx({
+          waitForCallback: vi.fn(async (exp: { state?: string }) => {
+            const p = new URLSearchParams();
+            p.set("code", "auth-code");
+            if (exp.state) p.set("state", exp.state);
+            p.set("iss", "https://evil.test"); // wrong issuer host
+            return p;
+          }),
+        }),
+      ),
+    ).rejects.toThrow(/issuer mismatch|mix-up/i);
+  });
 });
 
 describe("MastodonOAuthStrategy.revoke", () => {
@@ -115,5 +136,6 @@ describe("MastodonOAuthStrategy.revoke", () => {
     });
     expect(body).toContain("token=tok");
     expect(body).toContain("client_id=cid");
+    expect(body).toContain("client_secret=csecret");
   });
 });

--- a/tests/unit/mastodon-oauth.test.ts
+++ b/tests/unit/mastodon-oauth.test.ts
@@ -1,0 +1,119 @@
+import { HttpResponse, http } from "msw";
+import { setupServer } from "msw/node";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { MastodonOAuthStrategy } from "../../src/auth/login/mastodon-oauth.js";
+
+vi.mock("../../src/validation/url.js", () => ({
+  validateExternalUrl: vi.fn().mockResolvedValue(undefined),
+}));
+
+const server = setupServer();
+beforeAll(() => server.listen({ onUnhandledRequest: "bypass" }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+const strategy = new MastodonOAuthStrategy();
+
+function ctx(overrides: Partial<Parameters<typeof strategy.authorize>[0]> = {}) {
+  return {
+    instance: "mastodon.test",
+    redirectUri: "http://127.0.0.1:7777/callback",
+    scopes: ["read", "write", "follow"],
+    openBrowser: vi.fn().mockResolvedValue(undefined),
+    // Default: hand back a code + the state the strategy generated.
+    waitForCallback: vi.fn(async (exp: { state?: string }) => {
+      const p = new URLSearchParams();
+      p.set("code", "auth-code");
+      if (exp.state) p.set("state", exp.state);
+      return p;
+    }),
+    ...overrides,
+  };
+}
+
+describe("MastodonOAuthStrategy.authorize", () => {
+  it("registers an app, opens authorize with PKCE, exchanges the code, and returns a LoginResult", async () => {
+    let appBody = "";
+    let tokenBody = "";
+    server.use(
+      http.post("https://mastodon.test/api/v1/apps", async ({ request }) => {
+        appBody = await request.text();
+        return HttpResponse.json({ client_id: "cid", client_secret: "csecret" });
+      }),
+      http.post("https://mastodon.test/oauth/token", async ({ request }) => {
+        tokenBody = await request.text();
+        return HttpResponse.json({
+          access_token: "tok",
+          token_type: "Bearer",
+          scope: "read write follow",
+        });
+      }),
+      http.get("https://mastodon.test/api/v1/accounts/verify_credentials", () =>
+        HttpResponse.json({
+          id: "1",
+          username: "alice",
+          acct: "alice",
+          url: "https://mastodon.test/@alice",
+        }),
+      ),
+    );
+
+    const c = ctx();
+    const result = await strategy.authorize(c);
+
+    expect(appBody).toContain("client_name=activitypub-mcp");
+    expect(appBody).toContain(encodeURIComponent("http://127.0.0.1:7777/callback"));
+    // Authorize URL carries PKCE + state.
+    const openedUrl = (c.openBrowser as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    expect(openedUrl).toContain("code_challenge=");
+    expect(openedUrl).toContain("code_challenge_method=S256");
+    expect(openedUrl).toContain("state=");
+    // Token exchange includes the verifier + the code.
+    expect(tokenBody).toContain("grant_type=authorization_code");
+    expect(tokenBody).toContain("code=auth-code");
+    expect(tokenBody).toContain("code_verifier=");
+    expect(result).toMatchObject({
+      instance: "mastodon.test",
+      username: "alice",
+      accessToken: "tok",
+      tokenType: "Bearer",
+      scopes: ["read", "write", "follow"],
+      clientId: "cid",
+      clientSecret: "csecret",
+    });
+  });
+
+  it("rejects when the app registration fails with the platform error", async () => {
+    server.use(
+      http.post("https://mastodon.test/api/v1/apps", () =>
+        HttpResponse.json({ error: "bad client" }, { status: 422 }),
+      ),
+    );
+    await expect(strategy.authorize(ctx())).rejects.toThrow(/bad client|422/);
+  });
+});
+
+describe("MastodonOAuthStrategy.revoke", () => {
+  it("posts client creds + token to /oauth/revoke", async () => {
+    let body = "";
+    server.use(
+      http.post("https://mastodon.test/oauth/revoke", async ({ request }) => {
+        body = await request.text();
+        return HttpResponse.json({});
+      }),
+    );
+    await strategy.revoke({
+      id: "alice@mastodon.test",
+      instance: "mastodon.test",
+      username: "alice",
+      accessToken: "tok",
+      tokenType: "Bearer",
+      scopes: [],
+      clientId: "cid",
+      clientSecret: "csecret",
+      createdAt: "2026-01-01T00:00:00.000Z",
+    });
+    expect(body).toContain("token=tok");
+    expect(body).toContain("client_id=cid");
+  });
+});

--- a/tests/unit/mcp-server-startup.test.ts
+++ b/tests/unit/mcp-server-startup.test.ts
@@ -4,28 +4,35 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+// Mock the account-manager module so the spy attaches to the same instance the
+// server imports, regardless of dynamic-import evaluation order. (Same pattern as
+// mcp-server.test.ts.)
+vi.mock("../../src/auth/account-manager.js", () => ({
+  accountManager: {
+    loadPersisted: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
 describe("server startup loads persisted accounts", () => {
   const originalEnv = process.env;
   beforeEach(() => {
-    vi.resetModules();
     process.env = { ...originalEnv };
   });
   afterEach(() => {
     process.env = originalEnv;
-    vi.restoreAllMocks();
+    vi.clearAllMocks();
   });
 
   it("awaits accountManager.loadPersisted() during start()", async () => {
     const { accountManager } = await import("../../src/auth/account-manager.js");
-    const spy = vi.spyOn(accountManager, "loadPersisted").mockResolvedValue(undefined);
-
     const { default: ActivityPubMCPServer } = await import("../../src/mcp-server.js");
     const server = new ActivityPubMCPServer();
-    // Stub the transport connect so start() doesn't open stdio.
+    // StdioServerTransport.connect() reads from stdin; stub it so start() doesn't
+    // block the test process on fd 0.
     // @ts-expect-error reaching into the private mcpServer for the test
     server.mcpServer.connect = vi.fn().mockResolvedValue(undefined);
 
     await server.start("stdio");
-    expect(spy).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(accountManager.loadPersisted)).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/unit/mcp-server-startup.test.ts
+++ b/tests/unit/mcp-server-startup.test.ts
@@ -1,0 +1,31 @@
+/**
+ * Verifies the server loads persisted accounts before connecting a transport.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("server startup loads persisted accounts", () => {
+  const originalEnv = process.env;
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = { ...originalEnv };
+  });
+  afterEach(() => {
+    process.env = originalEnv;
+    vi.restoreAllMocks();
+  });
+
+  it("awaits accountManager.loadPersisted() during start()", async () => {
+    const { accountManager } = await import("../../src/auth/account-manager.js");
+    const spy = vi.spyOn(accountManager, "loadPersisted").mockResolvedValue(undefined);
+
+    const { default: ActivityPubMCPServer } = await import("../../src/mcp-server.js");
+    const server = new ActivityPubMCPServer();
+    // Stub the transport connect so start() doesn't open stdio.
+    // @ts-expect-error reaching into the private mcpServer for the test
+    server.mcpServer.connect = vi.fn().mockResolvedValue(undefined);
+
+    await server.start("stdio");
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/mcp-server.test.ts
+++ b/tests/unit/mcp-server.test.ts
@@ -49,6 +49,12 @@ vi.mock("@logtape/logtape", () => ({
   }),
 }));
 
+vi.mock("../../src/auth/account-manager.js", () => ({
+  accountManager: {
+    loadPersisted: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
 vi.mock("../../src/config.js", () => ({
   SERVER_NAME: "test-server",
   SERVER_VERSION: "1.0.0",

--- a/tests/unit/miauth.test.ts
+++ b/tests/unit/miauth.test.ts
@@ -1,0 +1,73 @@
+import { HttpResponse, http } from "msw";
+import { setupServer } from "msw/node";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { MisskeyMiAuthStrategy } from "../../src/auth/login/miauth.js";
+
+vi.mock("../../src/validation/url.js", () => ({
+  validateExternalUrl: vi.fn().mockResolvedValue(undefined),
+}));
+
+const server = setupServer();
+beforeAll(() => server.listen({ onUnhandledRequest: "bypass" }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+const strategy = new MisskeyMiAuthStrategy();
+
+describe("MisskeyMiAuthStrategy.authorize", () => {
+  it("opens the miauth consent URL and exchanges the session for a token", async () => {
+    server.use(
+      http.post("https://misskey.test/api/miauth/:uuid/check", () =>
+        HttpResponse.json({ ok: true, token: "mk-token", user: { username: "bob" } }),
+      ),
+    );
+
+    const openBrowser = vi.fn().mockResolvedValue(undefined);
+    const result = await strategy.authorize({
+      instance: "misskey.test",
+      redirectUri: "http://127.0.0.1:7777/callback",
+      scopes: ["write:notes", "read:account"],
+      openBrowser,
+      // Echo back the session the strategy generated.
+      waitForCallback: vi.fn(async (exp: { session?: string }) => {
+        const p = new URLSearchParams();
+        if (exp.session) p.set("session", exp.session);
+        return p;
+      }),
+    });
+
+    const openedUrl = openBrowser.mock.calls[0][0] as string;
+    expect(openedUrl).toMatch(/^https:\/\/misskey\.test\/miauth\/[0-9a-f-]+\?/);
+    expect(openedUrl).toContain("name=activitypub-mcp");
+    expect(openedUrl).toContain(encodeURIComponent("write:notes,read:account"));
+    expect(result).toMatchObject({
+      instance: "misskey.test",
+      username: "bob",
+      accessToken: "mk-token",
+      tokenType: "Bearer",
+      scopes: ["write:notes", "read:account"],
+    });
+    expect(result.clientId).toBeUndefined();
+  });
+
+  it("rejects when check returns ok:false", async () => {
+    server.use(
+      http.post("https://misskey.test/api/miauth/:uuid/check", () =>
+        HttpResponse.json({ ok: false }),
+      ),
+    );
+    await expect(
+      strategy.authorize({
+        instance: "misskey.test",
+        redirectUri: "http://127.0.0.1:7777/callback",
+        scopes: ["write:notes"],
+        openBrowser: vi.fn().mockResolvedValue(undefined),
+        waitForCallback: vi.fn(async (exp: { session?: string }) => {
+          const p = new URLSearchParams();
+          if (exp.session) p.set("session", exp.session);
+          return p;
+        }),
+      }),
+    ).rejects.toThrow(/authorization (was )?(not approved|failed|denied)|ok:false|not approved/i);
+  });
+});

--- a/tests/unit/miauth.test.ts
+++ b/tests/unit/miauth.test.ts
@@ -70,4 +70,25 @@ describe("MisskeyMiAuthStrategy.authorize", () => {
       }),
     ).rejects.toThrow(/authorization (was )?(not approved|failed|denied)|ok:false|not approved/i);
   });
+
+  it("rejects when the check response carries no user identity", async () => {
+    server.use(
+      http.post("https://misskey.test/api/miauth/:uuid/check", () =>
+        HttpResponse.json({ ok: true, token: "mk-token", user: {} }),
+      ),
+    );
+    await expect(
+      strategy.authorize({
+        instance: "misskey.test",
+        redirectUri: "http://127.0.0.1:7777/callback",
+        scopes: ["write:notes"],
+        openBrowser: vi.fn().mockResolvedValue(undefined),
+        waitForCallback: vi.fn(async (exp: { session?: string }) => {
+          const p = new URLSearchParams();
+          if (exp.session) p.set("session", exp.session);
+          return p;
+        }),
+      }),
+    ).rejects.toThrow(/no user identity/i);
+  });
 });

--- a/tests/unit/secret-hygiene.test.ts
+++ b/tests/unit/secret-hygiene.test.ts
@@ -1,0 +1,90 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { HttpResponse, http } from "msw";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { server } from "../mocks/server.js";
+
+vi.mock("../../src/validation/url.js", () => ({
+  validateExternalUrl: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("../../src/discovery/nodeinfo.js", () => ({
+  getInstanceSoftware: vi.fn().mockResolvedValue({
+    domain: "mastodon.test",
+    detection: "success",
+    software: { name: "mastodon", version: "4.3.0" },
+    protocols: ["activitypub"],
+    openRegistrations: true,
+  }),
+}));
+vi.mock("../../src/auth/login/loopback-server.js", () => ({
+  createLoopbackServer: vi.fn().mockResolvedValue({
+    redirectUri: "http://127.0.0.1:7777/callback",
+    waitForCallback: vi.fn(async (exp: { state?: string }) => {
+      const p = new URLSearchParams();
+      p.set("code", "auth-code");
+      if (exp.state) p.set("state", exp.state);
+      return p;
+    }),
+    close: vi.fn(),
+  }),
+}));
+vi.mock("../../src/auth/login/browser.js", () => ({
+  openBrowser: vi.fn().mockResolvedValue(undefined),
+}));
+
+const SECRET_TOKEN = "SECRET-ACCESS-TOKEN-zzz";
+const SECRET_CLIENT = "SECRET-CLIENT-SECRET-zzz";
+
+describe("secret hygiene: a full login leaks no secrets to stdout/stderr", () => {
+  const originalEnv = process.env;
+  let captured: string;
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = { ...originalEnv };
+    process.env.ACTIVITYPUB_CONFIG_DIR = join(mkdtempSync(join(tmpdir(), "apmcp-hy-")), "cfg");
+    captured = "";
+    const sink = ((chunk: string | Uint8Array) => {
+      captured += chunk.toString();
+      return true;
+    }) as typeof process.stdout.write;
+    vi.spyOn(process.stdout, "write").mockImplementation(sink);
+    vi.spyOn(process.stderr, "write").mockImplementation(sink);
+
+    // Register the Mastodon HTTP handlers on the global MSW server for this test.
+    server.use(
+      http.post("https://mastodon.test/api/v1/apps", () =>
+        HttpResponse.json({ client_id: "cid", client_secret: SECRET_CLIENT }),
+      ),
+      http.post("https://mastodon.test/oauth/token", () =>
+        HttpResponse.json({
+          access_token: SECRET_TOKEN,
+          token_type: "Bearer",
+          scope: "read write follow",
+        }),
+      ),
+      http.get("https://mastodon.test/api/v1/accounts/verify_credentials", () =>
+        HttpResponse.json({
+          id: "1",
+          username: "alice",
+          acct: "alice",
+          url: "https://mastodon.test/@alice",
+        }),
+      ),
+    );
+  });
+  afterEach(() => {
+    process.env = originalEnv;
+    vi.restoreAllMocks();
+  });
+
+  it("prints the success line but no token / client secret / verifier", async () => {
+    const { runLogin } = await import(/* @vite-ignore */ "../../src/cli/login.js");
+    await runLogin(["mastodon.test"]);
+
+    expect(captured).toContain("Authorized as @alice@mastodon.test");
+    expect(captured).not.toContain(SECRET_TOKEN);
+    expect(captured).not.toContain(SECRET_CLIENT);
+    expect(captured).not.toContain("code_verifier");
+  });
+});

--- a/tests/unit/utils.test.ts
+++ b/tests/unit/utils.test.ts
@@ -3,7 +3,11 @@
  */
 
 import { describe, expect, it } from "vitest";
-import { getErrorMessage, UnsupportedOnPlatformError } from "../../src/utils/errors.js";
+import {
+  getErrorMessage,
+  TokenRejectedError,
+  UnsupportedOnPlatformError,
+} from "../../src/utils/errors.js";
 import { stripHtmlTags } from "../../src/utils/html.js";
 import {
   isBlockedHostname,
@@ -253,5 +257,16 @@ describe("UnsupportedOnPlatformError", () => {
     expect(err.op).toBe("vote-on-poll");
     expect(err.platform).toBe("Misskey");
     expect(err.message).toBe("vote-on-poll is not supported on Misskey");
+  });
+});
+
+describe("TokenRejectedError", () => {
+  it("formats a re-auth message with instance + username", () => {
+    const err = new TokenRejectedError("mastodon.social", "alice");
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe("TokenRejectedError");
+    expect(err.instance).toBe("mastodon.social");
+    expect(err.message).toContain("@alice@mastodon.social");
+    expect(err.message).toContain("activitypub-mcp login mastodon.social");
   });
 });


### PR DESCRIPTION
Sub-project 2 of 4: lets users acquire and persist a Fediverse access token via a real browser authorization flow, replacing hand-pasted tokens. Spec: `docs/superpowers/specs/2026-05-29-oauth-onboarding-design.md`; plan: `docs/superpowers/plans/2026-05-30-oauth-onboarding.md`.

## Summary
- **`activitypub-mcp login <instance>`** — acquires a token via **Mastodon OAuth2 (PKCE)** or **Misskey/Foundkey MiAuth**, routed by NodeInfo software detection (mirrors SP1's adapter resolver). Uses an **ephemeral `127.0.0.1` loopback** callback (RFC 8252) and a cross-platform browser opener; prints the URL as a fallback.
- **Persistence** — tokens stored in a `node:fs` JSON store at `${XDG_CONFIG_HOME:-~/.config}/activitypub-mcp/accounts.json` (dir `0700` / file `0600`, atomic `O_EXCL` write, symlink/owner refusal, corrupt-file preservation). `AccountManager` loads them at startup alongside env-var accounts (env wins on id collision).
- **`activitypub-mcp logout <id>`** (revoke on Mastodon, local drop on Misskey) and **`activitypub-mcp accounts`** (merged env+persisted list, no secrets).
- **`TokenRejectedError`** — a rejected token (HTTP 401) now returns an actionable "run `activitypub-mcp login <instance>`" message via the shared `authenticatedFetch`. (403 still flows to adapters for body extraction.)
- New **`guardedFetch`** (guarded *unauthenticated* fetch — SSRF/blocklist/redirect-guard/size-cap) shared by the login flows and `nodeinfo` (refactored onto it).
- **`ACTIVITYPUB_CONFIG_DIR`** to override the store location. README + `.env` examples + CHANGELOG `[Unreleased]` updated.

## Security
Ephemeral loopback port (anti port-stealing); PKCE S256 + CSPRNG `state`; `iss` mix-up check (RFC 9700); CSPRNG MiAuth session via constant-time compare; SSRF/blocklist on every instance fetch; secrets never logged/printed (asserted by a secret-hygiene test); plaintext-at-rest trade-off documented.

## Test plan
- [x] `npm test` — 40 files, 745 passing (incl. credential-store, loopback, both strategies, resolve, CLI login/logout/accounts/dispatch, guarded-fetch, secret-hygiene; SP1 + nodeinfo regression suites green)
- [x] `npm run typecheck` / `npm run lint` / `npm run validate:version` clean
- [ ] CI green on the PR
- [ ] Manual smoke against a real instance: `node dist/mcp-main.js login <instance>` → `accounts` → `logout <id>` (needs a real account)

## Process
16 plan tasks, each executed by a fresh subagent with two-stage (spec + code-quality) review; review findings (temp-file cleanup, `O_NOFOLLOW` read, ephemeral-port timer de-leak, `openBrowser` spawn-event fallback, `ResponseTooLargeError` surfacing, `iss`/username guards, `--port` validation) were applied. The spec and plan were each adversarially verified by a multi-agent workflow before implementation.