### PR TITLE
Sweep stale docs after v3.1.0

### DIFF
--- a/MIGRATION-v2.md
+++ b/MIGRATION-v2.md
@@ -123,6 +123,10 @@ v1 user code path constructs non-https URLs, but `HEALTH_CHECK_URL` is
 operator-configurable. If you set it to an `http://` endpoint in v1, the
 v2 health check will fail. Update to `https://`.
 
+> **Note (v3+):** `HEALTH_CHECK_URL` and the `/health` outbound reach test
+> were removed in v3; `/health` is now a trivial liveness check. See
+> [`MIGRATION-v3.md`](./MIGRATION-v3.md).
+
 ### Blocklist now applied to WebFinger and authenticated writes
 
 v1's `BLOCKED_INSTANCES` only gated read-side calls through the remote
@@ -218,6 +222,13 @@ the outbound connectivity probe (the `/health` endpoint's reach test to
 `mastodon.social`), use the new `HEALTH_CHECK_EXTERNAL_PROBE=false`
 instead.
 
+> **Note (v3+):** This describes the v1 → v2 transition only. In current
+> (v3.x) releases, the `/health` outbound connectivity probe was removed and
+> `/health` is now a trivial liveness check (200 OK, no reach test). All
+> `HEALTH_CHECK_*` env vars — including `HEALTH_CHECK_EXTERNAL_PROBE` and
+> `HEALTH_CHECK_URL` — were removed in v3 and are read by nothing. See
+> [`MIGRATION-v3.md`](./MIGRATION-v3.md).
+
 Reference commit: `1c70764` — `fix(health): replace dead HEALTH_CHECK_ENABLED with HEALTH_CHECK_EXTERNAL_PROBE (M7)`
 
 ## Resource URI changes
@@ -252,7 +263,7 @@ which is the Mastodon-compatible ActivityPub URL.
 > (`https://{domain}/web/statuses/{statusId}`); non-Mastodon implementations
 > (Pleroma, Akkoma, Misskey, etc.) have different status URL shapes and may not
 > resolve via this form. To identify an instance's software before constructing a
-> URL, use the `get-instance-software` tool added in v2.1.0.
+> URL, use the `get-instance-info` tool (which includes the software field).
 
 Reference commit: `a6f8049`
 

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -32,14 +32,13 @@ The two in-repo artifacts already exist:
 
 **Hard ordering constraint — the registry validates the _live_ npm tarball.**
 The registry checks that the published npm package's `package.json` contains a
-matching `mcpName`. No 3.x has ever shipped to npm (`latest` is `2.2.0`; the
-`v3.0.0` tag was created but never published), so `3.0.1` is the first tarball
-to carry `mcpName`. **It must be live on npm before you register** — the
-registry has nothing to validate against otherwise.
+matching `mcpName`. 3.x has shipped to npm (`latest` is `3.1.0`); `3.0.1` was
+the first tarball to carry `mcpName`. **It must be live on npm before you
+register** — the registry has nothing to validate against otherwise.
 
 So the sequence is:
 
-1. Bump the version (e.g. `3.0.1`) — update `package.json`, `package-lock.json`
+1. Bump the version (e.g. `3.1.0`) — update `package.json`, `package-lock.json`
    (`npm install --package-lock-only`), `src/config.ts`, **and** `server.json`
    (both `version` and `packages[0].version`). `npm run validate:version`
    enforces all five agree.
@@ -47,6 +46,12 @@ So the sequence is:
    [`release.yml`](../.github/workflows/release.yml) does this with
    `--provenance --access public`). Now the live tarball carries `mcpName`.
 3. Publish to the registry (§1). Everything downstream (§2) flows from there.
+
+Steps 2 and 3 run **automatically**: merging the version bump from step 1 to
+`main` triggers [`auto-release.yml`](../.github/workflows/auto-release.yml),
+which tags `vX.Y.Z` and calls `release.yml` (npm publish) and
+[`publish-mcp.yml`](../.github/workflows/publish-mcp.yml) (registry) inline as
+reusable workflows in a single run — zero manual steps.
 
 ---
 
@@ -73,23 +78,29 @@ curl "https://registry.modelcontextprotocol.io/v0/servers?search=activitypub-mcp
 [`publish-mcp.yml`](../.github/workflows/publish-mcp.yml) does this in CI with
 **no stored secret** — it authenticates with GitHub Actions OIDC
 (`mcp-publisher login github-oidc`), which the registry maps to the repo owner's
-identity to authorize the `io.github.cameronrye/*` namespace. It is
-`workflow_dispatch`-only and kept **separate** from `release.yml` on purpose:
+identity to authorize the `io.github.cameronrye/*` namespace. It declares both
+`on: workflow_call` and `on: workflow_dispatch`, and `auto-release.yml` calls it
+inline (`uses: ./.github/workflows/publish-mcp.yml`) after the npm release in the
+same run. The normal path is fully automatic on merge to `main`; the manual
+dispatch is only a fallback re-run:
 
 ```bash
-# After the npm release for this version is live:
+# Fallback only — re-run the registry publish on its own:
 gh workflow run publish-mcp.yml
 ```
 
-> **Why separate, not folded into `release.yml`:** a tag pushed by another
-> workflow using `GITHUB_TOKEN` (e.g. `auto-release.yml`) will **not** trigger a
-> separate `on: push: tags` workflow — GitHub's anti-recursion rule. The npm
-> release is therefore dispatched by hand (`gh workflow run release.yml --ref
-> vX.Y.Z`), and the registry publish is its own dispatchable job so a registry
-> hiccup can never break the proven npm-release path, and so it can be re-run on
-> its own. Before relying on the OIDC path, confirm the Actions OIDC subject for
-> `cameronrye/activitypub-mcp` is authorized for the `io.github.cameronrye/*`
-> namespace (it is owner-scoped, so it should be).
+> **Why it runs as a reusable workflow, not as `on: push: tags`:** a tag pushed
+> by another workflow using `GITHUB_TOKEN` (e.g. `auto-release.yml`) will **not**
+> trigger a separate `on: push: tags` workflow — GitHub's anti-recursion rule.
+> `auto-release.yml` sidesteps this by **calling** `release.yml` and
+> `publish-mcp.yml` as reusable workflows within the same merge-triggered run, so
+> it never relies on a tag-push event. The npm release auto-publishes; it is no
+> longer dispatched by hand. Keeping the registry publish as its own reusable
+> (and `workflow_dispatch`-able) job means a registry hiccup can never break the
+> proven npm-release path, and it can be re-run on its own. Before relying on the
+> OIDC path, confirm the Actions OIDC subject for `cameronrye/activitypub-mcp` is
+> authorized for the `io.github.cameronrye/*` namespace (it is owner-scoped, so
+> it should be).
 
 ---
 
@@ -200,9 +211,10 @@ adding a second `packages[]` entry to `server.json` with `"registryType": "mcpb"
 ## 4. Recommended sequence
 
 1. ✅ `mcpName` + `server.json` + contract test + version guard.
-2. ✅ Released 3.0.1 (npm publish with `mcpName` → registry publish). The server
-   is live in the registry, which seeds PulseMCP, mcp.so, and the
-   modelcontextprotocol redirect downstream.
+2. ✅ Released 3.0.1 (npm publish with `mcpName` → registry publish); the latest
+   release is now 3.1.0 (npm `latest` = `3.1.0`). The server is live in the
+   registry, which seeds PulseMCP, mcp.so, and the modelcontextprotocol redirect
+   downstream.
 3. ✅ Built the `.mcpb` and attached it to the v3.0.1 release; committed
    `glama.json`; claimed the Glama listing and deployed its hosted container
    (npx build spec, §2). **Make Release in Glama's UI turns on the install button.**
@@ -216,11 +228,15 @@ adding a second `packages[]` entry to `server.json` with `"registryType": "mcpb"
 ## Open questions / risks (carried from research)
 
 - **npm-first:** registry publish fails until a version with `mcpName` is live on
-  npm; `3.0.1` is the first (no 3.x is on npm yet — `latest` is `2.2.0`).
-- **Tag-trigger anti-recursion:** a `GITHUB_TOKEN`-pushed tag won't fire a
-  separate `on: push: tags` workflow, so the npm release is dispatched manually
-  and the registry publish lives in its own `workflow_dispatch` job
-  ([`publish-mcp.yml`](../.github/workflows/publish-mcp.yml)).
+  npm; `3.0.1` was the first tarball with `mcpName`, and 3.x is published (npm
+  `latest` is `3.1.0`).
+- **Tag-trigger anti-recursion (resolved):** a `GITHUB_TOKEN`-pushed tag won't
+  fire a separate `on: push: tags` workflow, so `auto-release.yml` invokes
+  `release.yml` and `publish-mcp.yml`
+  ([`publish-mcp.yml`](../.github/workflows/publish-mcp.yml)) as reusable
+  workflows in-run — neither the npm release nor the registry publish depends on
+  a tag-push event or manual dispatch. The manual dispatch remains only as a
+  fallback.
 - **OIDC namespace:** verify the Actions OIDC subject maps to
   `io.github.cameronrye/*` before relying on `login github-oidc`.
 - **Unverified sync:** mcp.so's auto-sync from the registry and whether Smithery

--- a/site/src/content/docs/api/resources.mdx
+++ b/site/src/content/docs/api/resources.mdx
@@ -30,7 +30,7 @@ MCP Resources provide read-only access to remote ActivityPub data from any fediv
 
 ### `activitypub://server-info`
 
-Provides comprehensive information about the MCP server instance. In v2 the
+Provides comprehensive information about the MCP server instance. The
 tools/resources/prompts arrays are populated dynamically from the live capability
 registry, so the list never drifts from what the server actually serves.
 
@@ -39,7 +39,7 @@ registry, so the list never drifts from what the server actually serves.
 Returns comprehensive server information including:
 
 - Server name, version, and uptime
-- Available tools, resources, and prompts (live from the registry — v2)
+- Available tools, resources, and prompts (live from the registry)
 - Configuration settings and feature flags
 - Performance statistics
 
@@ -331,14 +331,14 @@ Replace `{domain}` with the instance domain and `{statusId}`
 with the Mastodon status ID. Constructs
 `https://{domain}/web/statuses/{statusId}` internally — the Mastodon-compatible URL.
 
-#### Legacy URI Template (deprecated, removed in 2.1.0)
+#### Legacy URI Template (removed in 2.1.0)
 
 `activitypub://post-thread/{postUrl}`
 
-The original URL-encoded form is still accepted with a deprecation warning. It remains
-useful for non-Mastodon ActivityPub implementations (Pleroma, Akkoma, Misskey, etc.)
-whose status URLs do not match the Mastodon shape. Will be removed in v2.1.0 once
-instance-software detection lands.
+The original URL-encoded form has been removed. The resource handler now rejects
+encoded-URL input with an error. For non-Mastodon ActivityPub implementations
+(Misskey, Calckey, Pixelfed, PeerTube, etc.) whose status URLs do not match the
+Mastodon shape, use the `get-post-thread` tool with the full post URL instead.
 
 #### Content Structure
 
@@ -360,9 +360,9 @@ URI: `activitypub://post-thread/mastodon.social/123456`
 
 > "Show me the full conversation for this post"
 
-**Legacy form (Pleroma/Misskey/etc.)**
+**Non-Mastodon instances (Misskey/Calckey/Pixelfed/PeerTube)**
 
-URI: `activitypub://post-thread/https%3A%2F%2Fpleroma.example%2Fnotice%2FAaBbCc`
+Use the `get-post-thread` tool with the full post URL, e.g. `https://misskey.example/notes/AaBbCc`
 
 </div>
 

--- a/site/src/content/docs/api/tools.mdx
+++ b/site/src/content/docs/api/tools.mdx
@@ -54,37 +54,9 @@ Returns an ActivityPub Actor object with:
 
 <div class="tool-reference">
 
-### `discover-instances`
-
-Discover popular fediverse instances by category, topic, or size.
-
-#### Parameters
-
-| Name | Type | Required | Description |
-|------|------|----------|-------------|
-| `category` | enum | No | Type of fediverse software: "mastodon", "pleroma", "misskey", "peertube", "pixelfed", "lemmy", or "all" |
-| `topic` | string | No | Topic or interest to search for (e.g., "technology", "art", "gaming") |
-| `size` | enum | No | Instance size preference: "small", "medium", or "large" |
-| `region` | string | No | Geographic region or language |
-| `beginnerFriendly` | boolean | No | Show only beginner-friendly instances |
-
-#### Examples
-
-```bash
-# Find Mastodon instances
-discover-instances --category mastodon
-
-# Find technology-focused instances
-discover-instances --topic technology
-
-# Find small, beginner-friendly instances
-discover-instances --size small --beginnerFriendly true
-
-# Find instances in a specific region
-discover-instances --region europe
-```
-
 </div>
+
+> **`discover-instances`** is documented under [Live Instance Discovery](#live-instance-discovery) below — it queries instances.social for real-time data.
 
 ## Information Tools
 
@@ -331,6 +303,7 @@ Discover fediverse instances in real-time using the instances.social API with ad
 | `maxUsers` | number | No | Maximum number of users |
 | `openRegistrations` | boolean | No | Only show instances with open registrations |
 | `sortBy` | enum | No | Sort by: "users", "statuses", "connections", "name" |
+| `sortOrder` | enum | No | Sort direction: "asc" or "desc" (default: "desc") |
 | `limit` | number | No | Number of results (default: 20, max: 50) |
 
 #### Examples
@@ -351,8 +324,8 @@ discover-instances --maxUsers 5000 --sortBy users
 ## Write Tools
 
 Write tools are **disabled by default** and only registered when `ACTIVITYPUB_ENABLE_WRITES=true` is set in the server environment.
-They additionally require OAuth token configuration via `ACTIVITYPUB_ACCOUNTS`.
-See the [Configuration Options](/activitypub-mcp/docs/getting-started/configuration/) page for setup instructions.
+They also require an authenticated account. The recommended way to authenticate is the CLI flow — `activitypub-mcp login <instance>` (Mastodon OAuth2 / Misskey MiAuth), which stores credentials in the on-disk credential store; alternatively set `ACTIVITYPUB_ACCOUNTS` (or `ACTIVITYPUB_DEFAULT_INSTANCE` + `ACTIVITYPUB_DEFAULT_TOKEN`).
+See the [Authentication](/activitypub-mcp/docs/getting-started/authentication/) and [Configuration Options](/activitypub-mcp/docs/getting-started/configuration/) pages for setup instructions.
 
 ### Account Management
 

--- a/site/src/content/docs/development/architecture.mdx
+++ b/site/src/content/docs/development/architecture.mdx
@@ -15,7 +15,7 @@ order: 1
 
 ↕ HTTP/HTTPS
 
-**Fediverse Layer** — Mastodon, Pixelfed, PeerTube, Other ActivityPub Servers
+**Fediverse Layer** — Mastodon, Misskey/Foundkey, Pixelfed, PeerTube, Other ActivityPub Servers
 
 ## Core Components
 
@@ -39,25 +39,15 @@ HTTP client for communicating with fediverse servers
 - HTTP request optimization
 - Error handling and retries
 
-### Performance Monitor
+As of v3.1.0, reads and writes are routed by NodeInfo software detection. A dedicated Misskey/Foundkey read adapter (`src/activitypub/read-adapter.ts`) normalizes Misskey responses into Mastodon shapes for `search`, trending hashtags/posts, and public timelines, so these tools work on Misskey/Foundkey instances as well as Mastodon-compatible ones.
 
-System performance tracking and metrics collection
+### Health Endpoint
 
-#### Key Features:
-- Request timing and latency tracking
-- Memory usage monitoring
-- Error rate tracking
-- Performance analytics
-
-### Health Checker
-
-System health monitoring and diagnostics
+Liveness check for the HTTP transport
 
 #### Key Features:
-- Server status verification
-- Dependency health checks
-- Resource availability monitoring
-- Diagnostic reporting
+- Trivial `/health` liveness endpoint returning `{ status: "ok" }`
+- No dependency, connectivity, or readiness probing
 
 ### Instance Discovery
 
@@ -156,10 +146,12 @@ Secure error handling that doesn't leak sensitive information
 Intelligent caching reduces redundant requests and improves response times
 
 #### Cache Layers:
-- **WebFinger Cache:** 5-minute TTL for actor resolution
-- **Actor Profile Cache:** 5-minute TTL for profile data
-- **Instance Info Cache:** 15-minute TTL for instance metadata
-- **Error Cache:** 1-minute TTL for failed requests
+The remote client (`src/activitypub/remote-client.ts`) keeps two LRU caches — an instance-info cache and an ETag cache — and the WebFinger client keeps its own response and actor caches. All use the shared `CACHE_TTL` (default 300000 ms = 5 minutes), configurable via the `CACHE_TTL` env var.
+
+- **WebFinger Cache:** 5-minute default TTL for actor resolution
+- **Actor Profile Cache:** 5-minute default TTL for profile data
+- **Instance Info Cache:** 5-minute default TTL for instance metadata
+- **ETag Cache:** 5-minute default TTL for conditional requests
 
 ### Request Optimization
 
@@ -214,9 +206,9 @@ RFC 7033 standard for resource discovery
 
 ### Performance Metrics
 
-Comprehensive performance tracking and analysis
+The server does not currently track or expose performance metrics — there is no perf-monitoring code. The items below are aspirational and not part of the current implementation:
 
-#### Tracked Metrics:
+#### Aspirational Metrics:
 - Request latency and throughput
 - Error rates and types
 - Cache hit/miss ratios
@@ -224,9 +216,9 @@ Comprehensive performance tracking and analysis
 
 ### Health Monitoring
 
-Continuous health checks and system diagnostics
+The only health surface is the `/health` liveness endpoint, which returns a trivial `{ status: "ok" }`. It does not perform continuous, dependency, or configuration health checks. The items below are aspirational and not part of the current implementation:
 
-#### Health Checks:
+#### Aspirational Health Checks:
 - Server responsiveness
 - External dependency status
 - Resource availability

--- a/site/src/content/docs/development/dependencies.mdx
+++ b/site/src/content/docs/development/dependencies.mdx
@@ -10,16 +10,17 @@ order: 2
 ### Core Dependencies
 
 - **@modelcontextprotocol/sdk:** MCP protocol implementation
-- **node-fetch:** HTTP client for ActivityPub requests
-- **@types/node:** TypeScript definitions for Node.js
-- **typescript:** TypeScript compiler and tooling
+- **@logtape/logtape:** Structured logging
+- **undici:** HTTP client for ActivityPub requests
+- **zod:** Schema validation
 
 ### Development Dependencies
 
 - **@biomejs/biome:** Linting and formatting
-- **vitest:** Testing framework
-- **@types/jest:** TypeScript definitions for testing
+- **vitest** (+ **@vitest/coverage-v8**): Testing framework and coverage
 - **tsx:** TypeScript execution environment
+- **typescript:** TypeScript compiler and tooling
+- **@types/node:** TypeScript definitions for Node.js
 
 ## Package Management
 
@@ -109,8 +110,8 @@ npm audit --json > audit-report.json
 ### Bundle Size Analysis
 
 ```bash
-# Analyze bundle size
-npm run build:analyze
+# Build the project
+npm run build
 
 # Check package sizes
 npm ls --depth=0

--- a/site/src/content/docs/development/performance.mdx
+++ b/site/src/content/docs/development/performance.mdx
@@ -42,11 +42,17 @@ curl http://localhost:3000/health
 activitypub://server-info
 ```
 
-#### Available Metrics:
-- Request count and timing statistics
-- Memory usage and garbage collection stats
-- Cache performance metrics
-- Error counts and types
+#### Available Information:
+
+`/health` is a liveness-only probe: it returns exactly `\{ status: "ok" \}` and performs no outbound connectivity or readiness check.
+
+The `activitypub://server-info` MCP resource returns server metadata only — no request timing, memory/GC, cache, or error metrics. Its fields are:
+
+- `name`, `version`, and `description`
+- `capabilities` (counts of resources, tools, and prompts)
+- `features` (audit logging, instance blocklist, content warnings, trending content, thread support)
+- `configuration` (rate limit settings and log level)
+- `uptime` and `timestamp`
 
 ### External Monitoring Tools
 
@@ -123,13 +129,9 @@ node --inspect server.js
 
 #### Cache Metrics
 
-```bash
-# Check cache statistics
-curl activitypub://server-info | jq '.statistics'
+The `activitypub://server-info` resource has no `.statistics` field, and `activitypub://` is an MCP resource URI (accessed via the MCP protocol), not an HTTP endpoint that `curl` can fetch. No `cacheHits`/`cacheMisses` are exposed through `server-info` or `/health`.
 
-# Monitor cache hit rate
-watch -n 5 'curl -s activitypub://server-info | jq ".statistics.cacheHits, .statistics.cacheMisses"'
-```
+Cache statistics exist only internally (`LRUCache.getStats` and the WebFinger cache) and are not surfaced to clients.
 
 #### Optimization Strategies
 
@@ -180,9 +182,12 @@ watch -n 5 'curl -s activitypub://server-info | jq ".statistics.cacheHits, .stat
 ```bash
 # Simple performance monitor
 #!/bin/bash
+# Note: activitypub://server-info is an MCP resource URI accessed via the MCP
+# protocol, not an HTTP endpoint — curl cannot fetch it. Time the HTTP liveness
+# probe (/health) instead.
 while true; do
   MEMORY=$(ps -o pid,vsz,rss,comm -p $(pgrep -f activitypub-mcp))
-  RESPONSE_TIME=$(curl -w "%{time_total}" -s -o /dev/null activitypub://server-info)
+  RESPONSE_TIME=$(curl -w "%{time_total}" -s -o /dev/null http://localhost:3000/health)
 
   echo "$(date): Memory: $MEMORY, Response: ${RESPONSE_TIME}s"
 

--- a/site/src/content/docs/getting-started/claude-desktop.mdx
+++ b/site/src/content/docs/getting-started/claude-desktop.mdx
@@ -219,7 +219,7 @@ Claude should chain multiple tools together to fulfill this request.
 **Solutions:**
 
 1. Reduce cache TTL for faster updates
-2. Limit concurrent requests
+2. Lower `RATE_LIMIT_MAX` to throttle outbound requests
 3. Use more specific queries
 4. Clear server cache periodically
 

--- a/site/src/content/docs/getting-started/cross-platform.mdx
+++ b/site/src/content/docs/getting-started/cross-platform.mdx
@@ -29,8 +29,8 @@ npm --version
 #### 2. Install ActivityPub MCP Server
 
 ```bash
-# Quick install
-npx activitypub-mcp install
+# Run directly with npx
+npx -y activitypub-mcp
 
 # Or install globally
 npm install -g activitypub-mcp
@@ -104,7 +104,7 @@ npm --version
 
 ```bash
 # In PowerShell or Command Prompt
-npx activitypub-mcp install
+npx -y activitypub-mcp
 
 # Or install globally
 npm install -g activitypub-mcp
@@ -193,8 +193,8 @@ sudo pacman -S nodejs npm
 #### 2. Install ActivityPub MCP Server
 
 ```bash
-# Quick install
-npx activitypub-mcp install
+# Run directly with npx
+npx -y activitypub-mcp
 
 # Or install globally
 npm install -g activitypub-mcp
@@ -245,13 +245,12 @@ npx @modelcontextprotocol/inspector
 
 Run the server in a container for consistent behavior across platforms:
 
-#### 1. Pull the Docker Image
+#### 1. Build the Docker Image
+
+No prebuilt image is published to a registry; the included Dockerfile is for self-hosting, built from source (Glama builds its own image rather than using this file).
 
 ```bash
-# Pull the latest image
-docker pull activitypub-mcp:latest
-
-# Or build from source
+# Build from source
 git clone https://github.com/cameronrye/activitypub-mcp.git
 cd activitypub-mcp
 docker build -t activitypub-mcp .
@@ -260,13 +259,13 @@ docker build -t activitypub-mcp .
 #### 2. Run the Container
 
 ```bash
-# Basic run
-docker run -p 8080:8080 activitypub-mcp
+# Basic run (stdio transport on stdin/stdout; no port to publish)
+docker run --rm -i activitypub-mcp
 
 # With environment variables
-docker run -p 8080:8080 \
+docker run --rm -i \
   -e LOG_LEVEL=debug \
-  -e CACHE_TTL=600 \
+  -e CACHE_TTL=600000 \
   activitypub-mcp
 ```
 

--- a/site/src/content/docs/getting-started/installation.mdx
+++ b/site/src/content/docs/getting-started/installation.mdx
@@ -137,7 +137,7 @@ npm run mcp
 Run the server in a container:
 
 ```bash
-docker run -p 8080:8080 \
+docker run --rm -i \
   -e LOG_LEVEL=debug \
   activitypub-mcp
 ```

--- a/site/src/content/docs/guides/examples.mdx
+++ b/site/src/content/docs/guides/examples.mdx
@@ -166,7 +166,7 @@ A single call returns the root post plus ancestors and replies. Capped at depth 
 GET activitypub://post-thread/mastodon.social/111234567890
 ```
 
-The legacy `activitypub://post-thread/\{postUrl\}` URL-encoded form is still accepted with a deprecation warning and will be removed in v2.1.0.
+The legacy `activitypub://post-thread/\{postUrl\}` URL-encoded form was removed in v2.1.0 and is now rejected: passing an encoded/`://`-containing value throws an `InvalidParams` error directing you to use `activitypub://post-thread/\{domain\}/\{statusId\}` instead.
 
 #### Step 3: Explore Participants
 

--- a/site/src/content/docs/reference/troubleshooting.mdx
+++ b/site/src/content/docs/reference/troubleshooting.mdx
@@ -17,22 +17,16 @@ order: 1
 
 #### Solutions:
 
-1. **Check server status:**
+1. **Restart the server** by re-launching your MCP client, or run it directly:
    ```bash
-   npm run status
+   npm run mcp
    ```
-1. **Restart the server:**
+1. **Check logs for errors** by enabling verbose logging:
    ```bash
-   npm run restart
+   export LOG_LEVEL=debug
+   npm run mcp
    ```
-1. **Verify configuration:**
-   ```bash
-   npm run config:check
-   ```
-1. **Check logs for errors:**
-   ```bash
-   npm run logs
-   ```
+1. **Verify your environment variables** (read by `src/config.ts`) are set correctly
 
 ### Network Connectivity Problems
 
@@ -122,15 +116,7 @@ order: 1
 
 #### Solutions:
 
-1. **Validate configuration file:**
-   ```bash
-   npm run config:validate
-   ```
-1. **Reset to default configuration:**
-   ```bash
-   npm run config:reset
-   ```
-1. **Check required environment variables**
+1. **Check required environment variables** — configuration is supplied via environment variables read by `src/config.ts`, not a config file
 1. **Review configuration documentation**
 
 ### Claude Desktop Integration

--- a/site/src/content/docs/specifications/activitypub.mdx
+++ b/site/src/content/docs/specifications/activitypub.mdx
@@ -60,10 +60,10 @@ How servers federate with each other
 
 How our server fits into the ecosystem
 
-- Read-only access to public data
+- Read-only access to public data by default
 - Actor and instance discovery
 - Content aggregation and analysis
-- No content creation or modification
+- Optional write tools (post, reply, follow, boost, etc.), gated behind `ACTIVITYPUB_ENABLE_WRITES` and opt-in
 
 ## Core ActivityPub Objects
 


### PR DESCRIPTION
A documentation-accuracy sweep after v3.1.0. Audited every repo + site doc (30 files) against current ground truth and surgically fixed the drift — 13 files changed, docs-only (no code/tests/workflows).

## What was stale and is now fixed
**Release flow** (`docs/distribution.md`) — the biggest one. It still described the old manual `gh workflow run` / `workflow_dispatch` / tag-re-push process and the GITHUB_TOKEN anti-recursion problem as unsolved. Rewrote it: releases now auto-publish (`auto-release` calls `release.yml` + `publish-mcp.yml` inline as reusable workflows); manual dispatch is documented as a fallback only. Also refreshed npm-version claims (`latest` is **3.1.0**, not 2.2.0/3.0.0).

**Misskey reads** — noted in architecture + resources docs that `search` / trending / public-timeline now work on Misskey/Foundkey via the NodeInfo-routed read adapter (previously implied Mastodon-only).

**Removed descriptions of things that don't exist:**
- A phantom `discover-instances` parameter set (`category`/`topic`/`size`/`region`/`beginnerFriendly`) and a duplicate entry → kept the single real (live) one and added its missing `sortOrder` param (tools).
- A non-existent "Performance Monitor" component and a `curl activitypub://server-info | jq '.statistics'` example (the telemetry subsystem was removed in v3; `server-info` is an MCP resource, not an HTTP endpoint) (architecture, performance).
- Phantom npm scripts (`npm run status/restart/config:check/logs/build:analyze`) → real commands (troubleshooting, dependencies).
- The broken `npx activitypub-mcp install` command → `npx -y activitypub-mcp` (installation, cross-platform, examples, claude-desktop).

**Corrected facts:** `/health` is liveness-only; Docker runs stdio (`--rm -i`, no port to publish, build-from-source); `CACHE_TTL` is in ms; write tools are opt-in (the ActivityPub spec page no longer claims "no content creation or modification"); the recommended auth path is `activitypub-mcp login`; forward-looking v3 notes added to MIGRATION-v2 for the removed `HEALTH_CHECK_*` vars.

## Verification
- `llms-registry-sync` + `config-env-drift` drift guards pass · full suite **814 tests** pass · `build:site` clean (22 pages, all MDX valid).

## Method
Ran a 9-area audit → per-file surgical fixes (workflow), then hand-fixed 5 doc-file findings the audit had mis-categorized as code-level. Historical CHANGELOG / per-version sections were intentionally left untouched.
