### PR TITLE
Release v3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.1.0] - 2026-06-04
+
+### Added
+
+- **Misskey / Foundkey read support.** `search`, `get-trending-hashtags`, `get-trending-posts`, and `get-public-timeline` now work on Misskey-family instances. Reads are routed per instance by NodeInfo software detection through a new read adapter and normalized into the same Mastodon-shaped results, so these tools no longer silently fail on platforms already supported for writes.
+- **Authentication guide on the docs site** covering the `activitypub-mcp login` (Mastodon OAuth2 / Misskey MiAuth) flow, credential storage, and multi-account usage.
+
+### Fixed
+
+- **Install command on the site.** The "Quick install" step shipped `npx activitypub-mcp install`, a subcommand the CLI does not dispatch — it silently started a stdio server that blocked on stdin. Corrected to `npx -y activitypub-mcp`.
+- **Interactive runs no longer look hung.** Starting the stdio server directly in a terminal now prints a one-line stderr hint that it is waiting for an MCP client; the hint never appears for a connected (piped) client.
+- **Getting-started docs reconciled with the code.** Removed phantom env vars (`ACTOR_/INSTANCE_/TIMELINE_CACHE_TTL`, `CONCURRENT_REQUESTS`), a removed `HEALTH_CHECK_EXTERNAL_PROBE` setting, and non-existent npm scripts; corrected the `REQUEST_TIMEOUT`/`CACHE_TTL` defaults and a false CORS "renamed from" claim. A new drift test fails CI if a config page documents an env var the code never reads.
+
+### Security
+
+- **Full IPv6 private-range SSRF blocking.** The private-range checks used literal-prefix regexes that matched only the canonical address, leaving most of `fc00::/7` (unique-local) and `fe80::/10` (link-local) reachable — e.g. `https://[fc12:3456::1]`. Replaced with leading-hextet masks covering each block in full, plus deprecated site-local `fec0::/10`.
+- **All GitHub Actions pinned to commit SHAs**, so a retagged or compromised third-party action can no longer run in the credential-bearing release jobs.
+
+### Changed
+
+- **Releases now publish automatically.** `release.yml` and `publish-mcp.yml` are reusable workflows that `auto-release` calls inline after tagging, removing the manual `workflow_dispatch` step the `GITHUB_TOKEN` anti-recursion rule previously required.
+
 ## [3.0.1] - 2026-06-02
 
 ### Security

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.2",
   "name": "activitypub-mcp",
   "display_name": "ActivityPub MCP",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "description": "Security-first, read-only-by-default MCP server for ActivityPub and the Fediverse.",
   "long_description": "Lets an LLM explore and interact with the existing Fediverse — Mastodon, Misskey, Foundkey, Pleroma, and compatible servers. Read-only by default; write tools are opt-in. Untrusted fediverse content is wrapped in an <untrusted-content> envelope before it reaches the model.",
   "author": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "activitypub-mcp",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "activitypub-mcp",
-      "version": "3.0.1",
+      "version": "3.1.0",
       "license": "MIT",
       "dependencies": {
         "@logtape/logtape": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activitypub-mcp",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "description": "A Model Context Protocol server for exploring and interacting with the existing Fediverse",
   "mcpName": "io.github.cameronrye/activitypub-mcp",
   "main": "dist/mcp-main.js",

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -116,7 +116,7 @@ Upgrading from v1.x? See [MIGRATION-v2.md](https://github.com/cameronrye/activit
 
 ---
 
-**Version:** 3.0.1
+**Version:** 3.1.0
 **License:** MIT
 **Maintainer:** Cameron Rye (https://rye.dev/)
 **Repository:** https://github.com/cameronrye/activitypub-mcp

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.cameronrye/activitypub-mcp",
   "description": "Security-first, read-only-by-default MCP server for ActivityPub and the Fediverse.",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "repository": {
     "url": "https://github.com/cameronrye/activitypub-mcp",
     "source": "github"
@@ -12,7 +12,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "activitypub-mcp",
-      "version": "3.0.1",
+      "version": "3.1.0",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/site/src/content/docs/reference/changelog.mdx
+++ b/site/src/content/docs/reference/changelog.mdx
@@ -9,6 +9,24 @@ order: 2
 
 All notable changes to the ActivityPub MCP Server are documented here. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### v3.1.0 - 2026-06-04
+
+**Multi-platform reads &amp; activation fixes.** Misskey/Foundkey instances now work for search, trending, and public timelines; a broken homepage install command and several docs-drift issues are fixed; and an IPv6 SSRF gap is closed. See [CHANGELOG.md](https://github.com/cameronrye/activitypub-mcp/blob/main/CHANGELOG.md) for the complete entry.
+
+#### Added
+
+- **Misskey / Foundkey read support** for `search`, `get-trending-hashtags`, `get-trending-posts`, and `get-public-timeline`, routed per instance by NodeInfo software detection and normalized into Mastodon-shaped results.
+- **Authentication guide** documenting the `activitypub-mcp login` (Mastodon OAuth2 / Misskey MiAuth) flow, credential storage, and multi-account usage.
+
+#### Fixed
+
+- The site's "Quick install" command (`npx activitypub-mcp install` → `npx -y activitypub-mcp`); running the bin directly in a terminal now prints a hint instead of appearing to hang; getting-started docs reconciled with the actual configuration (phantom env vars and wrong defaults removed).
+
+#### Security
+
+- **Full IPv6 private-range SSRF blocking** (`fc00::/7`, `fe80::/10`, `fec0::/10`) — closes a gap where most of those ranges were reachable via crafted IPv6 hosts.
+- **All GitHub Actions pinned to commit SHAs** so a retagged or compromised action can't run in the credential-bearing release jobs.
+
 ### v3.0.1 - 2026-06-02
 
 **Correctness &amp; distribution.** A cross-origin redirect security fix, Misskey and remote-fetch correctness fixes, and the server is now publishable to the official MCP Registry. See [CHANGELOG.md](https://github.com/cameronrye/activitypub-mcp/blob/main/CHANGELOG.md) for the complete entry.

--- a/src/config.ts
+++ b/src/config.ts
@@ -40,7 +40,7 @@ function parseBoolEnv(value: string | undefined, defaultValue: boolean): boolean
 export const SERVER_NAME = process.env.MCP_SERVER_NAME || "activitypub-mcp";
 
 /** MCP Server version */
-export const SERVER_VERSION = process.env.MCP_SERVER_VERSION || "3.0.1";
+export const SERVER_VERSION = process.env.MCP_SERVER_VERSION || "3.1.0";
 
 /**
  * Directory for the persisted credential store (accounts.json).


### PR DESCRIPTION
Cuts **3.1.0**, shipping the work merged in #155 + #156 (which `main` hasn't released yet) and — when merged — exercising the new auto-publish pipeline end-to-end for the first time.

## ⚠️ Merging this triggers a real release
On merge to `main`, `auto-release.yml` detects the version change, tags `v3.1.0`, and (via the reusable-workflow refactor from #155) calls `release.yml` → **npm publish** + GitHub release, then `publish-mcp.yml` → **MCP registry** — automatically, no manual `workflow_dispatch`. This is the validation step for that pipeline. If it stalls, the manual dispatch fallback still works.

## Version stamps (all bumped to 3.1.0, `validate:version` passes)
`package.json` · `package-lock.json` (×2) · `server.json` (×2) · `manifest.json` · `src/config.ts` · `public/llms.txt` footer · site changelog page.

## What 3.1.0 contains (minor — new backward-compatible feature)
- **Added:** Misskey/Foundkey read support (search, trending, public timelines via NodeInfo routing); an Authentication docs page.
- **Fixed:** the broken homepage install command + the bare-run silent hang; getting-started docs reconciled with the code.
- **Security:** full IPv6 private-range SSRF blocking (`fc00::/7`, `fe80::/10`, `fec0::/10`); all GitHub Actions pinned to commit SHAs.
- **Changed:** releases now auto-publish (reusable workflows).

## Verification
- 814 unit tests pass · `validate:version` ✓ · `tsc`/`biome`/build clean · `build:site` ✓ (22 pages).

Review the version number and CHANGELOG wording before merging — once you merge, it publishes. If you'd rather hold the release, this can sit until you're ready.
