### PR TITLE
ci: drop dead v2 trigger from Pages deploy workflow

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -2,7 +2,7 @@ name: Deploy to GitHub Pages
 
 on:
   push:
-    branches: [ main, v2 ]
+    branches: [ main ]
   workflow_dispatch:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages


### PR DESCRIPTION
The `v2` branch no longer exists, so the `push` trigger in `deploy-pages.yml` never fired for it and only added noise. Deploys run from `main`.

This is a follow-up to fixing the Pages deploy failure (the `github-pages` environment deployment-branch policy was stale on `master` after the rename; corrected separately via the API).