### PR TITLE
Shrink the oversized Glama badge in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,12 @@
 
 <p align="center">
   <a href="https://github.com/cameronrye/activitypub-mcp/actions"><img src="https://github.com/cameronrye/activitypub-mcp/actions/workflows/ci.yml/badge.svg" alt="CI" /></a>
-  <a href="https://glama.ai/mcp/servers/cameronrye/activitypub-mcp"><img src="https://glama.ai/mcp/servers/cameronrye/activitypub-mcp/badge" alt="Glama" /></a>
   <a href="https://www.npmjs.com/package/activitypub-mcp"><img src="https://img.shields.io/npm/dm/activitypub-mcp.svg" alt="npm downloads" /></a>
   <a href="https://github.com/cameronrye/activitypub-mcp"><img src="https://img.shields.io/github/stars/cameronrye/activitypub-mcp?style=social" alt="GitHub stars" /></a>
+</p>
+
+<p align="center">
+  <a href="https://glama.ai/mcp/servers/cameronrye/activitypub-mcp"><img src="https://glama.ai/mcp/servers/cameronrye/activitypub-mcp/badge" alt="Glama quality and maintenance score" width="200" /></a>
 </p>
 
 ---


### PR DESCRIPTION
The Glama badge is a 760×400 card, not a flat shields.io badge, so wedging it into the row of ~20px badges made it dominate the header. Move it onto its own centered line and cap it at 200px wide so it reads as a compact card.