### PR TITLE
v3.1.1: upload-media exfil guard, Misskey + pagination fixes, ship .mcpb on every release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -143,6 +143,20 @@ jobs:
     - name: Pack release tarball
       run: npm pack
 
+    - name: Build Claude Desktop Extension (.mcpb)
+      # The README's one-click install points at this asset on the latest
+      # release, so every release MUST carry it. Build a self-contained bundle
+      # (ESM entrypoint needs its own package.json + prod node_modules) per the
+      # steps in docs/distribution.md §3.
+      run: |
+        npm install -g @anthropic-ai/mcpb
+        stage="$(mktemp -d)"
+        cp manifest.json package.json package-lock.json "$stage"/
+        cp -R dist "$stage"/dist
+        ( cd "$stage" && npm ci --omit=dev --ignore-scripts )
+        mcpb validate manifest.json
+        mcpb pack "$stage" "activitypub-mcp-${{ steps.get_version.outputs.VERSION }}.mcpb"
+
     - name: Create Release
       uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3
       env:
@@ -154,9 +168,11 @@ jobs:
         draft: false
         prerelease: false
         # Attach the full npm tarball — individual JS files would have
-        # broken inter-module imports if anyone tried to wget+run them.
+        # broken inter-module imports if anyone tried to wget+run them — plus
+        # the .mcpb bundle the README's one-click Claude Desktop install needs.
         files: |
           activitypub-mcp-${{ steps.get_version.outputs.VERSION }}.tgz
+          activitypub-mcp-${{ steps.get_version.outputs.VERSION }}.mcpb
 
     - name: Upload build artifacts
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.1.1] - 2026-06-05
+
+### Security
+
+- **`upload-media` validates file content before sending.** The tool read whatever
+  `filePath` the model supplied and forwarded it to the instance with no type check, so a
+  prompt-injected model (injection arriving through the read tools that surface fediverse
+  content) could name an arbitrary path — an SSH key, the credential store, a `.env` — and
+  exfiltrate it to a public media URL. Files are now sniffed by magic bytes and rejected
+  unless they are a recognized image/video/audio type, neutralizing the exfiltration vector
+  while preserving the ability to upload media from anywhere on disk.
+
+### Fixed
+
+- **Misskey relationship results.** `users/relation` returns the relation wrapped in a
+  one-element array for a single user id (its `res` schema is `oneOf: [object, array]`); the
+  adapter read it as a bare object, so `following` / `followed_by` / `muting` / `blocking` /
+  `requested` silently came back `false` after every Misskey follow, mute, or block. Both
+  response shapes are now handled.
+- **Outbox pagination no longer reports phantom "more".** `fetchActorOutboxPaginated` set
+  `hasMore: true` whenever a page was full (`items.length === limit`), even with no `next`
+  cursor to follow — so a caller on a full final page would loop on the same page. `hasMore`
+  is now true only when there is a cursor to follow.
+
+### Distribution
+
+- **The Claude Desktop Extension (`.mcpb`) is built and attached to every release.** The
+  README's one-click install points at this asset on the latest release, but it had only
+  ever been attached to v3.0.1 by hand; `release.yml` now builds the bundle and uploads it
+  on every release, and a test fails CI if the workflow stops doing so.
+
+### Changed
+
+- **LLM-facing reference files reconciled with the code.** `public/llms.txt` and
+  `public/llms-full.txt` no longer describe removed surfaces (the `/metrics` endpoint,
+  a "metrics tool", the `HEALTH_CHECK_EXTERNAL_PROBE` / `ENABLE_PERFORMANCE_MONITORING`
+  env vars) or non-existent tool/prompt names in their examples, and now document the
+  read-only-by-default posture and the `ACTIVITYPUB_ENABLE_WRITES` master switch.
+
 ## [3.1.0] - 2026-06-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ npx -y activitypub-mcp
 
 ### Claude Desktop
 
-**One-click:** download `activitypub-mcp.mcpb` from the [latest release](https://github.com/cameronrye/activitypub-mcp/releases/latest) and open it in Claude Desktop.
+**One-click:** download the `.mcpb` bundle (`activitypub-mcp-<version>.mcpb`) from the [latest release](https://github.com/cameronrye/activitypub-mcp/releases/latest) and open it in Claude Desktop.
 
 **Manual:** edit `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) or `%APPDATA%\Claude\claude_desktop_config.json` (Windows):
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.2",
   "name": "activitypub-mcp",
   "display_name": "ActivityPub MCP",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Security-first, read-only-by-default MCP server for ActivityPub and the Fediverse.",
   "long_description": "Lets an LLM explore and interact with the existing Fediverse — Mastodon, Misskey, Foundkey, Pleroma, and compatible servers. Read-only by default; write tools are opt-in. Untrusted fediverse content is wrapped in an <untrusted-content> envelope before it reaches the model.",
   "author": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "activitypub-mcp",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "activitypub-mcp",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "license": "MIT",
       "dependencies": {
         "@logtape/logtape": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activitypub-mcp",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "A Model Context Protocol server for exploring and interacting with the existing Fediverse",
   "mcpName": "io.github.cameronrye/activitypub-mcp",
   "main": "dist/mcp-main.js",

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -21,19 +21,19 @@
 
 The ActivityPub MCP Server is a Fediverse client that allows AI assistants to discover actors, fetch timelines, explore instances, and search content across the decentralized social web. It implements the complete MCP specification with resources for data access, tools for interaction, and prompts for guided exploration.
 
-### Key Features (v3.0.0)
+### Key Features
 
-- **Fediverse Integration**: Connect to any ActivityPub server (Mastodon, Pleroma, Misskey, etc.)
-- **WebFinger Discovery**: Find and resolve actors across the network (same-origin self link enforced in v2)
+- **Read-only by default**: discovery and timeline tools need no credentials; every write/mutation tool is opt-in behind `ACTIVITYPUB_ENABLE_WRITES` and is not even registered unless that flag is set
+- **Fediverse Integration**: Mastodon, Pleroma, Misskey, Foundkey, and compatible servers; Misskey-family reads are routed per instance by NodeInfo software detection and normalized into the same Mastodon-shaped results
+- **WebFinger Discovery**: Find and resolve actors across the network (same-origin self link enforced)
 - **37 MCP Tools**: 9 read-only discovery/timeline + 28 authenticated (post, follow, boost, polls, media, schedule)
 - **10 MCP Resources, 5 MCP Prompts**: `server-info` dynamic from live capability registry
-- **Multi-Account Support**: Pipe-delimited `ACTIVITYPUB_ACCOUNTS` config; per-call account selection
-- **Dual Transport**: stdio (default, for Claude Desktop / Cursor) and HTTP (Bearer-authenticated `/mcp` + `/metrics`)
+- **Multi-Account Support**: `activitypub-mcp login` (Mastodon OAuth2 / Misskey MiAuth) or pipe-delimited `ACTIVITYPUB_ACCOUNTS`; per-call account selection
+- **Dual Transport**: stdio (default, for Claude Desktop / Cursor) and HTTP (Bearer-authenticated `/mcp`)
 - **TypeScript Implementation**: Modern, strict TypeScript with ESM, topic-organized source tree
 - **Cross-Platform Support**: Works on Windows, macOS, and Linux (Node 20+ required)
-- **Security-Hardened**: SSRF guard on every outbound call, streaming response-size caps (default 10MB), HTTPS-only outbound, instance blocklist, thread cross-origin gating, audit logging on every write tool
-- **Performance Monitoring**: Comprehensive logging, metrics tool, in-memory caches
-- **Testing**: 624+ unit tests plus a daily integration workflow against the live Fediverse
+- **Security-Hardened**: SSRF guard on every outbound call (full IPv4 + IPv6 private-range blocking), streaming response-size caps (default 10MB), HTTPS-only outbound, credential stripping on cross-origin redirects, instance blocklist, thread cross-origin gating, `upload-media` content-type validation, audit logging on every write tool
+- **Testing**: 830+ unit tests plus a daily integration workflow against the live Fediverse
 
 ### Architecture
 
@@ -162,34 +162,38 @@ Create a `.env` file in your project root or set these environment variables. Au
 ```bash
 # ---- Core ----
 LOG_LEVEL=info                                  # debug | info | warning | error | fatal
-USER_AGENT=ActivityPub-MCP-Client/3.0.0
 REQUEST_TIMEOUT=15000                           # production default: 10000
 CACHE_TTL=300                                   # seconds
 RATE_LIMIT_ENABLED=true
 RATE_LIMIT_MAX=100
 RATE_LIMIT_WINDOW=900000
 
+# ---- Writes (off by default) ----
+ACTIVITYPUB_ENABLE_WRITES=false                 # master switch. While false, NO mutation tool
+                                                # (post/follow/boost/media/...) is registered, so
+                                                # prompt-injected content cannot name a tool that
+                                                # does not exist. Set true to opt in.
+
 # ---- HTTP transport (only when MCP_TRANSPORT_MODE=http) ----
 MCP_TRANSPORT_MODE=stdio                        # stdio | http
 MCP_HTTP_PORT=3000
 MCP_HTTP_HOST=127.0.0.1
 MCP_HTTP_SECRET=                                # REQUIRED for http. 32+ random chars.
-                                                # All /mcp + /metrics requests must include
+                                                # All /mcp requests must include
                                                 # `Authorization: Bearer <secret>`. /health stays open.
-MCP_HTTP_CORS_ORIGINS=                          # v2 default empty (no origins). Was "*" in v1.
+MCP_HTTP_CORS_ORIGINS=                          # default empty (no origins).
+MCP_HTTP_ALLOWED_HOSTS=                         # DNS-rebinding allowlist; required for non-localhost binds.
 
 # ---- Authenticated write tools ----
-# v2 uses PIPE (|) delimiter. v1 colon format is rejected at startup.
+# Preferred: `activitypub-mcp login` (Mastodon OAuth2 / Misskey MiAuth), which stores
+# credentials under ~/.config/activitypub-mcp/accounts.json. Or supply them inline:
+# PIPE (|) delimiter; legacy colon format is rejected at startup.
 ACTIVITYPUB_ACCOUNTS=id|instance|token|user|label,id2|instance|token|user|label
 
-# ---- Thread traversal caps (v2) ----
+# ---- Thread traversal caps ----
 MCP_THREAD_MAX_DEPTH=5
 MCP_THREAD_MAX_REPLIES=50
-MCP_THREAD_CROSS_ORIGIN_FETCH=false             # set true to restore v1 fetch-everything
-
-# ---- Health ----
-HEALTH_CHECK_EXTERNAL_PROBE=true                # gates outbound mastodon.social probe
-                                                # (replaces removed HEALTH_CHECK_ENABLED)
+MCP_THREAD_CROSS_ORIGIN_FETCH=false             # set true to fetch cross-origin replies
 ```
 
 ### Configuration Files
@@ -302,7 +306,7 @@ Use the `discover-actor` tool to find actors across the Fediverse:
 ```typescript
 // Using MCP client
 const result = await client.callTool("discover-actor", {
-  handle: "@username@instance.com"
+  identifier: "@username@instance.com"
 });
 ```
 
@@ -312,7 +316,7 @@ Retrieve an actor's public posts:
 
 ```typescript
 const timeline = await client.callTool("fetch-timeline", {
-  handle: "@username@instance.com",
+  identifier: "@username@instance.com",
   limit: 20
 });
 ```
@@ -322,9 +326,9 @@ const timeline = await client.callTool("fetch-timeline", {
 Search for posts, accounts, or hashtags:
 
 ```typescript
-const results = await client.callTool("search-fediverse", {
+const results = await client.callTool("search", {
   query: "activitypub",
-  type: "statuses",
+  type: "posts",
   limit: 10
 });
 ```
@@ -338,7 +342,7 @@ All MCP operations return structured error responses:
 ```typescript
 try {
   const result = await client.callTool("discover-actor", {
-    handle: "@invalid@nonexistent.com"
+    identifier: "@invalid@nonexistent.com"
   });
 } catch (error) {
   if (error.code === "InvalidParams") {
@@ -388,7 +392,7 @@ The server respects instance rate limits and implements exponential backoff:
 ```typescript
 // Step 1: Discover the actor
 const discovery = await client.callTool("discover-actor", {
-  handle: "@gargron@mastodon.social"
+  identifier: "@gargron@mastodon.social"
 });
 
 // Step 2: Fetch actor profile
@@ -398,7 +402,7 @@ const actor = await client.readResource(
 
 // Step 3: Fetch recent posts
 const timeline = await client.callTool("fetch-timeline", {
-  handle: "@gargron@mastodon.social",
+  identifier: "@gargron@mastodon.social",
   limit: 10
 });
 
@@ -410,21 +414,21 @@ console.log(`Posts: ${timeline.orderedItems.length}`);
 
 ```typescript
 // Search for posts about a topic
-const posts = await client.callTool("search-fediverse", {
+const posts = await client.callTool("search", {
   query: "activitypub protocol",
-  type: "statuses",
+  type: "posts",
   limit: 20
 });
 
 // Search for accounts
-const accounts = await client.callTool("search-fediverse", {
+const accounts = await client.callTool("search", {
   query: "developer",
   type: "accounts",
   limit: 10
 });
 
 // Search for hashtags
-const hashtags = await client.callTool("search-fediverse", {
+const hashtags = await client.callTool("search", {
   query: "opensource",
   type: "hashtags",
   limit: 5
@@ -443,25 +447,24 @@ console.log(`Instance: ${instance.title}`);
 console.log(`Users: ${instance.stats.user_count}`);
 console.log(`Posts: ${instance.stats.status_count}`);
 
-// Explore instance using tool
-const exploration = await client.callTool("explore-instance", {
-  domain: "mastodon.social",
-  include_stats: true
+// Get instance details using a tool
+const exploration = await client.callTool("get-instance-info", {
+  domain: "mastodon.social"
 });
 ```
 
 ### Example 4: Using Prompts
 
 ```typescript
-// Use the fediverse-discovery prompt
-const discovery = await client.getPrompt("fediverse-discovery", {
-  topic: "open source software",
-  instance: "fosstodon.org"
+// Use the explore-fediverse prompt
+const discovery = await client.getPrompt("explore-fediverse", {
+  interests: "open source software",
+  instanceType: "mastodon"
 });
 
-// Use the actor-analysis prompt
-const analysis = await client.getPrompt("actor-analysis", {
-  handle: "@gargron@mastodon.social"
+// Use the analyze-user-activity prompt
+const analysis = await client.getPrompt("analyze-user-activity", {
+  identifier: "@gargron@mastodon.social"
 });
 ```
 
@@ -471,9 +474,9 @@ Find popular open source projects on the Fediverse:
 
 ```typescript
 // 1. Search for open source content
-const results = await client.callTool("search-fediverse", {
+const results = await client.callTool("search", {
   query: "open source",
-  type: "statuses",
+  type: "posts",
   limit: 50
 });
 
@@ -489,7 +492,7 @@ for (const handle of actors) {
   );
 
   const timeline = await client.callTool("fetch-timeline", {
-    handle: `@${handle}`,
+    identifier: `@${handle}`,
     limit: 10
   });
 
@@ -501,7 +504,7 @@ for (const handle of actors) {
 
 ## Development
 
-### Project Structure (v2 — topic-organized)
+### Project Structure (topic-organized)
 
 ```
 activitypub-mcp/
@@ -515,13 +518,15 @@ activitypub-mcp/
 │   │   ├── resources.ts              # 10 resources
 │   │   ├── prompts.ts                # 5 prompts
 │   │   └── capabilities.ts           # Dynamic capability registry
-│   ├── activitypub/                  # ActivityPub client
-│   │   └── remote-client.ts
-│   ├── discovery/                    # WebFinger and instance discovery
+│   ├── discovery/                    # WebFinger, NodeInfo, instance discovery
 │   │   ├── webfinger.ts
-│   │   ├── instance-discovery.ts
+│   │   ├── nodeinfo.ts               # software detection (Mastodon vs Misskey)
+│   │   ├── software-kind.ts
 │   │   └── dynamic-instance-discovery.ts
-│   ├── auth/                         # Account management + credentials
+│   ├── activitypub/                  # ActivityPub client + read adapter
+│   │   ├── remote-client.ts
+│   │   └── read-adapter.ts           # per-instance read routing (Misskey reads)
+│   ├── auth/                         # Login (OAuth2/MiAuth), accounts, write adapters
 │   ├── policy/                       # Instance blocklist
 │   │   └── instance-blocklist.ts
 │   ├── audit/                        # Audit logging
@@ -539,7 +544,7 @@ activitypub-mcp/
 │   └── utils/                        # Errors, HTML stripping
 │       ├── errors.ts
 │       └── html.ts
-├── tests/                            # 624+ unit tests + integration suite
+├── tests/                            # 830+ unit tests + integration suite
 ├── docs/specifications/              # Protocol reference guides
 ├── scripts/
 │   ├── install.sh / install.ps1      # Installer
@@ -614,22 +619,16 @@ npm run build:site
 npm run preview:site
 ```
 
-### Performance Monitoring
+### Logging
 
-The server includes built-in performance monitoring:
+The server uses structured logging via LogTape. Set the level with `LOG_LEVEL`
+(`debug | info | warning | error | fatal`). On stdio, logs go to stderr so they
+never corrupt the MCP protocol stream on stdout. Audit logging records every
+write-tool invocation (tool name, parameters, success/failure, duration).
 
-```typescript
-// Enable performance monitoring
-ENABLE_PERFORMANCE_MONITORING=true
-PERFORMANCE_LOG_INTERVAL=60000  // Log every 60 seconds
+```bash
+LOG_LEVEL=debug   # verbose; surfaces every outbound request and cache hit/miss
 ```
-
-Metrics tracked:
-- Request latency
-- Cache hit/miss rates
-- Error rates
-- Memory usage
-- Active connections
 
 ### Security
 
@@ -639,8 +638,8 @@ Security best practices:
 2. **Input Validation**: All inputs are validated using Zod schemas
 3. **Rate Limiting**: Respects instance rate limits
 4. **Error Handling**: Comprehensive error handling and logging
-5. **HTTPS**: All external requests use HTTPS
-6. **No Credentials**: Server operates as a read-only client
+5. **HTTPS**: All external requests use HTTPS (non-https schemes are rejected)
+6. **Read-only by default**: write/mutation tools are not registered unless `ACTIVITYPUB_ENABLE_WRITES=true`
 
 ### Contributing
 
@@ -799,7 +798,7 @@ MCP is a protocol for integrating context providers with LLM applications.
 **Problem:** Server fails to start or crashes immediately.
 
 **Solutions:**
-1. Check Node.js version: `node --version` (must be 18.0.0+)
+1. Check Node.js version: `node --version` (must be 20.0.0+)
 2. Reinstall dependencies: `npm install`
 3. Clear cache: `npm cache clean --force`
 4. Check for port conflicts
@@ -917,7 +916,38 @@ Log levels:
 
 The canonical changelog lives in [CHANGELOG.md](https://github.com/cameronrye/activitypub-mcp/blob/main/CHANGELOG.md). Highlights:
 
-### Version 3.0.1 (Current) — 2026-06-02
+### Version 3.1.1 (Current)
+
+Correctness and distribution patch.
+
+**Fixed:**
+- Misskey relationship results: `users/relation` returns the relation wrapped in an array for a single user id, which the adapter read as a bare object — so follow / mute / block relationship fields silently came back `false`. Both shapes are now handled.
+- Outbox pagination no longer reports `hasMore: true` without a cursor to follow (a full final page with no `next` link previously looked like there was more).
+
+**Security:**
+- `upload-media` validates that the file content is an actual image/video/audio file (by magic bytes, not extension) before sending. A prompt-injected model can no longer name an arbitrary path (a key, the credential store, a `.env`) and exfiltrate it to a public media URL.
+
+**Distribution:**
+- The Claude Desktop Extension (`.mcpb`) is now built and attached to every GitHub Release, so the README's one-click install always resolves on the latest release.
+
+### Version 3.1.0 — 2026-06-04
+
+**Added:**
+- Misskey / Foundkey read support: `search`, `get-trending-hashtags`, `get-trending-posts`, and `get-public-timeline` now work on Misskey-family instances, routed per instance by NodeInfo software detection and normalized into Mastodon-shaped results.
+- Authentication guide on the docs site covering the `activitypub-mcp login` (Mastodon OAuth2 / Misskey MiAuth) flow, credential storage, and multi-account usage.
+
+**Fixed:**
+- Corrected the site's "Quick install" command and added a one-line stderr hint so an interactive stdio start no longer looks hung.
+- Reconciled getting-started docs with the code (removed phantom env vars; a drift test now fails CI on documentation of an env var the code never reads).
+
+**Security:**
+- Full IPv6 private-range SSRF blocking (`fc00::/7`, `fe80::/10`, `fec0::/10`) via leading-hextet masks, replacing literal-prefix regexes that matched only canonical addresses.
+- All GitHub Actions pinned to commit SHAs.
+
+**Changed:**
+- Releases publish automatically: `release.yml` and `publish-mcp.yml` are reusable workflows called inline after tagging.
+
+### Version 3.0.1 — 2026-06-02
 
 Correctness and distribution release.
 
@@ -994,8 +1024,8 @@ Copyright (c) 2025 ActivityPub MCP Server Contributors
 
 **Built With:**
 - TypeScript
-- Model Context Protocol SDK
-- Fedify (ActivityPub framework)
+- Model Context Protocol SDK (`@modelcontextprotocol/sdk`)
+- undici (HTTP client)
 - LogTape (Logging)
 - Zod (Validation)
 

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -6,14 +6,15 @@
 
 The ActivityPub MCP Server is a Fediverse client that allows AI assistants to discover actors, fetch timelines, explore instances, and search content across the decentralized social web. It implements the complete MCP specification with resources for data access, tools for interaction, and prompts for guided exploration.
 
-### Key Features (v3.0.0)
+### Key Features
 
-- **Fediverse Integration**: Connect to any ActivityPub server (Mastodon, Pleroma, Misskey, etc.)
+- **Read-only by default**: discovery and timeline tools work with no credentials; all write/mutation tools are opt-in behind `ACTIVITYPUB_ENABLE_WRITES`
+- **Fediverse Integration**: Mastodon, Pleroma, Misskey, Foundkey, and compatible ActivityPub servers; Misskey-family reads are routed per instance by NodeInfo software detection
 - **WebFinger Discovery**: Find and resolve actors across the network
 - **37 MCP Tools**: 9 read-only discovery/timeline + 28 authenticated (post, follow, boost, polls, media, schedule)
 - **10 MCP Resources, 5 MCP Prompts**: Including dynamic `server-info` from the live capability registry
-- **Multi-Account Support**: Pipe-delimited `ACTIVITYPUB_ACCOUNTS` config; per-call account selection
-- **Dual Transport**: stdio (Claude Desktop / Cursor) and HTTP (Bearer-authenticated `/mcp` + `/metrics`)
+- **Multi-Account Support**: `activitypub-mcp login` (Mastodon OAuth2 / Misskey MiAuth) or pipe-delimited `ACTIVITYPUB_ACCOUNTS`; per-call account selection
+- **Dual Transport**: stdio (Claude Desktop / Cursor) and HTTP (Bearer-authenticated `/mcp`)
 - **TypeScript Implementation**: Modern, type-safe codebase with strict TS and ESM
 - **Cross-Platform Support**: Works on Windows, macOS, and Linux (Node 20+)
 - **Security-Hardened**: SSRF guard on all outbound calls, streaming response-size caps, instance blocklist, thread cross-origin gating, audit logging on every write tool
@@ -116,7 +117,7 @@ Upgrading from v1.x? See [MIGRATION-v2.md](https://github.com/cameronrye/activit
 
 ---
 
-**Version:** 3.1.0
+**Version:** 3.1.1
 **License:** MIT
 **Maintainer:** Cameron Rye (https://rye.dev/)
 **Repository:** https://github.com/cameronrye/activitypub-mcp

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.cameronrye/activitypub-mcp",
   "description": "Security-first, read-only-by-default MCP server for ActivityPub and the Fediverse.",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "repository": {
     "url": "https://github.com/cameronrye/activitypub-mcp",
     "source": "github"
@@ -12,7 +12,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "activitypub-mcp",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/site/src/content/docs/reference/changelog.mdx
+++ b/site/src/content/docs/reference/changelog.mdx
@@ -9,6 +9,23 @@ order: 2
 
 All notable changes to the ActivityPub MCP Server are documented here. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### v3.1.1 - 2026-06-05
+
+**Correctness &amp; distribution patch.** Closes a media-upload exfiltration vector, fixes Misskey relationship and outbox-pagination bugs, and makes every release ship the one-click Claude Desktop bundle. See [CHANGELOG.md](https://github.com/cameronrye/activitypub-mcp/blob/main/CHANGELOG.md) for the complete entry.
+
+#### Security
+
+- **`upload-media` now validates file content by magic bytes** and refuses anything that is not a recognized image/video/audio file, so a prompt-injected model can no longer name an arbitrary path (a key, the credential store, a `.env`) and exfiltrate it to a public media URL.
+
+#### Fixed
+
+- **Misskey relationship results** — `users/relation` returns a one-element array for a single user id, which the adapter read as a bare object, so follow / mute / block results came back `false`. Both shapes are handled now.
+- **Outbox pagination** no longer reports `hasMore: true` on a full final page with no `next` cursor.
+
+#### Distribution
+
+- The Claude Desktop Extension (`.mcpb`) is built and attached to **every** release, so the README's one-click install always resolves on the latest release.
+
 ### v3.1.0 - 2026-06-04
 
 **Multi-platform reads &amp; activation fixes.** Misskey/Foundkey instances now work for search, trending, and public timelines; a broken homepage install command and several docs-drift issues are fixed; and an IPv6 SSRF gap is closed. See [CHANGELOG.md](https://github.com/cameronrye/activitypub-mcp/blob/main/CHANGELOG.md) for the complete entry.

--- a/src/activitypub/remote-client.ts
+++ b/src/activitypub/remote-client.ts
@@ -365,7 +365,10 @@ export class RemoteActivityPubClient {
     return {
       items,
       totalItems: collection.totalItems,
-      hasMore: !!nextCursor || items.length === limit,
+      // Only "more" if there is a cursor to follow. A full page (`items.length
+      // === limit`) with no `next`/`first` link is the end — reporting hasMore
+      // without a cursor makes callers loop on the same page forever.
+      hasMore: !!nextCursor,
       nextCursor,
       prevCursor,
       collectionId: collection.id,

--- a/src/auth/adapters/misskey-adapter.ts
+++ b/src/auth/adapters/misskey-adapter.ts
@@ -287,13 +287,17 @@ export class MisskeyWriteAdapter implements WriteAdapter {
   }
 
   private async relation(account: AccountCredentials, userId: string): Promise<Relationship> {
-    const rel = await misskeyPostJson<MisskeyRelation>(
+    // Misskey's `users/relation` returns `oneOf: [object, array]`: a single
+    // userId string is answered with the relation wrapped in a one-element array
+    // (`getRelation(...).then(it => [it])`), not a bare object. Unwrap either
+    // shape so the relationship fields aren't silently read off the array.
+    const rel = await misskeyPostJson<MisskeyRelation | MisskeyRelation[]>(
       account,
       "/api/users/relation",
       { userId },
       "get relationship",
     );
-    return relationToRelationship(userId, rel);
+    return relationToRelationship(userId, Array.isArray(rel) ? rel[0] : rel);
   }
 
   async followAccount(

--- a/src/config.ts
+++ b/src/config.ts
@@ -40,7 +40,7 @@ function parseBoolEnv(value: string | undefined, defaultValue: boolean): boolean
 export const SERVER_NAME = process.env.MCP_SERVER_NAME || "activitypub-mcp";
 
 /** MCP Server version */
-export const SERVER_VERSION = process.env.MCP_SERVER_VERSION || "3.1.0";
+export const SERVER_VERSION = process.env.MCP_SERVER_VERSION || "3.1.1";
 
 /**
  * Directory for the persisted credential store (accounts.json).

--- a/src/mcp/tools-write.ts
+++ b/src/mcp/tools-write.ts
@@ -14,6 +14,7 @@ import { accountManager, authenticatedClient } from "../auth/index.js";
 import { ENABLE_WRITES } from "../config.js";
 import type { RateLimiter } from "../resilience/rate-limiter.js";
 import { formatErrorWithSuggestion, getErrorMessage } from "../utils/errors.js";
+import { sniffMediaType } from "../utils/media-type.js";
 import { sanitizeInline, wrapUntrusted } from "../utils/untrusted.js";
 import { trackedMcpServer } from "./capabilities.js";
 
@@ -1856,6 +1857,19 @@ function registerUploadMediaTool(mcpServer: McpServer, rateLimiter: RateLimiter)
         const path = await import("node:path");
 
         const fileBuffer = await fs.readFile(filePath);
+
+        // Validate by content, not extension: only forward actual media. A
+        // model coaxed by prompt-injected fediverse content could otherwise
+        // name any path (~/.ssh/id_rsa, the credential store, a .env file) and
+        // exfiltrate it to a public media URL. A non-media file is refused
+        // before its bytes are handed to the instance.
+        const mediaType = sniffMediaType(fileBuffer);
+        if (!mediaType) {
+          throw new Error(
+            `File is not a recognized media file (image, video, or audio): ${path.basename(filePath)}. upload-media only accepts media files.`,
+          );
+        }
+
         const filename = path.basename(filePath);
 
         const focus =

--- a/src/utils/media-type.ts
+++ b/src/utils/media-type.ts
@@ -1,0 +1,74 @@
+/**
+ * Magic-byte media-type sniffing.
+ *
+ * Used to gate `upload-media`: a file path supplied by the model is only read
+ * and sent to the user's instance if its *content* is a recognized image,
+ * video, or audio file. A path naming a credential store, SSH key, `.env`, or
+ * any other non-media secret is rejected before any bytes leave the process, so
+ * a prompt-injected model cannot turn the media uploader into a file
+ * exfiltration primitive. Detection is by file signature, not extension, so a
+ * secret renamed `cat.png` is still rejected.
+ */
+
+function startsWith(bytes: Uint8Array, sig: number[], offset = 0): boolean {
+  if (bytes.length < offset + sig.length) return false;
+  for (let i = 0; i < sig.length; i++) {
+    if (bytes[offset + i] !== sig[i]) return false;
+  }
+  return true;
+}
+
+function asciiAt(bytes: Uint8Array, offset: number, len: number): string {
+  if (bytes.length < offset + len) return "";
+  let s = "";
+  for (let i = 0; i < len; i++) s += String.fromCharCode(bytes[offset + i]);
+  return s;
+}
+
+/** Map an ISO base-media (`ftyp`) major brand to a concrete media type. */
+function isoBmffType(brand: string): string {
+  const b = brand.trim().toLowerCase();
+  if (b === "qt") return "video/quicktime";
+  if (b.startsWith("m4a")) return "audio/mp4";
+  if (b.startsWith("heic") || b.startsWith("heix") || b === "mif1" || b === "msf1")
+    return "image/heic";
+  if (b.startsWith("avif") || b.startsWith("avis")) return "image/avif";
+  // isom, mp41/mp42, iso2/iso4/iso5/iso6, M4V, dash, etc.
+  return "video/mp4";
+}
+
+/**
+ * Sniff the media type of a file from its leading bytes.
+ *
+ * @returns a MIME type string for recognized image/video/audio formats, or
+ *   `null` if the content is not a media file we accept.
+ */
+export function sniffMediaType(bytes: Uint8Array): string | null {
+  if (bytes.length < 4) return null;
+
+  // Images
+  if (startsWith(bytes, [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])) return "image/png";
+  if (startsWith(bytes, [0xff, 0xd8, 0xff])) return "image/jpeg";
+  if (startsWith(bytes, [0x47, 0x49, 0x46, 0x38])) return "image/gif"; // GIF8
+  if (startsWith(bytes, [0x42, 0x4d])) return "image/bmp"; // BM
+
+  // RIFF container: WEBP (image) or WAVE (audio)
+  if (asciiAt(bytes, 0, 4) === "RIFF") {
+    const form = asciiAt(bytes, 8, 4);
+    if (form === "WEBP") return "image/webp";
+    if (form === "WAVE") return "audio/wav";
+    return null;
+  }
+
+  // ISO base media (MP4/MOV/M4A/HEIC/AVIF): "ftyp" box at offset 4
+  if (asciiAt(bytes, 4, 4) === "ftyp") return isoBmffType(asciiAt(bytes, 8, 4));
+
+  // Audio / video
+  if (startsWith(bytes, [0x1a, 0x45, 0xdf, 0xa3])) return "video/webm"; // EBML (webm/mkv)
+  if (asciiAt(bytes, 0, 4) === "OggS") return "audio/ogg";
+  if (asciiAt(bytes, 0, 3) === "ID3") return "audio/mpeg"; // MP3 with ID3 tag
+  if (bytes[0] === 0xff && (bytes[1] & 0xe0) === 0xe0) return "audio/mpeg"; // MP3 frame sync
+  if (asciiAt(bytes, 0, 4) === "fLaC") return "audio/flac";
+
+  return null;
+}

--- a/tests/unit/mcp-tools-write.test.ts
+++ b/tests/unit/mcp-tools-write.test.ts
@@ -2,6 +2,8 @@
  * Tests for MCP write tool handlers
  */
 
+import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -12,6 +14,18 @@ import { RateLimiter } from "../../src/resilience/rate-limiter.js";
 
 const THIS_FILE = fileURLToPath(import.meta.url);
 const PKG_JSON_PATH = path.resolve(path.dirname(THIS_FILE), "../../package.json");
+
+// A real 1x1 PNG written to a temp path — upload-media now validates that the
+// file content is actually a media file, so the fixture must carry valid PNG
+// magic bytes rather than just any readable path.
+const PNG_FIXTURE_PATH = path.join(os.tmpdir(), "activitypub-mcp-test-pixel.png");
+fs.writeFileSync(
+  PNG_FIXTURE_PATH,
+  Buffer.from(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==",
+    "base64",
+  ),
+);
 
 // Force writes enabled so mutation tools are registered in this test file
 vi.mock("../../src/config.js", async (importOriginal) => {
@@ -689,6 +703,22 @@ describe("MCP Write Tools", () => {
         "Failed to upload media",
       );
     });
+
+    it("rejects a non-media file (no upload, exfiltration guard)", async () => {
+      const uploadMediaMock = authenticatedClient.uploadMedia as Mock;
+      uploadMediaMock.mockClear();
+      const tool = registeredTools.get("upload-media");
+      // package.json is JSON, not a media file — must be refused before any read
+      // leaves the process.
+      const result = await tool?.handler({ filePath: PKG_JSON_PATH });
+
+      expect((result as { isError: boolean }).isError).toBe(true);
+      expect((result as { content: { text: string }[] }).content[0].text).toMatch(
+        /not (a |an )?(recognized )?media|media file|image, video/i,
+      );
+      // The file's bytes must never be handed to the upload client.
+      expect(uploadMediaMock).not.toHaveBeenCalled();
+    });
   });
 
   describe("get-scheduled-posts tool", () => {
@@ -1007,7 +1037,7 @@ describe("MCP Write Tools", () => {
       auditLoggerMock.logToolInvocation.mockClear();
       const tool = registeredTools.get("upload-media");
       expect(tool).toBeDefined();
-      await tool?.handler({ filePath: PKG_JSON_PATH });
+      await tool?.handler({ filePath: PNG_FIXTURE_PATH });
       expect(auditLoggerMock.logToolInvocation).toHaveBeenCalledWith(
         "upload-media",
         expect.anything(),

--- a/tests/unit/media-type.test.ts
+++ b/tests/unit/media-type.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import { sniffMediaType } from "../../src/utils/media-type.js";
+
+/** Build a byte array from a list of byte values, padded to `len` with zeros. */
+function bytes(values: number[], len = values.length): Uint8Array {
+  const out = new Uint8Array(len);
+  out.set(values.slice(0, len));
+  return out;
+}
+
+/** "ftyp" ISO-BMFF box: 4-byte size, "ftyp", 4-byte major brand. */
+function ftyp(brand: string): Uint8Array {
+  const enc = new TextEncoder();
+  return new Uint8Array([
+    0x00,
+    0x00,
+    0x00,
+    0x18,
+    ...enc.encode("ftyp"),
+    ...enc.encode(brand.padEnd(4, " ")),
+    ...new Uint8Array(8),
+  ]);
+}
+
+function ascii(s: string): Uint8Array {
+  return new TextEncoder().encode(s);
+}
+
+describe("sniffMediaType", () => {
+  it("recognizes PNG", () => {
+    expect(sniffMediaType(bytes([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]))).toBe(
+      "image/png",
+    );
+  });
+
+  it("recognizes JPEG", () => {
+    expect(sniffMediaType(bytes([0xff, 0xd8, 0xff, 0xe0]))).toBe("image/jpeg");
+  });
+
+  it("recognizes GIF", () => {
+    expect(sniffMediaType(ascii("GIF89a"))).toBe("image/gif");
+  });
+
+  it("recognizes WebP (RIFF/WEBP)", () => {
+    const b = new Uint8Array(16);
+    b.set(ascii("RIFF"), 0);
+    b.set(ascii("WEBP"), 8);
+    expect(sniffMediaType(b)).toBe("image/webp");
+  });
+
+  it("recognizes MP4 via ftyp", () => {
+    expect(sniffMediaType(ftyp("isom"))).toBe("video/mp4");
+  });
+
+  it("recognizes QuickTime via ftyp", () => {
+    expect(sniffMediaType(ftyp("qt"))).toBe("video/quicktime");
+  });
+
+  it("recognizes WebM (EBML)", () => {
+    expect(sniffMediaType(bytes([0x1a, 0x45, 0xdf, 0xa3]))).toBe("video/webm");
+  });
+
+  it("recognizes Ogg", () => {
+    expect(sniffMediaType(ascii("OggS"))).toBe("audio/ogg");
+  });
+
+  it("recognizes MP3 (ID3)", () => {
+    expect(sniffMediaType(ascii("ID3"))).toBe("audio/mpeg");
+  });
+
+  it("recognizes WAV (RIFF/WAVE)", () => {
+    const b = new Uint8Array(16);
+    b.set(ascii("RIFF"), 0);
+    b.set(ascii("WAVE"), 8);
+    expect(sniffMediaType(b)).toBe("audio/wav");
+  });
+
+  it("recognizes FLAC", () => {
+    expect(sniffMediaType(ascii("fLaC"))).toBe("audio/flac");
+  });
+
+  it("rejects JSON credential-store content", () => {
+    expect(sniffMediaType(ascii('{\n  "accounts": [{ "token": "secret" }]\n}'))).toBeNull();
+  });
+
+  it("rejects an SSH private key", () => {
+    expect(sniffMediaType(ascii("-----BEGIN OPENSSH PRIVATE KEY-----\n"))).toBeNull();
+  });
+
+  it("rejects a dotenv file", () => {
+    expect(sniffMediaType(ascii("API_KEY=sk-live-1234\nDB_PASSWORD=hunter2\n"))).toBeNull();
+  });
+
+  it("rejects plain text", () => {
+    expect(sniffMediaType(ascii("just some notes"))).toBeNull();
+  });
+
+  it("rejects an empty buffer", () => {
+    expect(sniffMediaType(new Uint8Array(0))).toBeNull();
+  });
+});

--- a/tests/unit/misskey-adapter.test.ts
+++ b/tests/unit/misskey-adapter.test.ts
@@ -118,13 +118,18 @@ describe("MisskeyWriteAdapter social ops", () => {
       http.post("https://misskey.test/api/following/create", () => HttpResponse.json({ id: "u2" })),
       http.post("https://misskey.test/api/users/relation", async ({ request }) => {
         relBody = (await request.json()) as Record<string, unknown>;
-        return HttpResponse.json({
-          isFollowing: true,
-          isFollowed: false,
-          isBlocking: false,
-          isMuted: false,
-          hasPendingFollowRequestFromYou: false,
-        });
+        // Misskey returns the relation wrapped in an array for a single userId
+        // string (res schema is `oneOf: [object, array]`; the string branch is
+        // `getRelation(...).then(it => [it])`).
+        return HttpResponse.json([
+          {
+            isFollowing: true,
+            isFollowed: false,
+            isBlocking: false,
+            isMuted: false,
+            hasPendingFollowRequestFromYou: false,
+          },
+        ]);
       }),
     );
     const rel = await adapter.followAccount(account, "u2");
@@ -141,7 +146,7 @@ describe("MisskeyWriteAdapter social ops", () => {
         () => new HttpResponse(null, { status: 204 }),
       ),
       http.post("https://misskey.test/api/users/relation", () =>
-        HttpResponse.json({ isMuted: true }),
+        HttpResponse.json([{ isMuted: true }]),
       ),
     );
     const rel = await adapter.muteAccount(account, "u2");

--- a/tests/unit/release-mcpb-asset.test.ts
+++ b/tests/unit/release-mcpb-asset.test.ts
@@ -1,0 +1,32 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Guard against silently shipping a release without the Claude Desktop
+ * Extension (`.mcpb`) bundle. The README's one-click install points users at
+ * this asset on the *latest* release; v3.1.0 shipped without it because the
+ * bundle was a one-off manual build that the release workflow never produced.
+ * This test fails CI if the workflow stops building or attaching it.
+ */
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const releaseYml = readFileSync(path.join(ROOT, ".github/workflows/release.yml"), "utf-8");
+
+describe("release workflow ships the .mcpb bundle", () => {
+  it("builds the .mcpb bundle", () => {
+    expect(releaseYml).toMatch(/mcpb pack/);
+  });
+
+  it("attaches a versioned .mcpb asset to the GitHub release", () => {
+    expect(releaseYml).toMatch(
+      /activitypub-mcp-\$\{\{\s*steps\.get_version\.outputs\.VERSION\s*\}\}\.mcpb/,
+    );
+  });
+
+  it("still attaches the npm tarball too", () => {
+    expect(releaseYml).toMatch(
+      /activitypub-mcp-\$\{\{\s*steps\.get_version\.outputs\.VERSION\s*\}\}\.tgz/,
+    );
+  });
+});

--- a/tests/unit/remote-client.test.ts
+++ b/tests/unit/remote-client.test.ts
@@ -706,6 +706,52 @@ describe("extractNextCursor semantics (M12)", () => {
     expect(result.nextCursor).toBeUndefined();
     expect(result.hasMore).toBe(false);
   });
+
+  it("reports hasMore=false on a full page that has no `next` cursor", async () => {
+    server.use(
+      http.get("https://m12fullpage.test/.well-known/webfinger", () =>
+        HttpResponse.json({
+          subject: "acct:user@m12fullpage.test",
+          links: [
+            {
+              rel: "self",
+              type: "application/activity+json",
+              href: "https://m12fullpage.test/users/user",
+            },
+          ],
+        }),
+      ),
+      http.get("https://m12fullpage.test/users/user", () =>
+        HttpResponse.json({
+          id: "https://m12fullpage.test/users/user",
+          type: "Person",
+          preferredUsername: "user",
+          inbox: "https://m12fullpage.test/users/user/inbox",
+          outbox: "https://m12fullpage.test/users/user/outbox",
+        }),
+      ),
+      // A page returning exactly `limit` items but with NO `next` link.
+      http.get("https://m12fullpage.test/users/user/outbox/page-1", () =>
+        HttpResponse.json({
+          id: "https://m12fullpage.test/users/user/outbox/page-1",
+          type: "OrderedCollectionPage",
+          orderedItems: [
+            { type: "Note", content: "a" },
+            { type: "Note", content: "b" },
+          ],
+        }),
+      ),
+    );
+
+    const result = await client.fetchActorOutboxPaginated("user@m12fullpage.test", {
+      cursor: "https://m12fullpage.test/users/user/outbox/page-1",
+      limit: 2,
+    });
+    // A full page with no `next` cursor is the end — `hasMore` must not be true
+    // when there is no cursor to follow, or the caller loops on the same page.
+    expect(result.nextCursor).toBeUndefined();
+    expect(result.hasMore).toBe(false);
+  });
 });
 
 describe("RemoteActivityPubClient response size cap (M2)", () => {


### PR DESCRIPTION
A fresh review of the project surfaced two silent leaks in the install funnel (which is finally driving npm downloads) plus three real correctness/security gaps in the read/write paths. This ships them as **v3.1.1**.

## Security
- **`upload-media` arbitrary-file exfiltration guard.** The tool read whatever `filePath` the model supplied and forwarded it to the instance with **no type check** — so a prompt-injected model (injection arriving through the read tools that surface fediverse content) could name an SSH key, the credential store, or a `.env` and exfiltrate it to a *public* media URL. Files are now sniffed by **magic bytes** (`src/utils/media-type.ts`) and refused unless they are a recognized image/video/audio type. Uploading real media from anywhere on disk still works.

## Fixed
- **Misskey relationship results.** `users/relation` returns the relation wrapped in a **one-element array** for a single user id (`res` schema is `oneOf: [object, array]`); the adapter read it as a bare object, so `following` / `followed_by` / `muting` / `blocking` / `requested` silently came back `false` after every Misskey follow, mute, or block. Both shapes are handled now.
- **Outbox pagination phantom "more".** `fetchActorOutboxPaginated` set `hasMore: true` whenever a page was full (`items.length === limit`) even with no `next` cursor, so a caller on a full final page looped on the same page. `hasMore` is now true only when there's a cursor to follow.

## Distribution
- **Ship the `.mcpb` on every release.** The README's one-click Claude Desktop install points at `activitypub-mcp-<version>.mcpb` on the *latest* release, but the bundle had only ever been attached to v3.0.1 by hand — every auto-release since silently dropped it. `release.yml` now builds and uploads it, and `tests/unit/release-mcpb-asset.test.ts` fails CI if the workflow stops. (Verified the build locally: produces a 3.9 MB bundle, manifest validation passes.)

## Docs
- **Reconciled `public/llms.txt` + `llms-full.txt` with the code.** Dropped the removed `/metrics` endpoint, a non-existent "metrics tool", and dead env vars (`HEALTH_CHECK_EXTERNAL_PROBE`, `ENABLE_PERFORMANCE_MONITORING`/`PERFORMANCE_LOG_INTERVAL`); fixed example code that called non-existent tools/prompts (`search-fediverse`, `explore-instance`, `fediverse-discovery`, `actor-analysis`); documented read-only-by-default and the `ACTIVITYPUB_ENABLE_WRITES` master switch. These AI-discoverability files ship on the live docs site and feed the project's exact target audience.

## Verification
- 835 unit tests pass (61 files; +21 new), `tsc` clean, lint clean, `validate:version` agrees across all 7 stamps, `.mcpb` builds locally.
- Every code fix was written test-first (failing test → fix → green), including correcting the Misskey mock that had encoded the wrong (bare-object) response shape and masked the bug.

Merging triggers `auto-release.yml` → tag `v3.1.1` → npm + MCP registry publish + GitHub release (now with the `.mcpb`).