### PR TITLE
Fix Glama deploy: use CMD so the start command is set

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,5 +23,8 @@ COPY package.json package-lock.json ./
 RUN npm ci --omit=dev --ignore-scripts && npm cache clean --force
 COPY --from=build /app/dist ./dist
 USER node
-# stdio transport on stdin/stdout; no port is exposed.
-ENTRYPOINT ["node", "dist/mcp-main.js"]
+# stdio transport on stdin/stdout; no port is exposed. Use CMD (not ENTRYPOINT)
+# so hosts that read the image's start command — e.g. Glama wrapping it with
+# mcp-proxy — pick it up; an ENTRYPOINT-only image leaves Cmd empty and Glama
+# reports "At least one command argument is required".
+CMD ["node", "dist/mcp-main.js"]

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -113,11 +113,15 @@ earned by the tool/parameter descriptions we already control, not by hosting.
 2. ✅ [`glama.json`](../glama.json) committed at repo root (`maintainers: ["cameronrye"]`).
    Re-run the claim flow to re-sync after edits (there is no automatic re-sync).
 3. ✅ [`Dockerfile`](../Dockerfile) committed so Glama can build and **host** the
-   server as an installable container. Glama runs it over stdio and bridges to
-   SSE / Streamable HTTP, so the entrypoint is `node dist/mcp-main.js` with no
-   exposed port (read-only by default; non-root). **Final manual step (Glama
-   admin UI): open the server's Dockerfile / Deploy page → deploy → once the
-   checks pass, "Make Release" to turn on the install button.**
+   server as an installable container. Glama runs it over stdio (wrapped by
+   `mcp-proxy`) and bridges to SSE / Streamable HTTP, so the start command is
+   `CMD ["node", "dist/mcp-main.js"]` with no exposed port (read-only by default;
+   non-root). **Use `CMD`, not `ENTRYPOINT`** — Glama reads the image's `Cmd`, so
+   an `ENTRYPOINT`-only image leaves it empty and the deploy fails with
+   "At least one command argument is required". **Final manual step (Glama admin
+   UI): open the server's Dockerfile / Deploy page → deploy → if a Command field
+   is shown, it is `node dist/mcp-main.js` → once checks pass, "Make Release" to
+   turn on the install button.**
 4. Tighten every tool + parameter description: lead with read-only intent and
    explicitly flag the write tools as gated behind `ACTIVITYPUB_ENABLE_WRITES`.
    This both communicates the security posture and raises the ~70% score.


### PR DESCRIPTION
The Glama "Build and Release" fails with **"At least one command argument is required"**.

**Cause:** Glama wraps the server with `mcp-proxy` and reads the image's `Cmd` to get the start command. The Dockerfile used `ENTRYPOINT` only, leaving `Cmd` empty — so Glama has no command argument.

**Fix:** switch to `CMD ["node", "dist/mcp-main.js"]`. Verified the rebuilt image now reports `Cmd=["node","dist/mcp-main.js"]` and still boots cleanly over stdio (non-root, `/app`). Doc updated with the gotcha.