### PR TITLE
Fix MSW test setup, unblock @mswjs/interceptors 0.41.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2134,9 +2134,9 @@
       }
     },
     "node_modules/@mswjs/interceptors": {
-      "version": "0.41.2",
-      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.41.2.tgz",
-      "integrity": "sha512-7G0Uf0yK3f2bjElBLGHIQzgRgMESczOMyYVasq1XK8P5HaXtlW4eQhz9MBL+TQILZLaruq+ClGId+hH0w4jvWw==",
+      "version": "0.41.9",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.41.9.tgz",
+      "integrity": "sha512-VVPPgHyQ6ShqnrmDWuxjmUIsO9gWyOZFmuOfLd9LfBGQJwZfy0gvv9pbHSJuoFNIYC7ZDX9aoFwowjcdSC4E8w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/tests/unit/authenticated-client.test.ts
+++ b/tests/unit/authenticated-client.test.ts
@@ -3,13 +3,13 @@
  */
 
 import { HttpResponse, http } from "msw";
-import { setupServer } from "msw/node";
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { accountManager } from "../../src/auth/account-manager.js";
 import { authenticatedFetch } from "../../src/auth/adapters/write-adapter.js";
 import { AuthenticatedClient } from "../../src/auth/authenticated-client.js";
 import { getInstanceSoftware } from "../../src/discovery/nodeinfo.js";
 import { TokenRejectedError, UnsupportedOnPlatformError } from "../../src/utils/errors.js";
+import { server } from "../mocks/server.js";
 
 // Mock logtape
 vi.mock("@logtape/logtape", () => ({
@@ -48,13 +48,6 @@ vi.mock("../../src/discovery/nodeinfo.js", () => ({
   }),
   clearNodeInfoCache: vi.fn(),
 }));
-
-// Create MSW server
-const server = setupServer();
-
-// Start and stop MSW server at file scope so all describe blocks share it.
-beforeAll(() => server.listen({ onUnhandledRequest: "bypass" }));
-afterAll(() => server.close());
 
 // Mock account credentials
 const mockAccount = {

--- a/tests/unit/guarded-fetch.test.ts
+++ b/tests/unit/guarded-fetch.test.ts
@@ -1,17 +1,12 @@
 import { HttpResponse, http } from "msw";
-import { setupServer } from "msw/node";
-import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { guardedFetch } from "../../src/utils/fetch-helpers.js";
+import { server } from "../mocks/server.js";
 
 vi.mock("../../src/validation/url.js", () => ({
   validateExternalUrl: vi.fn().mockResolvedValue(undefined),
   resolveAndPin: vi.fn().mockResolvedValue({}),
 }));
-
-const server = setupServer();
-beforeAll(() => server.listen({ onUnhandledRequest: "bypass" }));
-afterEach(() => server.resetHandlers());
-afterAll(() => server.close());
 
 describe("guardedFetch", () => {
   it("performs a GET and parses JSON by default", async () => {

--- a/tests/unit/mastodon-oauth.test.ts
+++ b/tests/unit/mastodon-oauth.test.ts
@@ -1,17 +1,12 @@
 import { HttpResponse, http } from "msw";
-import { setupServer } from "msw/node";
-import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { MastodonOAuthStrategy } from "../../src/auth/login/mastodon-oauth.js";
+import { server } from "../mocks/server.js";
 
 vi.mock("../../src/validation/url.js", () => ({
   validateExternalUrl: vi.fn().mockResolvedValue(undefined),
   resolveAndPin: vi.fn().mockResolvedValue({}),
 }));
-
-const server = setupServer();
-beforeAll(() => server.listen({ onUnhandledRequest: "bypass" }));
-afterEach(() => server.resetHandlers());
-afterAll(() => server.close());
 
 const strategy = new MastodonOAuthStrategy();
 

--- a/tests/unit/miauth.test.ts
+++ b/tests/unit/miauth.test.ts
@@ -1,17 +1,12 @@
 import { HttpResponse, http } from "msw";
-import { setupServer } from "msw/node";
-import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { MisskeyMiAuthStrategy } from "../../src/auth/login/miauth.js";
+import { server } from "../mocks/server.js";
 
 vi.mock("../../src/validation/url.js", () => ({
   validateExternalUrl: vi.fn().mockResolvedValue(undefined),
   resolveAndPin: vi.fn().mockResolvedValue({}),
 }));
-
-const server = setupServer();
-beforeAll(() => server.listen({ onUnhandledRequest: "bypass" }));
-afterEach(() => server.resetHandlers());
-afterAll(() => server.close());
 
 const strategy = new MisskeyMiAuthStrategy();
 

--- a/tests/unit/misskey-adapter.test.ts
+++ b/tests/unit/misskey-adapter.test.ts
@@ -3,19 +3,14 @@
  */
 
 import { HttpResponse, http } from "msw";
-import { setupServer } from "msw/node";
-import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { MisskeyWriteAdapter } from "../../src/auth/adapters/misskey-adapter.js";
+import { server } from "../mocks/server.js";
 
 vi.mock("../../src/validation/url.js", () => ({
   validateExternalUrl: vi.fn().mockResolvedValue(undefined),
   resolveAndPin: vi.fn().mockResolvedValue({}),
 }));
-
-const server = setupServer();
-beforeAll(() => server.listen({ onUnhandledRequest: "bypass" }));
-afterEach(() => server.resetHandlers());
-afterAll(() => server.close());
 
 const account = {
   id: "mk",

--- a/tests/unit/remote-client-thread.test.ts
+++ b/tests/unit/remote-client-thread.test.ts
@@ -1,6 +1,6 @@
 import { HttpResponse, http } from "msw";
-import { setupServer } from "msw/node";
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { server } from "../mocks/server.js";
 
 // Pin DNS to a public IP so resolveAndPin succeeds for fixture hosts (which
 // don't resolve on the real resolver) and MSW intercepts the pinned fetch.
@@ -10,17 +10,12 @@ vi.mock("node:dns/promises", () => ({
   lookup: async () => [{ address: "93.184.216.34", family: 4 }],
 }));
 
-const server = setupServer();
-// Note: the production fetch helper catches and silently skips unmatched
-// requests, so MSW's "error" mode would only add console noise without
-// failing tests. The strict `.toBe(3)` assertion below is the real guard
-// against the cap regressing.
-beforeAll(() => server.listen({ onUnhandledRequest: "bypass" }));
+// The production fetch helper catches and silently skips unmatched requests,
+// so unhandled requests only add console noise; the strict `.toBe(3)`
+// assertion below is the real guard against the cap regressing.
 afterEach(() => {
-  server.resetHandlers();
   vi.restoreAllMocks();
 });
-afterAll(() => server.close());
 
 describe("fetchPostThread cross-origin guard (M3)", () => {
   const originalEnv = process.env;


### PR DESCRIPTION
Supersedes #142, which bumped `@mswjs/interceptors` 0.41.2 → 0.41.9 and failed 6 unit-test files. **The bump only exposed a latent test-setup bug; this fixes the root cause and takes the bump.**

## Root cause
`tests/setup.ts` is a global `setupFile`, so its `setupServer()` runs for every test. Six files *also* created their own `setupServer()` — two concurrent instances both patching `fetch` through the shared `@mswjs/interceptors` singleton, which MSW does not support. interceptors 0.41.2 happened to route requests to the per-file server; **0.41.9 routes them to the first-applied (global) server**, whose handlers don't include the test URLs — so every mocked request fell through to the real network (`ENOTFOUND`).

Verified by isolating the variable (override `@mswjs/interceptors` to 0.41.9, nothing else): the failing test passes with the global setup removed, fails with it present.

## Fix
The six files now import the single shared `server` from `tests/mocks/server.js` and register per-test handlers with `server.use()`. The global setup already owns `listen`/`resetHandlers`/`close`, so the per-file lifecycle is removed — notably the per-file `server.close()`, which on a shared instance would have torn down interception for sibling files. This is MSW's documented single-server pattern and is interceptor-version-agnostic.

Files: authenticated-client, guarded-fetch, mastodon-oauth, miauth, misskey-adapter, remote-client-thread.

## Verification (local)
- Full unit suite: **49 files / 747 tests pass** under interceptors 0.41.9
- `tsc --noEmit` clean, `biome check` clean
- Lockfile diff is scoped to the single `@mswjs/interceptors` 0.41.2 → 0.41.9 bump (no `overrides`, not added to `package.json`)