### PR TITLE
Hotfix: broken logo.svg XML + dual-theme code blocks

### DIFF
--- a/public/logo.svg
+++ b/public/logo.svg
@@ -8,7 +8,7 @@
     <path d="M22 22 Q50 70 78 78" stroke="#2F7D6B" />
   </g>
   <!-- Four corner dots (no center node) -->
-  <!-- Top-left: ink, flips to paper on dark via --logo-dot-flip -->
+  <!-- Top-left: ink, flips to paper on dark via the logo-dot-flip variable -->
   <circle cx="18" cy="18" r="9" fill="var(--logo-dot-flip, #1A1714)" />
   <!-- Top-right: pine-teal -->
   <circle cx="82" cy="18" r="9" fill="#2F7D6B" />

--- a/site/styles/main.css
+++ b/site/styles/main.css
@@ -1559,24 +1559,26 @@ pre code {
   margin-bottom: var(--space-8);
 }
 
-/* Dual-theme Shiki code blocks (spec §3.6) */
-.astro-code,
-.astro-code span {
-  color: var(--shiki-light);
-  background-color: var(--shiki-light-bg);
-}
-
-[data-theme="dark"] .astro-code,
-[data-theme="dark"] .astro-code span {
-  color: var(--shiki-dark);
-  background-color: var(--shiki-dark-bg);
+/* Dual-theme Shiki code blocks (spec §3.6).
+   Astro emits the LIGHT theme as INLINE styles (background-color/color) on
+   .astro-code, and the DARK theme as --shiki-dark / --shiki-dark-bg CSS vars.
+   Light needs no rule (the inline styles read correctly on paper). To switch to
+   dark we must override those inline styles, which requires !important. */
+:root[data-theme="dark"] .astro-code,
+:root[data-theme="dark"] .astro-code span,
+:root.theme-dark .astro-code,
+:root.theme-dark .astro-code span {
+  background-color: var(--shiki-dark-bg) !important;
+  color: var(--shiki-dark) !important;
 }
 
 @media (prefers-color-scheme: dark) {
-  [data-theme="system"] .astro-code,
-  [data-theme="system"] .astro-code span {
-    color: var(--shiki-dark);
-    background-color: var(--shiki-dark-bg);
+  :root[data-theme="system"] .astro-code,
+  :root[data-theme="system"] .astro-code span,
+  :root.theme-system .astro-code,
+  :root.theme-system .astro-code span {
+    background-color: var(--shiki-dark-bg) !important;
+    color: var(--shiki-dark) !important;
   }
 }
 

--- a/tests/unit/public-svg-wellformed.test.ts
+++ b/tests/unit/public-svg-wellformed.test.ts
@@ -1,0 +1,38 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+// Public SVGs are served as standalone files (via <img>/<link rel=icon>) and are
+// parsed as STRICT XML by browsers — unlike inline SVG in .astro (lenient HTML).
+// A malformed standalone SVG renders as a broken image. The most common defect is
+// a literal "--" (double hyphen) inside an XML comment, which is illegal in XML
+// (e.g. a comment mentioning the CSS var "--logo-dot-flip"). Guard against it.
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const publicDir = join(repoRoot, "public");
+const svgFiles = readdirSync(publicDir).filter((f) => f.endsWith(".svg"));
+
+describe("public SVG assets are well-formed XML", () => {
+  it("finds SVG files to check", () => {
+    expect(svgFiles.length).toBeGreaterThan(0);
+  });
+
+  for (const name of svgFiles) {
+    it(`${name}: no '--' inside any XML comment`, () => {
+      const src = readFileSync(join(publicDir, name), "utf-8");
+      const comments = src.match(/<!--[\s\S]*?-->/g) ?? [];
+      for (const comment of comments) {
+        const inner = comment.slice(4, -3); // strip "<!--" and "-->"
+        expect(inner.includes("--"), `${name}: illegal '--' inside XML comment -> ${comment}`).toBe(
+          false,
+        );
+      }
+    });
+
+    it(`${name}: starts with an <svg> root`, () => {
+      const src = readFileSync(join(publicDir, name), "utf-8").trimStart();
+      expect(src.startsWith("<svg") || src.startsWith("<?xml")).toBe(true);
+    });
+  }
+});


### PR DESCRIPTION
Post-deploy hotfix for two rendering bugs:
- **logo.svg**: illegal `--` inside an XML comment made the file invalid XML → broken `<img>` (hero + footer logos). Rephrased; added a vitest guard parsing every public SVG.
- **Dual-theme Shiki**: the hook used non-existent `--shiki-light` vars and lacked `!important`, so code blocks never switched to dark (white boxes on the dark theme). Now overrides Shiki's inline light styles with `!important` via `--shiki-dark`/`--shiki-dark-bg`.

Verified by headless render (dark): logo renders, code blocks dark. 730 tests pass, lint clean.