### PR TITLE
Add a Dockerfile for Glama hosting

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+node_modules
+dist
+dist-site
+coverage
+.astro
+.git
+.github
+site
+tests
+docs
+public
+scripts
+*.mcpb
+*.log
+.env*
+.vscode

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+# syntax=docker/dockerfile:1
+
+# Container image for the ActivityPub MCP server, primarily for Glama-style
+# hosting that runs each server as a stdio container and bridges it to
+# SSE / Streamable HTTP. Read-only by default; writes stay disabled unless
+# ACTIVITYPUB_ENABLE_WRITES=true is supplied at runtime.
+
+# --- Build stage: install all deps and compile TypeScript to dist/. ---
+FROM node:22-slim AS build
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci --ignore-scripts
+COPY tsconfig.json ./
+COPY src ./src
+RUN npm run build
+
+# --- Runtime stage: production deps + built output only. ---
+FROM node:22-slim AS runtime
+ENV NODE_ENV=production \
+    MCP_TRANSPORT_MODE=stdio
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev --ignore-scripts && npm cache clean --force
+COPY --from=build /app/dist ./dist
+USER node
+# stdio transport on stdin/stdout; no port is exposed.
+ENTRYPOINT ["node", "dist/mcp-main.js"]

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -108,19 +108,19 @@ gh workflow run publish-mcp.yml
 Glama scores listings **~70% on tool-definition quality**, 30% on coherence —
 earned by the tool/parameter descriptions we already control, not by hosting.
 
-1. Sign in to [glama.ai](https://glama.ai) with GitHub (`cameronrye`) and claim
-   `https://glama.ai/mcp/servers/cameronrye/activitypub-mcp` via OAuth (a
-   personal repo claims with OAuth alone).
-2. Optionally commit a `glama.json` at repo root to lock metadata, then **re-run
-   the claim flow** to trigger a re-sync (there is no automatic re-sync after
-   edits):
-
-   ```json
-   { "$schema": "https://glama.ai/mcp/schemas/server.json", "maintainers": ["cameronrye"] }
-   ```
-3. Tighten every tool + parameter description: lead with read-only intent and
+1. ✅ Claimed at [glama.ai](https://glama.ai) via GitHub OAuth (`cameronrye`).
+   Glama indexes the listing as `hn4391ubvo` (`glama.ai/mcp/servers/cameronrye/activitypub-mcp`).
+2. ✅ [`glama.json`](../glama.json) committed at repo root (`maintainers: ["cameronrye"]`).
+   Re-run the claim flow to re-sync after edits (there is no automatic re-sync).
+3. ✅ [`Dockerfile`](../Dockerfile) committed so Glama can build and **host** the
+   server as an installable container. Glama runs it over stdio and bridges to
+   SSE / Streamable HTTP, so the entrypoint is `node dist/mcp-main.js` with no
+   exposed port (read-only by default; non-root). **Final manual step (Glama
+   admin UI): open the server's Dockerfile / Deploy page → deploy → once the
+   checks pass, "Make Release" to turn on the install button.**
+4. Tighten every tool + parameter description: lead with read-only intent and
    explicitly flag the write tools as gated behind `ACTIVITYPUB_ENABLE_WRITES`.
-   This both communicates the security posture and raises the score.
+   This both communicates the security posture and raises the ~70% score.
 
 ### Smithery — defer (highest effort, lowest marginal reach)
 


### PR DESCRIPTION
Enables Glama's **install / hosting** for the server (the listing is claimed but had no install option because the repo lacked a `Dockerfile` — Glama runs each installable server as a container).

- **`Dockerfile`** — multi-stage `node:22-slim`: build stage compiles TypeScript; runtime stage ships prod deps + `dist/` only, runs as non-root `node`, stdio `ENTRYPOINT` (no exposed port — Glama bridges stdio↔SSE/HTTP). Read-only by default. **Built and smoke-tested locally** (385MB image, server boots cleanly over stdio).
- **`.dockerignore`** — trims the build context.
- **`docs/distribution.md`** — Glama section updated; the only step left is the maintainer clicking Deploy → "Make Release" in Glama's admin UI.

No code or package changes.