### PR TITLE
Website hotfixes: render bugs, registry/version sync, changelog backfill, SEO/a11y

### DIFF
--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -255,17 +255,15 @@ Resources provide read-only access to remote ActivityPub data via `activitypub:/
 activitypub://remote-actor/@gargron@mastodon.social
 ```
 
-### MCP Tools (53 total)
+### MCP Tools (37 total)
 
-Tools fall into three groups. Full schemas and examples at <https://cameronrye.github.io/activitypub-mcp/docs/api/tools/>.
+Tools fall into two groups. Full schemas and examples at <https://cameronrye.github.io/activitypub-mcp/docs/api/tools/>.
 
-**Read-only (21):** `discover-actor`, `fetch-timeline`, `search-instance`, `get-instance-info`, `discover-instances`, `discover-instances-live`, `recommend-instances`, `health-check`, `performance-metrics`, `get-post-thread`, `get-trending-hashtags`, `get-trending-posts`, `get-local-timeline`, `get-federated-timeline`, `search-accounts`, `search-hashtags`, `search-posts`, `search`, `convert-url`, `batch-fetch-actors`, `batch-fetch-posts`.
+**Read-only (9):** `discover-actor`, `discover-instances`, `get-instance-info`, `fetch-timeline`, `get-post-thread`, `get-public-timeline`, `get-trending-hashtags`, `get-trending-posts`, `search`.
 
 **Authenticated write (28):** `list-accounts`, `switch-account`, `verify-account`, `post-status`, `reply-to-post`, `delete-post`, `boost-post`, `unboost-post`, `favourite-post`, `unfavourite-post`, `bookmark-post`, `unbookmark-post`, `follow-account`, `unfollow-account`, `mute-account`, `unmute-account`, `block-account`, `unblock-account`, `get-relationship`, `get-home-timeline`, `get-notifications`, `get-bookmarks`, `get-favourites`, `vote-on-poll`, `upload-media`, `get-scheduled-posts`, `update-scheduled-post`, `cancel-scheduled-post`.
 
-**Export (4):** `export-timeline`, `export-thread`, `export-account-info`, `export-hashtag` — output JSON, Markdown, or CSV.
-
-**Notable v2 changes:**
+**Behavior notes:**
 - `post-status` accepts `mediaIds` and `scheduledAt` for media attachments and scheduled posts.
 - `cancel-scheduled-post` / `update-scheduled-post` use `scheduledPostId` (not v1's `scheduledId`).
 - `get-relationship` takes `acct: string` (not v1's `accountIds: string[]`).
@@ -279,23 +277,17 @@ Tools fall into three groups. Full schemas and examples at <https://cameronrye.g
 }
 ```
 
-### MCP Prompts (11 total)
+### MCP Prompts (5 total)
 
 Guided workflows. Full reference at <https://cameronrye.github.io/activitypub-mcp/docs/api/prompts/>.
 
 | Prompt | Purpose |
 |---|---|
 | `explore-fediverse` | Open-ended fediverse exploration |
-| `compare-instances` | Side-by-side instance comparison |
-| `discover-content` | Find content across instances on a topic |
 | `compare-accounts` | Compare two fediverse accounts |
 | `analyze-user-activity` | Detailed activity analysis |
 | `find-experts` | Discover experts on a topic |
 | `summarize-trending` | Summarize trending posts and hashtags |
-| `content-strategy` | Plan fediverse content strategy |
-| `community-health` | Analyze instance moderation and health |
-| `migration-helper` | Evaluate and plan instance migration |
-| `thread-composer` | Compose well-structured threaded posts |
 
 ---
 
@@ -534,10 +526,8 @@ activitypub-mcp/
 │   │   └── instance-blocklist.ts
 │   ├── audit/                        # Audit logging
 │   │   └── logger.ts
-│   ├── telemetry/                    # Health, logging, perf
-│   │   ├── health-check.ts
-│   │   ├── logging.ts
-│   │   └── performance-monitor.ts
+│   ├── telemetry/                    # Structured logging
+│   │   └── logging.ts
 │   ├── transport/                    # HTTP transport + Bearer auth middleware
 │   │   ├── http.ts
 │   │   └── auth-middleware.ts
@@ -943,7 +933,7 @@ Major release. Security, correctness, and ergonomics overhaul.
 
 **Added:**
 - `post-status` supports `mediaIds` and `scheduledAt` (round-trip with `upload-media`).
-- `search-instance` returns prose output (was raw JSON).
+- Unified `search` tool with `type: "all" | "accounts" | "posts" | "hashtags"` (consolidates the former `search-instance` / `search-accounts` / `search-hashtags` / `search-posts`), returning prose output.
 - `fetch-timeline` renders all posts (was capped at 10) with 500-char per-post truncation.
 - Dynamic `server-info` capabilities — list comes from the live registry.
 - Thread traversal caps: `MCP_THREAD_MAX_DEPTH=5`, `MCP_THREAD_MAX_REPLIES=50`, with `MCP_THREAD_CROSS_ORIGIN_FETCH=false` cross-origin gate.

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -50,12 +50,12 @@ Add to your Claude Desktop configuration:
 
 ## Documentation
 
-### Setup & Installation
+### Getting Started
 
-- [Installation Guide](https://cameronrye.github.io/activitypub-mcp/docs/setup/): Complete setup instructions
-- [Claude Desktop Integration](https://cameronrye.github.io/activitypub-mcp/docs/setup/claude-desktop/): Configure with Claude Desktop
-- [Cross-Platform Setup](https://cameronrye.github.io/activitypub-mcp/docs/setup/cross-platform/): Platform-specific installation
-- [Configuration Guide](https://cameronrye.github.io/activitypub-mcp/docs/setup/config-guide/): Environment variables and options
+- [Installation & Setup](https://cameronrye.github.io/activitypub-mcp/docs/getting-started/installation/): Complete setup instructions
+- [Claude Desktop Integration](https://cameronrye.github.io/activitypub-mcp/docs/getting-started/claude-desktop/): Configure with Claude Desktop
+- [Configuration](https://cameronrye.github.io/activitypub-mcp/docs/getting-started/configuration/): Environment variables and options
+- [Cross-Platform Setup](https://cameronrye.github.io/activitypub-mcp/docs/getting-started/cross-platform/): Platform-specific installation
 
 ## API Reference
 
@@ -66,32 +66,35 @@ Add to your Claude Desktop configuration:
 ## Guides & Examples
 
 - [Basic Usage](https://cameronrye.github.io/activitypub-mcp/docs/guides/basic-usage/): Getting started with the MCP server
-- [Usage Guide](https://cameronrye.github.io/activitypub-mcp/docs/guides/usage-guide/): Comprehensive usage documentation
 - [Examples](https://cameronrye.github.io/activitypub-mcp/docs/guides/examples/): Practical examples and integration patterns
-- [Real-World Scenarios](https://cameronrye.github.io/activitypub-mcp/docs/guides/real-world-test-scenario/): Testing with actual fediverse instances
+- [Fediverse Exploration](https://cameronrye.github.io/activitypub-mcp/docs/guides/fediverse-exploration/): Discover actors, instances, and content
+- [Advanced Workflows](https://cameronrye.github.io/activitypub-mcp/docs/guides/advanced-workflows/): Best practices and real-world scenarios
 
 ## Development
 
-- [Performance Monitoring](https://cameronrye.github.io/activitypub-mcp/docs/development/performance-monitoring/): Built-in logging and metrics
-- [Dependency Management](https://cameronrye.github.io/activitypub-mcp/docs/development/dependency-management/): Managing project dependencies
-- [Security Audit](https://cameronrye.github.io/activitypub-mcp/docs/development/security-audit-checklist/): Security best practices and audit checklist
+- [Architecture](https://cameronrye.github.io/activitypub-mcp/docs/development/architecture/): System design and internals
+- [Dependency Management](https://cameronrye.github.io/activitypub-mcp/docs/development/dependencies/): Managing project dependencies
+- [Performance Monitoring](https://cameronrye.github.io/activitypub-mcp/docs/development/performance/): Built-in logging and metrics
+- [Security Audit](https://cameronrye.github.io/activitypub-mcp/docs/development/security/): Security best practices and audit checklist
 
 ## Specifications
 
-- [ActivityPub LLM Guide](https://cameronrye.github.io/activitypub-mcp/docs/specifications/activitypub-llm-specification-guide/): Understanding ActivityPub for LLM integration
+- [ActivityPub Guide](https://cameronrye.github.io/activitypub-mcp/docs/specifications/activitypub/): Understanding ActivityPub for LLM integration
+- [WebFinger Guide](https://cameronrye.github.io/activitypub-mcp/docs/specifications/webfinger/): Actor discovery via WebFinger
+- [ActivityStreams Guide](https://cameronrye.github.io/activitypub-mcp/docs/specifications/activitystreams/): The ActivityStreams vocabulary
 
 ## Project Resources
 
 - [GitHub Repository](https://github.com/cameronrye/activitypub-mcp): Source code and issue tracking
 - [npm Package](https://www.npmjs.com/package/activitypub-mcp): Install via npm
 - [Documentation Site](https://cameronrye.github.io/activitypub-mcp/): Complete documentation
-- [Changelog](https://cameronrye.github.io/activitypub-mcp/docs/changelog/): Version history and updates
+- [Changelog](https://cameronrye.github.io/activitypub-mcp/docs/reference/changelog/): Version history and updates
 
 ## Additional Resources
 
 ### Troubleshooting & Support
 
-- [Troubleshooting Guide](https://cameronrye.github.io/activitypub-mcp/docs/troubleshooting/): Common issues and solutions
+- [Troubleshooting Guide](https://cameronrye.github.io/activitypub-mcp/docs/reference/troubleshooting/): Common issues and solutions
 - [GitHub Issues](https://github.com/cameronrye/activitypub-mcp/issues): Report bugs and request features
 - [GitHub Discussions](https://github.com/cameronrye/activitypub-mcp/discussions): Community support
 
@@ -113,7 +116,7 @@ Upgrading from v1.x? See [MIGRATION-v2.md](https://github.com/cameronrye/activit
 
 ---
 
-**Version:** 2.0.0
+**Version:** 3.0.0
 **License:** MIT
 **Maintainer:** Cameron Rye (https://rye.dev/)
 **Repository:** https://github.com/cameronrye/activitypub-mcp

--- a/public/logo.svg
+++ b/public/logo.svg
@@ -8,7 +8,7 @@
     <path d="M22 22 Q50 70 78 78" stroke="#2F7D6B" />
   </g>
   <!-- Four corner dots (no center node) -->
-  <!-- Top-left: ink, flips to paper on dark via --logo-dot-flip -->
+  <!-- Top-left: ink, flips to paper on dark via the logo-dot-flip variable -->
   <circle cx="18" cy="18" r="9" fill="var(--logo-dot-flip, #1A1714)" />
   <!-- Top-right: pine-teal -->
   <circle cx="82" cy="18" r="9" fill="#2F7D6B" />

--- a/site/layouts/BaseLayout.astro
+++ b/site/layouts/BaseLayout.astro
@@ -71,11 +71,6 @@ const structuredData = {
         price: "0",
         priceCurrency: "USD",
       },
-      aggregateRating: {
-        "@type": "AggregateRating",
-        ratingValue: "5",
-        ratingCount: "1",
-      },
     },
     {
       "@type": "WebPage",
@@ -169,6 +164,7 @@ const structuredData = {
   <!-- Styles are imported in the frontmatter -->
 </head>
 <body>
+  <a href="#main-content" class="skip-link">Skip to content</a>
   <div class="site-wrapper">
     <header class="site-header">
       <nav class="navbar">
@@ -228,7 +224,7 @@ const structuredData = {
       </nav>
     </header>
     
-    <main class="site-main" data-pagefind-body>
+    <main id="main-content" class="site-main" data-pagefind-body>
       <slot />
     </main>
 
@@ -279,6 +275,24 @@ const structuredData = {
 </html>
 
 <style>
+  /* Keyboard skip link — hidden off-screen until focused, then slides into the
+     top-left above the sticky header (z-index beats --z-sticky: 1020). */
+  .skip-link {
+    position: absolute;
+    left: var(--space-2);
+    top: -4rem;
+    z-index: 2000;
+    padding: var(--space-2) var(--space-4);
+    background: var(--accent);
+    color: var(--color-paper);
+    border-radius: var(--radius-md);
+    text-decoration: none;
+    font-weight: var(--font-semibold);
+  }
+  .skip-link:focus {
+    top: var(--space-2);
+  }
+
   /* Global styles will be moved to external CSS files */
   .site-wrapper {
     min-height: 100vh;

--- a/site/layouts/BaseLayout.astro
+++ b/site/layouts/BaseLayout.astro
@@ -27,7 +27,10 @@ const baseURL = import.meta.env.BASE_URL.endsWith("/")
   ? import.meta.env.BASE_URL
   : `${import.meta.env.BASE_URL}/`;
 
-const socialImage = new URL(image.startsWith("http") ? image : baseURL + "og-image.png", Astro.site);
+const socialImage = new URL(
+  image.startsWith("http") ? image : baseURL + image.replace(/^\//, ""),
+  Astro.site,
+);
 
 // Structured data for Schema.org
 const structuredData = {
@@ -228,7 +231,8 @@ const structuredData = {
     <main class="site-main" data-pagefind-body>
       <slot />
     </main>
-    
+
+    <slot name="footer">
     <footer class="site-footer">
       <div class="container">
         <div class="footer-content">
@@ -266,6 +270,7 @@ const structuredData = {
         </div>
       </div>
     </footer>
+    </slot>
   </div>
   
   <!-- Scripts -->

--- a/site/layouts/DocsLayout.astro
+++ b/site/layouts/DocsLayout.astro
@@ -82,7 +82,9 @@ const tocHeadings = headings.filter((h) => h.depth >= 2 && h.depth <= 3);
           </div>
         </aside>
 
-        <main class="docs-main">
+        <div class="docs-main">
+          <h1 class="docs-title">{_pageTitle}</h1>
+
           {tocHeadings.length > 0 && (
             <nav class="docs-toc" aria-label="Table of contents">
               <h2 class="toc-title">On this page</h2>
@@ -99,7 +101,7 @@ const tocHeadings = headings.filter((h) => h.depth >= 2 && h.depth <= 3);
           <div class="docs-content" data-pagefind-body>
             <slot />
           </div>
-        </main>
+        </div>
       </div>
     </div>
   </div>
@@ -220,6 +222,16 @@ const tocHeadings = headings.filter((h) => h.depth >= 2 && h.depth <= 3);
 
   .docs-main { display: block; }
   .docs-content { max-width: none; }
+
+  .docs-title {
+    font-family: var(--font-display);
+    font-size: clamp(1.875rem, 4vw, 2.5rem);
+    font-weight: var(--font-bold);
+    line-height: 1.15;
+    letter-spacing: -0.02em;
+    color: var(--text-primary);
+    margin: 0 0 var(--space-6);
+  }
 
   .docs-toc {
     background-color: var(--bg-raised);

--- a/site/pages/index.astro
+++ b/site/pages/index.astro
@@ -233,7 +233,7 @@ const chatgptConfig = `{
     </div>
   </section>
 
-  <footer class="home-footer">
+  <footer class="home-footer" slot="footer">
     <div class="container home-footer-grid">
       <div class="home-footer-brand">
         <img src={`${baseURL}logo.svg`} alt="" class="home-footer-logo" width="40" height="40" aria-hidden="true" />

--- a/site/src/content/docs/getting-started/claude-desktop.mdx
+++ b/site/src/content/docs/getting-started/claude-desktop.mdx
@@ -90,7 +90,7 @@ If the file doesn't exist, create it. Add the ActivityPub MCP Server configurati
       "args": ["-y", "activitypub-mcp"],
       "env": {
         "LOG_LEVEL": "debug",
-        "USER_AGENT": "Claude-ActivityPub-Explorer/2.0.0",
+        "USER_AGENT": "Claude-ActivityPub-Explorer/3.0.0",
         "REQUEST_TIMEOUT": "60000",
         "CACHE_TTL": "600",
         "RATE_LIMIT_MAX": "100"

--- a/site/src/content/docs/getting-started/configuration.mdx
+++ b/site/src/content/docs/getting-started/configuration.mdx
@@ -22,7 +22,7 @@ Configure the server using environment variables in your MCP client configuratio
 | Variable | Default | Description | Example |
 |----------|---------|-------------|---------|
 | `LOG_LEVEL` | `info` | Logging verbosity level | `debug`, `info`, `warning`, `error`, `fatal` |
-| `USER_AGENT` | `ActivityPub-MCP-Client/2.0.0` | Custom User-Agent for HTTP requests | `MyApp-ActivityPub/2.0` |
+| `USER_AGENT` | `ActivityPub-MCP-Client/3.0.0` | Custom User-Agent for HTTP requests | `MyApp-ActivityPub/2.0` |
 | `REQUEST_TIMEOUT` | `15000` | HTTP request timeout in milliseconds (production default: 10000) | `45000` (45 seconds) |
 | `MAX_RETRIES` | `3` | Maximum retry attempts | `5` |
 

--- a/site/src/content/docs/getting-started/installation.mdx
+++ b/site/src/content/docs/getting-started/installation.mdx
@@ -67,7 +67,7 @@ Customize the server behavior with environment variables:
 | Variable | Default | Description |
 |---|---|---|
 | `LOG_LEVEL` | `info` | Logging level: debug, info, warning, error, fatal |
-| `USER_AGENT` | `ActivityPub-MCP-Client/2.0.0` | Custom User-Agent for HTTP requests |
+| `USER_AGENT` | `ActivityPub-MCP-Client/3.0.0` | Custom User-Agent for HTTP requests |
 | `REQUEST_TIMEOUT` | `15000` | HTTP request timeout in milliseconds (production default: 10000) |
 | `CACHE_TTL` | `300` | Cache time-to-live in seconds |
 | `MCP_HTTP_SECRET` | *none* | **Required** when `MCP_TRANSPORT_MODE=http`. 32+ random chars; gates `/mcp` via Bearer auth. `/health` stays unauthenticated. |

--- a/site/src/content/docs/reference/changelog.mdx
+++ b/site/src/content/docs/reference/changelog.mdx
@@ -9,6 +9,60 @@ order: 2
 
 All notable changes to the ActivityPub MCP Server are documented here. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### v3.0.0 - 2026-05-31
+
+**Security &amp; surface-reduction overhaul.** Read-only by default, an untrusted-content envelope, and a leaner tool surface. See the [v3 Migration Guide](https://github.com/cameronrye/activitypub-mcp/blob/main/MIGRATION-v3.md) for full upgrade details, and [CHANGELOG.md](https://github.com/cameronrye/activitypub-mcp/blob/main/CHANGELOG.md) for the complete entry.
+
+#### Breaking &amp; Changed
+
+- **Read-only by default.** Mutation tools (post, reply, boost, follow, vote, scheduled posts, …) are only registered when `ACTIVITYPUB_ENABLE_WRITES=true`
+- `discover-instances-live` renamed to `discover-instances`; the static `recommend-instances` and old static `discover-instances` are removed
+- `search-instance` / `search-accounts` / `search-hashtags` / `search-posts` consolidated into `search` (pass `type: "all" | "accounts" | "posts" | "hashtags"`)
+- `get-local-timeline` + `get-federated-timeline` consolidated into `get-public-timeline` (pass `scope: "local" | "federated"`)
+- `get-instance-software` removed; `get-instance-info` now includes the software-detection block
+- All remote Fediverse content wrapped in an `<untrusted-content>` envelope before it reaches the model
+
+#### Added
+
+- `ACTIVITYPUB_ENABLE_WRITES` — master switch for all mutation tools (default `false`)
+- `MCP_HTTP_ALLOWED_HOSTS` / `MCP_HTTP_ALLOWED_ORIGINS` — allowlists for HTTP-transport DNS-rebinding protection
+- Browser-based login: `activitypub-mcp login <instance>` (Mastodon OAuth2 PKCE / Misskey MiAuth), plus `logout` and `accounts`; credentials persisted to `accounts.json` (mode `0600`)
+- `ACTIVITYPUB_CONFIG_DIR` to override the credential-store location
+
+#### Removed
+
+- Export tools (`export-timeline`, `export-thread`, `export-account-info`, `export-hashtag`)
+- `health-check` / `performance-metrics` tools, the telemetry subsystem, and the `/metrics` endpoint
+- `batch-fetch-actors` / `batch-fetch-posts`, `convert-url`, `recommend-instances`
+- MCP prompts `community-health`, `compare-instances`, `content-strategy`, `discover-content`, `migration-helper`, `thread-composer` (five remain)
+
+#### Security
+
+- Complete DNS-rebinding IP-pinning on **all** outbound fetch paths (previously HTTP transport only)
+- `<untrusted-content>` envelope structurally isolates Fediverse text from trusted context
+- HTTP transport rejects unexpected `Host` / `Origin` headers with `403`
+
+### v2.2.0 - 2026-05-29
+
+#### Added
+
+- **Platform-aware write layer.** Authenticated operations route to the correct Fediverse API per instance via NodeInfo software detection; a new Misskey/Foundkey adapter covers core-parity ops. Mastodon-API-compatible software (Pleroma, Akkoma, GotoSocial, Sharkey, Firefish) and undetected instances keep using the Mastodon adapter
+- `UnsupportedOnPlatformError` for operations with no Misskey equivalent (bookmarks, poll voting, scheduled posts)
+
+### v2.1.0 - 2026-05-28
+
+#### Added
+
+- **`get-instance-software` tool.** NodeInfo 2.0/2.1 software + version detection (Mastodon, Pleroma, Misskey, Akkoma, Sharkey, GotoSocial, Friendica, …)
+- `activitypub://instance-info/{domain}` enriched with a structured `software:` block
+- `MCP_INSTANCE_SOFTWARE_TTL_MS` to tune the NodeInfo positive-cache TTL (default 24h)
+- Dependabot config (weekly grouped npm + GitHub Actions updates)
+
+#### Breaking
+
+- `activitypub://post-thread/{postUrl}` URI form removed (deprecated in v2.0.0); use `activitypub://post-thread/{domain}/{statusId}`
+- `activitypub://instance-info/{domain}` `software` field is now an object (was a string); read `body.software.software?.name`
+
 ### v2.0.0 - 2026-05-27
 
 **Security &amp; correctness focused release.** See the [v2 Migration Guide](https://github.com/cameronrye/activitypub-mcp/blob/main/MIGRATION-v2.md) for full breaking-change details, and [CHANGELOG.md](https://github.com/cameronrye/activitypub-mcp/blob/main/CHANGELOG.md) for the complete entry.
@@ -50,6 +104,10 @@ All notable changes to the ActivityPub MCP Server are documented here. The forma
 For v1.0.0 and v1.1.0 release notes (initial public release and the authenticated-write-tools / multi-account additions), see the canonical [CHANGELOG.md](https://github.com/cameronrye/activitypub-mcp/blob/main/CHANGELOG.md) in the repository.
 
 ## Migration Guides
+
+### Upgrading to v3.0.0
+
+v3 is a security and surface-reduction overhaul: read-only by default, an untrusted-content envelope, and a trimmed tool set. See the full [v3 Migration Guide](https://github.com/cameronrye/activitypub-mcp/blob/main/MIGRATION-v3.md) for details on enabling writes (`ACTIVITYPUB_ENABLE_WRITES=true`), the renamed/consolidated tools (`search`, `get-public-timeline`, `discover-instances`), and the removed tools and prompts.
 
 ### Upgrading to v2.0.0
 

--- a/site/styles/main.css
+++ b/site/styles/main.css
@@ -323,7 +323,7 @@ body {
 
 /* Header and Navigation */
 .site-header {
-  background: rgba(255, 255, 255, 0.95);
+  background: color-mix(in srgb, var(--color-paper) 90%, transparent);
   border-bottom: 1px solid var(--border-primary);
   position: sticky;
   top: 0;
@@ -335,7 +335,7 @@ body {
 /* Dark theme header */
 :root[data-theme="dark"] .site-header,
 :root.theme-dark .site-header {
-  background: rgba(17, 24, 39, 0.95);
+  background: color-mix(in srgb, var(--color-ink) 92%, transparent);
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
 }
 
@@ -343,7 +343,7 @@ body {
 @media (prefers-color-scheme: dark) {
   :root[data-theme="system"] .site-header,
   :root.theme-system .site-header {
-    background: rgba(17, 24, 39, 0.95);
+    background: color-mix(in srgb, var(--color-ink) 92%, transparent);
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
   }
 }
@@ -470,7 +470,7 @@ body {
 
 .nav-link:hover {
   color: var(--color-primary);
-  background-color: rgba(37, 99, 235, 0.05);
+  background-color: color-mix(in srgb, var(--accent) 8%, transparent);
 }
 
 .nav-link:hover::after {
@@ -622,7 +622,7 @@ body {
 .mobile-search-toggle:focus {
   outline: none;
   border-color: var(--color-primary);
-  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.1);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 15%, transparent);
 }
 
 /* Hide mobile search toggle on desktop */
@@ -652,7 +652,7 @@ body {
   outline: none;
   border-color: var(--color-primary);
   box-shadow:
-    0 0 0 3px rgba(37, 99, 235, 0.1),
+    0 0 0 3px color-mix(in srgb, var(--accent) 15%, transparent),
     0 4px 12px rgba(0, 0, 0, 0.1);
   transform: translateY(-1px);
 }
@@ -698,23 +698,6 @@ body {
   padding: 0 var(--space-4);
   position: relative;
   z-index: 1;
-}
-
-.hero-logo {
-  width: 120px;
-  height: 120px;
-  margin: 0 auto var(--space-8);
-  display: block;
-  animation: float 3s ease-in-out infinite;
-}
-
-@keyframes float {
-  0%, 100% {
-    transform: translateY(0px);
-  }
-  50% {
-    transform: translateY(-10px);
-  }
 }
 
 .hero-title {
@@ -787,7 +770,7 @@ body {
   background: var(--color-primary-gradient);
   color: var(--color-white);
   border-color: var(--color-primary);
-  box-shadow: 0 4px 14px 0 rgba(37, 99, 235, 0.25);
+  box-shadow: 0 4px 14px 0 color-mix(in srgb, var(--accent) 30%, transparent);
   position: relative;
   overflow: hidden;
 }
@@ -816,7 +799,7 @@ body {
   );
   border-color: var(--color-primary-dark);
   transform: translateY(-2px);
-  box-shadow: 0 8px 25px 0 rgba(37, 99, 235, 0.35);
+  box-shadow: 0 8px 25px 0 color-mix(in srgb, var(--accent) 38%, transparent);
 }
 
 .btn-primary:hover::before {
@@ -846,7 +829,7 @@ body {
 .btn-outline:hover {
   color: var(--color-white);
   transform: translateY(-2px);
-  box-shadow: 0 8px 25px 0 rgba(37, 99, 235, 0.25);
+  box-shadow: 0 8px 25px 0 color-mix(in srgb, var(--accent) 28%, transparent);
 }
 
 .btn-outline:hover::before {
@@ -1319,27 +1302,17 @@ pre code {
   white-space: pre; /* prevent wrapping inside code fences */
 }
 
-/* Version Badge */
+/* Version Badge (legacy base; the homepage supplies its own scoped badge).
+   No animation/box-shadow here so the old emerald pulse never leaks through. */
 .version-badge {
   display: inline-block;
-  background: linear-gradient(135deg, var(--color-success) 0%, var(--color-accent) 100%);
+  background: linear-gradient(135deg, var(--accent-2) 0%, var(--accent-3) 100%);
   color: var(--color-white);
   padding: var(--space-2) var(--space-4);
   border-radius: var(--radius-full);
   font-size: var(--text-sm);
   font-weight: var(--font-semibold);
   margin-bottom: var(--space-6);
-  animation: pulse 2s ease-in-out infinite;
-  box-shadow: 0 4px 14px 0 rgba(16, 185, 129, 0.3);
-}
-
-@keyframes pulse {
-  0%, 100% {
-    box-shadow: 0 4px 14px 0 rgba(16, 185, 129, 0.3);
-  }
-  50% {
-    box-shadow: 0 4px 20px 0 rgba(16, 185, 129, 0.5);
-  }
 }
 
 /* Hero Stats */
@@ -1613,4 +1586,57 @@ pre code {
 }
 .docs-content a:hover {
   color: var(--link-hover);
+}
+
+/* Copy buttons injected by public/scripts/main.js (initCodeCopy) into the
+   rendered Shiki code blocks in docs prose. These are created in plain JS
+   without the scoped CopyButton.astro styles, so they would otherwise render
+   as bare "Copy" text. Style them here as a brand-tokened, reveal-on-hover
+   control. The homepage install snippets use the CodeBlock component and are
+   skipped by the script, so this only targets docs code blocks. */
+.docs-content pre {
+  position: relative;
+}
+
+.docs-content pre .copy-button {
+  position: absolute;
+  top: var(--space-2);
+  right: var(--space-2);
+  padding: var(--space-1) var(--space-2);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  background-color: var(--bg-raised);
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  line-height: 1;
+  cursor: pointer;
+  opacity: 0;
+  transition:
+    opacity var(--transition-fast),
+    color var(--transition-fast),
+    border-color var(--transition-fast);
+}
+
+.docs-content pre:hover .copy-button,
+.docs-content pre:focus-within .copy-button,
+.docs-content pre .copy-button:focus-visible {
+  opacity: 1;
+}
+
+.docs-content pre .copy-button:hover {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+
+.docs-content pre .copy-button.copied {
+  color: var(--accent-2);
+  border-color: var(--accent-2);
+  opacity: 1;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .docs-content pre .copy-button {
+    transition: none;
+  }
 }

--- a/site/styles/main.css
+++ b/site/styles/main.css
@@ -1559,24 +1559,26 @@ pre code {
   margin-bottom: var(--space-8);
 }
 
-/* Dual-theme Shiki code blocks (spec §3.6) */
-.astro-code,
-.astro-code span {
-  color: var(--shiki-light);
-  background-color: var(--shiki-light-bg);
-}
-
-[data-theme="dark"] .astro-code,
-[data-theme="dark"] .astro-code span {
-  color: var(--shiki-dark);
-  background-color: var(--shiki-dark-bg);
+/* Dual-theme Shiki code blocks (spec §3.6).
+   Astro emits the LIGHT theme as INLINE styles (background-color/color) on
+   .astro-code, and the DARK theme as --shiki-dark / --shiki-dark-bg CSS vars.
+   Light needs no rule (the inline styles read correctly on paper). To switch to
+   dark we must override those inline styles, which requires !important. */
+:root[data-theme="dark"] .astro-code,
+:root[data-theme="dark"] .astro-code span,
+:root.theme-dark .astro-code,
+:root.theme-dark .astro-code span {
+  background-color: var(--shiki-dark-bg) !important;
+  color: var(--shiki-dark) !important;
 }
 
 @media (prefers-color-scheme: dark) {
-  [data-theme="system"] .astro-code,
-  [data-theme="system"] .astro-code span {
-    color: var(--shiki-dark);
-    background-color: var(--shiki-dark-bg);
+  :root[data-theme="system"] .astro-code,
+  :root[data-theme="system"] .astro-code span,
+  :root.theme-system .astro-code,
+  :root.theme-system .astro-code span {
+    background-color: var(--shiki-dark-bg) !important;
+    color: var(--shiki-dark) !important;
   }
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -58,7 +58,7 @@ export const LOG_LEVEL = process.env.LOG_LEVEL || "info";
 // =============================================================================
 
 /** User-Agent string for HTTP requests */
-export const USER_AGENT = process.env.USER_AGENT || "ActivityPub-MCP-Client/1.0.0";
+export const USER_AGENT = process.env.USER_AGENT || `ActivityPub-MCP-Client/${SERVER_VERSION}`;
 
 /** Request timeout in milliseconds (default: 10 seconds) */
 export const REQUEST_TIMEOUT = parseIntEnv(process.env.REQUEST_TIMEOUT, 10000);

--- a/tests/unit/llms-registry-sync.test.ts
+++ b/tests/unit/llms-registry-sync.test.ts
@@ -1,0 +1,90 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { countRegistry } from "../../scripts/generate-registry-manifest.js";
+
+// Drift guard: the LLM-facing reference files (public/llms.txt,
+// public/llms-full.txt) and the committed registry manifest must stay in sync
+// with the actual MCP registry. These files are hand-maintained prose, so they
+// silently rot when tools/prompts/resources or the version change. This test
+// re-derives the truth from source via countRegistry() and asserts the curated
+// files still match — counts, names, and version.
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const read = (rel: string) => readFileSync(join(repoRoot, rel), "utf8");
+
+const registry = countRegistry(join(repoRoot, "src"));
+const manifest = JSON.parse(read("site/src/data/registry-manifest.json"));
+const pkg = JSON.parse(read("package.json"));
+const llms = read("public/llms.txt");
+const llmsFull = read("public/llms-full.txt");
+
+/** Slice a markdown section from its heading to the next heading / horizontal rule. */
+function section(text: string, heading: string): string {
+  const start = text.indexOf(heading);
+  if (start < 0) return "";
+  const after = text.slice(start + heading.length);
+  const end = after.search(/\n(?:#{2,3}\s|---\s*\n)/);
+  return end >= 0 ? after.slice(0, end) : after;
+}
+
+/** All `backtick-quoted` lowercase-kebab tokens in a chunk of text. */
+function tickNames(chunk: string): string[] {
+  return [...chunk.matchAll(/`([a-z0-9-]+)`/g)].map((m) => m[1]);
+}
+
+describe("registry-manifest.json stays in sync with the live registry", () => {
+  it("matches counts and names from countRegistry(src)", () => {
+    expect(manifest.tools).toBe(registry.tools);
+    expect(manifest.resources).toBe(registry.resources);
+    expect(manifest.prompts).toBe(registry.prompts);
+    expect(manifest.toolNames).toEqual(registry.toolNames);
+    expect(manifest.resourceNames).toEqual(registry.resourceNames);
+    expect(manifest.promptNames).toEqual(registry.promptNames);
+  });
+});
+
+describe("llms.txt stays in sync with the registry", () => {
+  it("states the real tool/resource/prompt counts", () => {
+    expect(llms).toContain(`${registry.tools} MCP Tools`);
+    expect(llms).toContain(`${registry.resources} MCP Resources, ${registry.prompts} MCP Prompts`);
+  });
+
+  it("version footer matches package.json", () => {
+    expect(llms).toContain(`**Version:** ${pkg.version}`);
+  });
+});
+
+describe("llms-full.txt capability sections stay in sync with the registry", () => {
+  it("section headers report the real counts", () => {
+    expect(llmsFull).toContain(`### MCP Tools (${registry.tools} total)`);
+    expect(llmsFull).toContain(`### MCP Resources (${registry.resources} total)`);
+    expect(llmsFull).toContain(`### MCP Prompts (${registry.prompts} total)`);
+  });
+
+  it("the Read-only + Authenticated write lists are exactly the registered tools (no phantoms, none missing)", () => {
+    const tools = section(llmsFull, "### MCP Tools");
+    const listed = tools
+      .split("\n")
+      .filter((line) => /^\*\*(Read-only|Authenticated write)/.test(line))
+      .flatMap(tickNames);
+    expect([...new Set(listed)].sort()).toEqual([...registry.toolNames].sort());
+  });
+
+  it("the prompts table lists exactly the registered prompts", () => {
+    const prompts = section(llmsFull, "### MCP Prompts");
+    const listed = prompts
+      .split("\n")
+      .filter((line) => line.trimStart().startsWith("| `"))
+      .flatMap(tickNames);
+    expect([...new Set(listed)].sort()).toEqual([...registry.promptNames].sort());
+  });
+
+  it("every registered resource appears in the resources table", () => {
+    const resources = section(llmsFull, "### MCP Resources");
+    for (const name of registry.resourceNames) {
+      expect(resources).toContain(`activitypub://${name}`);
+    }
+  });
+});

--- a/tests/unit/llms-registry-sync.test.ts
+++ b/tests/unit/llms-registry-sync.test.ts
@@ -88,3 +88,10 @@ describe("llms-full.txt capability sections stay in sync with the registry", () 
     }
   });
 });
+
+describe("site docs stay in sync with the package version", () => {
+  it("the changelog page documents the current release", () => {
+    const changelog = read("site/src/content/docs/reference/changelog.mdx");
+    expect(changelog).toContain(`### v${pkg.version}`);
+  });
+});

--- a/tests/unit/public-svg-wellformed.test.ts
+++ b/tests/unit/public-svg-wellformed.test.ts
@@ -1,0 +1,38 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+// Public SVGs are served as standalone files (via <img>/<link rel=icon>) and are
+// parsed as STRICT XML by browsers — unlike inline SVG in .astro (lenient HTML).
+// A malformed standalone SVG renders as a broken image. The most common defect is
+// a literal "--" (double hyphen) inside an XML comment, which is illegal in XML
+// (e.g. a comment mentioning the CSS var "--logo-dot-flip"). Guard against it.
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const publicDir = join(repoRoot, "public");
+const svgFiles = readdirSync(publicDir).filter((f) => f.endsWith(".svg"));
+
+describe("public SVG assets are well-formed XML", () => {
+  it("finds SVG files to check", () => {
+    expect(svgFiles.length).toBeGreaterThan(0);
+  });
+
+  for (const name of svgFiles) {
+    it(`${name}: no '--' inside any XML comment`, () => {
+      const src = readFileSync(join(publicDir, name), "utf-8");
+      const comments = src.match(/<!--[\s\S]*?-->/g) ?? [];
+      for (const comment of comments) {
+        const inner = comment.slice(4, -3); // strip "<!--" and "-->"
+        expect(inner.includes("--"), `${name}: illegal '--' inside XML comment -> ${comment}`).toBe(
+          false,
+        );
+      }
+    });
+
+    it(`${name}: starts with an <svg> root`, () => {
+      const src = readFileSync(join(publicDir, name), "utf-8").trimStart();
+      expect(src.startsWith("<svg") || src.startsWith("<?xml")).toBe(true);
+    });
+  }
+});


### PR DESCRIPTION
Follow-up fixes to the v3 website overhaul (#120), on top of the merged #122.

**Render / markup**
- Remove the duplicate homepage footer (BaseLayout exposes a `footer` slot the homepage fills; global footer no longer stacks, and moves out of the indexed `<main>`).
- Stop legacy global rules leaking onto new elements: the hero logo no longer floats and the version badge no longer pulses.
- Repoint reachable off-brand colors (button shadows, nav hover, sticky-header bg, search focus) to brand tokens.
- Give docs pages an `<h1>`; fix `<main>` nested in `<main>`; style the copy buttons main.js injects into docs code blocks; honor a custom OG image prop.

**Content / version sync**
- User-Agent default now derives from `SERVER_VERSION` (was hardcoded `1.0.0`); docs updated to 3.0.0.
- `llms.txt`: version → 3.0.0, doc links remapped to the migrated IA.
- `llms-full.txt`: capability inventory corrected to 37 tools / 5 prompts (dropped entries that no longer exist), stale changelog/file-tree lines fixed.
- Site **Changelog** backfilled with v3.0.0 / v2.2.0 / v2.1.0 (it had stopped at v2.0.0).

**SEO / a11y**
- Removed fabricated `aggregateRating` from the JSON-LD.
- Added a keyboard skip-to-content link.

**Tests**
- New drift-guard test ties the registry manifest, both `llms*.txt` files, and the changelog version back to the live registry / `package.json`. Full suite: 738 passing.