### PR TITLE
v3.1.2: fix stdio-logging corruption, cache/idempotency bugs, wire security audit events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.1.2] - 2026-06-09
+
+### Fixed
+
+- **Logs no longer corrupt the stdio JSON-RPC stream.** logtape's console sink maps
+  `info`/`debug` to `console.info`/`console.debug`, which Node writes to **stdout** — the
+  same channel the stdio transport uses for MCP JSON-RPC. At the default `LOG_LEVEL=info`
+  the startup line and every per-request "Fetching …" log were emitted onto that stream,
+  so a strict client could see malformed frames. All log levels now go to stderr, and a
+  test drives the real server and asserts stdout carries only JSON-RPC.
+- **`CACHE_MAX_SIZE=0` no longer hangs the server.** The value reached the LRU cache
+  unvalidated, and a non-positive `maxSize` made the eviction loop spin forever on the
+  first cache write — the server hung on its first request. A non-positive or non-finite
+  `maxSize` is now clamped to 1.
+- **Mastodon posts send an `Idempotency-Key`.** The adapter read the option but no caller
+  set it, so a retried post (model- or transport-driven) could duplicate. A key derived
+  from the post's content is now sent, so an identical retry collapses to the original
+  status server-side.
+- **`LOG_LEVEL=warn` works as documented.** The CLI documents `warn`, but logtape's level
+  is `warning`. The env value is now normalized (`warn` → `warning`, unknown values →
+  `info`) so a documented or mistyped level can't misconfigure logging.
+
+### Security
+
+- **SSRF blocks and rate-limit denials are now recorded in the audit trail.** The
+  `logSsrfBlocked` and `logRateLimitExceeded` audit methods existed but had no callers, so
+  the two most security-relevant events never appeared in the log. SSRF rejections are now
+  audited at the central pinned-fetch path (initial URL and every redirect hop), and the
+  three duplicated rate-limit guards are unified into one helper that audits before
+  rejecting.
+
+### Changed
+
+- **Dead GitHub Discussions links removed.** Discussions is disabled on the repository, so
+  the `/discussions` links in the site footer, the troubleshooting page, and both
+  `llms.txt` artifacts 404'd. They now point at GitHub Issues (the real support channel),
+  with a test guarding against reintroducing them.
+
 ## [3.1.1] - 2026-06-05
 
 ### Security

--- a/docs/launch-kit.md
+++ b/docs/launch-kit.md
@@ -116,5 +116,6 @@ workflow should I add next?"
 - [ ] GitHub repo: set About tagline to the one-liner; fix topics
       (drop `fedify`; add `mastodon`, `misskey`, `claude`, `llm`, `model-context-protocol`)
 - [ ] GitHub repo: upload `public/og-image.png` as the social preview
-- [ ] Enable GitHub Discussions (or remove the footer `/discussions` links)
+- [x] Dead `/discussions` links removed (Discussions is disabled; links now point to Issues).
+      Re-add them only if Discussions is enabled.
 - [ ] Cut a patch release so the new npm description/tagline goes live

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.2",
   "name": "activitypub-mcp",
   "display_name": "ActivityPub MCP",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "Read-only-by-default MCP server: let LLMs explore the Fediverse — Mastodon, Misskey, Pleroma.",
   "long_description": "Lets an LLM explore and interact with the existing Fediverse — Mastodon, Misskey, Foundkey, Pleroma, and compatible servers. Read-only by default; write tools are opt-in. Untrusted fediverse content is wrapped in an <untrusted-content> envelope before it reaches the model.",
   "author": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "activitypub-mcp",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "activitypub-mcp",
-      "version": "3.1.1",
+      "version": "3.1.2",
       "license": "MIT",
       "dependencies": {
         "@logtape/logtape": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activitypub-mcp",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "Model Context Protocol (MCP) server for the Fediverse — let Claude and other LLMs explore and post to Mastodon, Misskey, and Pleroma. Read-only by default.",
   "mcpName": "io.github.cameronrye/activitypub-mcp",
   "main": "dist/mcp-main.js",

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -877,7 +877,6 @@ Log levels:
 
 - **Documentation**: https://cameronrye.github.io/activitypub-mcp/
 - **GitHub Issues**: https://github.com/cameronrye/activitypub-mcp/issues
-- **GitHub Discussions**: https://github.com/cameronrye/activitypub-mcp/discussions
 - **npm Package**: https://www.npmjs.com/package/activitypub-mcp
 
 ---

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -96,8 +96,7 @@ Add to your Claude Desktop configuration:
 ### Troubleshooting & Support
 
 - [Troubleshooting Guide](https://cameronrye.github.io/activitypub-mcp/docs/reference/troubleshooting/): Common issues and solutions
-- [GitHub Issues](https://github.com/cameronrye/activitypub-mcp/issues): Report bugs and request features
-- [GitHub Discussions](https://github.com/cameronrye/activitypub-mcp/discussions): Community support
+- [GitHub Issues](https://github.com/cameronrye/activitypub-mcp/issues): Report bugs, request features, and ask for help
 
 ### External Documentation
 

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -116,7 +116,7 @@ Upgrading from v1.x? See [MIGRATION-v2.md](https://github.com/cameronrye/activit
 
 ---
 
-**Version:** 3.1.1
+**Version:** 3.1.2
 **License:** MIT
 **Maintainer:** Cameron Rye (https://rye.dev/)
 **Repository:** https://github.com/cameronrye/activitypub-mcp

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.cameronrye/activitypub-mcp",
   "description": "Read-only-by-default MCP server: let LLMs explore the Fediverse — Mastodon, Misskey, Pleroma.",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "repository": {
     "url": "https://github.com/cameronrye/activitypub-mcp",
     "source": "github"
@@ -12,7 +12,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "activitypub-mcp",
-      "version": "3.1.1",
+      "version": "3.1.2",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/site/layouts/BaseLayout.astro
+++ b/site/layouts/BaseLayout.astro
@@ -258,7 +258,6 @@ const structuredData = {
             <h4>Community</h4>
             <ul>
               <li><a href="https://github.com/cameronrye/activitypub-mcp/issues" target="_blank" rel="noopener">Issues</a></li>
-              <li><a href="https://github.com/cameronrye/activitypub-mcp/discussions" target="_blank" rel="noopener">Discussions</a></li>
             </ul>
           </div>
         </div>

--- a/site/src/content/docs/reference/changelog.mdx
+++ b/site/src/content/docs/reference/changelog.mdx
@@ -9,6 +9,25 @@ order: 2
 
 All notable changes to the ActivityPub MCP Server are documented here. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### v3.1.2 - 2026-06-09
+
+**Correctness, logging, and audit patch.** Fixes a logging bug that polluted the stdio JSON-RPC stream, a cache misconfiguration that could hang startup, and a missing post idempotency key; records SSRF and rate-limit denials in the audit trail; and removes dead support links. See [CHANGELOG.md](https://github.com/cameronrye/activitypub-mcp/blob/main/CHANGELOG.md) for the complete entry.
+
+#### Fixed
+
+- **Logs no longer corrupt the stdio JSON-RPC stream** — logtape's console sink routed `info`/`debug` to stdout, the channel the stdio transport uses for MCP frames; all log levels now go to stderr.
+- **`CACHE_MAX_SIZE=0` no longer hangs the server** — a non-positive cache size made the LRU eviction loop spin forever on the first write; it is now clamped to 1.
+- **Mastodon posts send an `Idempotency-Key`** derived from the post content, so a retried post can't duplicate.
+- **`LOG_LEVEL=warn` works as documented** — the value is normalized to logtape's `warning`, with unknown values falling back to `info`.
+
+#### Security
+
+- **SSRF blocks and rate-limit denials are now recorded in the audit trail** — the two audit methods existed but had no callers, so the most security-relevant events were invisible.
+
+#### Changed
+
+- **Dead GitHub Discussions links removed** — Discussions is disabled, so the footer, troubleshooting, and `llms.txt` links now point at GitHub Issues.
+
 ### v3.1.1 - 2026-06-05
 
 **Correctness &amp; distribution patch.** Closes a media-upload exfiltration vector, fixes Misskey relationship and outbox-pagination bugs, and makes every release ship the one-click Claude Desktop bundle. See [CHANGELOG.md](https://github.com/cameronrye/activitypub-mcp/blob/main/CHANGELOG.md) for the complete entry.

--- a/site/src/content/docs/reference/troubleshooting.mdx
+++ b/site/src/content/docs/reference/troubleshooting.mdx
@@ -233,9 +233,9 @@ Include:
 
 ### Community Support
 
-Join the discussion for help and tips:
+For help, tips, bug reports, and feature requests:
 
-[GitHub Discussions](https://github.com/cameronrye/activitypub-mcp/discussions)
+[GitHub Issues](https://github.com/cameronrye/activitypub-mcp/issues)
 
 ## Related Resources
 

--- a/src/auth/adapters/mastodon-adapter.ts
+++ b/src/auth/adapters/mastodon-adapter.ts
@@ -4,6 +4,7 @@
  * the fail-safe default when software detection is unavailable.
  */
 
+import { createHash } from "node:crypto";
 import { z } from "zod";
 import { MAX_RESPONSE_SIZE, USER_AGENT } from "../../config.js";
 import {
@@ -64,6 +65,29 @@ async function postAndParseRelationship(
   return RelationshipSchema.parse(await readJsonWithLimit(response, MAX_RESPONSE_SIZE));
 }
 
+/**
+ * Mastodon dedupes posts that arrive with a repeated `Idempotency-Key` (scoped
+ * per access token), returning the original status instead of creating a second
+ * one. Callers rarely set the key, so a transient error that triggers a retry —
+ * by the model or an internal layer — would double-post. Derive a stable key
+ * from the post's meaningful fields so an identical retry collapses to the
+ * original, while genuinely different posts get distinct keys.
+ */
+function deriveIdempotencyKey(options: CreatePostOptions): string {
+  const canonical = JSON.stringify([
+    options.content ?? "",
+    options.spoilerText ?? "",
+    options.visibility ?? "",
+    options.inReplyToId ?? "",
+    options.language ?? "",
+    options.sensitive ?? null,
+    options.mediaIds ?? [],
+    options.poll ?? null,
+    options.scheduledAt ?? "",
+  ]);
+  return createHash("sha256").update(canonical).digest("hex");
+}
+
 export class MastodonWriteAdapter implements WriteAdapter {
   async createPost(
     account: AccountCredentials,
@@ -79,8 +103,9 @@ export class MastodonWriteAdapter implements WriteAdapter {
     if (options.poll) body.poll = options.poll;
     if (options.scheduledAt) body.scheduled_at = options.scheduledAt;
 
-    const headers: Record<string, string> = {};
-    if (options.idempotencyKey) headers["Idempotency-Key"] = options.idempotencyKey;
+    const headers: Record<string, string> = {
+      "Idempotency-Key": options.idempotencyKey ?? deriveIdempotencyKey(options),
+    };
 
     const response = await authenticatedFetch(account, "/api/v1/statuses", {
       method: "POST",

--- a/src/config.ts
+++ b/src/config.ts
@@ -40,7 +40,7 @@ function parseBoolEnv(value: string | undefined, defaultValue: boolean): boolean
 export const SERVER_NAME = process.env.MCP_SERVER_NAME || "activitypub-mcp";
 
 /** MCP Server version */
-export const SERVER_VERSION = process.env.MCP_SERVER_VERSION || "3.1.1";
+export const SERVER_VERSION = process.env.MCP_SERVER_VERSION || "3.1.2";
 
 /**
  * Directory for the persisted credential store (accounts.json).

--- a/src/mcp-main.ts
+++ b/src/mcp-main.ts
@@ -35,7 +35,7 @@ ENVIRONMENT VARIABLES:
   MCP_TRANSPORT_MODE     Transport mode: 'stdio' (default) or 'http'
   MCP_HTTP_PORT          HTTP server port (default: 3000)
   MCP_HTTP_HOST          HTTP server host (default: 127.0.0.1)
-  LOG_LEVEL              Log level: debug, info, warn, error (default: info)
+  LOG_LEVEL              Log level: debug, info, warning, error, fatal (default: info; 'warn' accepted)
   REQUEST_TIMEOUT        Request timeout in ms (default: 10000)
   CACHE_TTL              Cache TTL in ms (default: 300000)
   RATE_LIMIT_ENABLED     Enable rate limiting (default: true)

--- a/src/mcp/rate-limit-guard.ts
+++ b/src/mcp/rate-limit-guard.ts
@@ -1,0 +1,17 @@
+import { ErrorCode, McpError } from "@modelcontextprotocol/sdk/types.js";
+import { auditLogger } from "../audit/logger.js";
+import type { RateLimiter } from "../resilience/rate-limiter.js";
+
+/**
+ * Enforce the per-identifier rate limit for an MCP tool/resource call. Shared by
+ * the read tools, write tools, and resources so the limit — and its audit-trail
+ * entry — behave identically everywhere. On rejection the event is recorded via
+ * `logRateLimitExceeded` before the error is thrown; previously that audit method
+ * had no caller, so rate-limit denials were invisible in the trail.
+ */
+export function checkRateLimit(rateLimiter: RateLimiter, identifier: string): void {
+  if (!rateLimiter.checkLimit(identifier)) {
+    auditLogger.logRateLimitExceeded(identifier);
+    throw new McpError(ErrorCode.InternalError, "Rate limit exceeded. Please try again later.");
+  }
+}

--- a/src/mcp/resources.ts
+++ b/src/mcp/resources.ts
@@ -17,6 +17,7 @@ import { wrapUntrustedBlock } from "../utils/untrusted.js";
 import { DomainSchema } from "../validation/schemas.js";
 import { extractSingleValue, validateActorIdentifier } from "../validation/validators.js";
 import { capabilitiesRegistry, trackedMcpServer } from "./capabilities.js";
+import { checkRateLimit } from "./rate-limit-guard.js";
 
 const logger = getLogger("activitypub-mcp:resources");
 
@@ -63,15 +64,6 @@ export function registerResources(
 
   // Content resources
   registerPostThreadResource(mcpServer, rateLimiter);
-}
-
-/**
- * Helper to check rate limit and throw if exceeded.
- */
-function checkRateLimit(rateLimiter: RateLimiter, identifier: string): void {
-  if (!rateLimiter.checkLimit(identifier)) {
-    throw new McpError(ErrorCode.InternalError, "Rate limit exceeded. Please try again later.");
-  }
 }
 
 /**

--- a/src/mcp/tools-write.ts
+++ b/src/mcp/tools-write.ts
@@ -17,6 +17,7 @@ import { formatRemoteError, getErrorMessage } from "../utils/errors.js";
 import { sniffMediaType } from "../utils/media-type.js";
 import { sanitizeInline, wrapUntrusted } from "../utils/untrusted.js";
 import { trackedMcpServer } from "./capabilities.js";
+import { checkRateLimit } from "./rate-limit-guard.js";
 
 const logger = getLogger("activitypub-mcp:tools-write");
 
@@ -63,15 +64,6 @@ export function registerWriteTools(mcpServer: McpServer, rateLimiter: RateLimite
   registerGetScheduledPostsTool(mcpServer, rateLimiter);
   registerCancelScheduledPostTool(mcpServer, rateLimiter);
   registerUpdateScheduledPostTool(mcpServer, rateLimiter);
-}
-
-/**
- * Helper to check rate limit.
- */
-function checkRateLimit(rateLimiter: RateLimiter, identifier: string): void {
-  if (!rateLimiter.checkLimit(identifier)) {
-    throw new McpError(ErrorCode.InternalError, "Rate limit exceeded. Please try again later.");
-  }
 }
 
 /**

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -7,7 +7,7 @@
 
 import { getLogger } from "@logtape/logtape";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { type CallToolResult, ErrorCode, McpError } from "@modelcontextprotocol/sdk/types.js";
+import { type CallToolResult, McpError } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
 import { remoteClient } from "../activitypub/remote-client.js";
 import { dynamicInstanceDiscovery } from "../discovery/dynamic-instance-discovery.js";
@@ -21,6 +21,7 @@ import {
   validateQuery,
 } from "../validation/validators.js";
 import { trackedMcpServer } from "./capabilities.js";
+import { checkRateLimit } from "./rate-limit-guard.js";
 import { registerWriteTools } from "./tools-write.js";
 
 const logger = getLogger("activitypub-mcp:tools");
@@ -53,15 +54,6 @@ export function registerTools(mcpServer: McpServer, rateLimiter: RateLimiter): v
 
   // Write operation tools (authenticated)
   registerWriteTools(mcpServer, rateLimiter);
-}
-
-/**
- * Helper to check rate limit and throw if exceeded.
- */
-function checkRateLimit(rateLimiter: RateLimiter, identifier: string): void {
-  if (!rateLimiter.checkLimit(identifier)) {
-    throw new McpError(ErrorCode.InternalError, "Rate limit exceeded. Please try again later.");
-  }
 }
 
 /**

--- a/src/telemetry/logging.ts
+++ b/src/telemetry/logging.ts
@@ -5,10 +5,22 @@ import { configure, getConsoleSink } from "@logtape/logtape";
 const logLevel =
   (process.env.LOG_LEVEL as "debug" | "info" | "warning" | "error" | "fatal") || "info";
 
+// logtape's console sink maps info/debug to console.info/console.debug, which
+// Node writes to stdout. Under the stdio transport stdout carries the MCP
+// JSON-RPC stream, so any log byte written there corrupts the protocol. Route
+// every level to stderr by giving the sink a console whose stdout-bound methods
+// delegate to console.error.
+const stderrConsole: Console = Object.assign(Object.create(console), {
+  log: console.error.bind(console),
+  info: console.error.bind(console),
+  debug: console.error.bind(console),
+  warn: console.error.bind(console),
+});
+
 await configure({
   contextLocalStorage: new AsyncLocalStorage(),
   sinks: {
-    console: getConsoleSink(),
+    console: getConsoleSink({ console: stderrConsole }),
   },
   filters: {},
   loggers: [

--- a/src/telemetry/logging.ts
+++ b/src/telemetry/logging.ts
@@ -1,9 +1,28 @@
 import { AsyncLocalStorage } from "node:async_hooks";
 import { configure, getConsoleSink } from "@logtape/logtape";
 
-// Get log level from environment variable, default to 'info' for production
-const logLevel =
-  (process.env.LOG_LEVEL as "debug" | "info" | "warning" | "error" | "fatal") || "info";
+export type LogLevel = "debug" | "info" | "warning" | "error" | "fatal";
+
+const LOG_LEVEL_ALIASES: Record<string, LogLevel> = {
+  debug: "debug",
+  info: "info",
+  warn: "warning", // the CLI help documents `warn`; logtape's level is `warning`
+  warning: "warning",
+  error: "error",
+  fatal: "fatal",
+};
+
+/**
+ * Map a LOG_LEVEL env value to a logtape level. Accepts the documented `warn`
+ * alias, is case-insensitive, and falls back to `info` for anything
+ * unrecognized so a typo can't silently disable logging.
+ */
+export function normalizeLogLevel(raw: string | undefined): LogLevel {
+  if (!raw) return "info";
+  return LOG_LEVEL_ALIASES[raw.trim().toLowerCase()] ?? "info";
+}
+
+const logLevel = normalizeLogLevel(process.env.LOG_LEVEL);
 
 // logtape's console sink maps info/debug to console.info/console.debug, which
 // Node writes to stdout. Under the stdio transport stdout carries the MCP

--- a/src/utils/fetch-helpers.ts
+++ b/src/utils/fetch-helpers.ts
@@ -8,9 +8,10 @@
  */
 
 import type { Agent } from "undici";
+import { auditLogger } from "../audit/logger.js";
 import { MAX_RESPONSE_SIZE, REQUEST_TIMEOUT, USER_AGENT } from "../config.js";
 import { instanceBlocklist } from "../policy/instance-blocklist.js";
-import { resolveAndPin } from "../validation/url.js";
+import { resolveAndPin, SsrfBlockedError } from "../validation/url.js";
 
 /** RequestInit augmented with the undici `dispatcher` (not in the DOM types). */
 export type DispatchInit = RequestInit & { dispatcher?: Agent };
@@ -146,13 +147,23 @@ export async function pinnedFetch(
   init: DispatchInit,
   onHop?: (target: string) => Promise<void> | void,
 ): Promise<Response> {
-  const { dispatcher } = await resolveAndPin(url);
-  if (onHop) await onHop(url);
-  return fetchWithRedirectGuard(url, { ...init, dispatcher }, async (target) => {
-    const pinned = await resolveAndPin(target);
-    if (onHop) await onHop(target);
-    return pinned.dispatcher;
-  });
+  try {
+    const { dispatcher } = await resolveAndPin(url);
+    if (onHop) await onHop(url);
+    return await fetchWithRedirectGuard(url, { ...init, dispatcher }, async (target) => {
+      const pinned = await resolveAndPin(target);
+      if (onHop) await onHop(target);
+      return pinned.dispatcher;
+    });
+  } catch (error) {
+    // Record SSRF rejections (on the initial URL or any redirect hop) to the
+    // audit trail before propagating. Operator-blocklist rejections are audited
+    // separately in the policy layer, so only SSRF blocks are logged here.
+    if (error instanceof SsrfBlockedError) {
+      auditLogger.logSsrfBlocked(url, error.message);
+    }
+    throw error;
+  }
 }
 
 export class ResponseTooLargeError extends Error {

--- a/src/utils/lru-cache.ts
+++ b/src/utils/lru-cache.ts
@@ -21,7 +21,11 @@ export class LRUCache<K, V> {
    * @param options.ttl - Time-to-live in milliseconds (default: 0 = no expiration)
    */
   constructor(options: { maxSize?: number; ttl?: number } = {}) {
-    this.maxSize = options.maxSize ?? 1000;
+    // A non-positive (or non-finite) maxSize would make set()'s eviction loop
+    // spin forever — it can never shrink an already-empty cache below the
+    // threshold. CACHE_MAX_SIZE reaches here unvalidated, so clamp to >= 1.
+    const requested = Math.floor(options.maxSize ?? 1000);
+    this.maxSize = Number.isFinite(requested) && requested >= 1 ? requested : 1;
     this.ttl = options.ttl ?? 0;
   }
 

--- a/tests/unit/log-level.test.ts
+++ b/tests/unit/log-level.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { normalizeLogLevel } from "../../src/telemetry/logging.js";
+
+/**
+ * The CLI help documents LOG_LEVEL as `debug, info, warn, error`, but logtape's
+ * level is spelled `warning`. Accept the documented `warn` as an alias, and fall
+ * back to `info` for anything unrecognized so a typo can't silently disable logs.
+ */
+describe("normalizeLogLevel", () => {
+  it("maps the documented 'warn' alias to logtape's 'warning'", () => {
+    expect(normalizeLogLevel("warn")).toBe("warning");
+  });
+
+  it("passes through valid logtape levels unchanged", () => {
+    for (const level of ["debug", "info", "warning", "error", "fatal"]) {
+      expect(normalizeLogLevel(level)).toBe(level);
+    }
+  });
+
+  it("is case-insensitive and trims surrounding whitespace", () => {
+    expect(normalizeLogLevel("  WARN ")).toBe("warning");
+    expect(normalizeLogLevel("INFO")).toBe("info");
+  });
+
+  it("defaults to info for undefined or unrecognized values", () => {
+    expect(normalizeLogLevel(undefined)).toBe("info");
+    expect(normalizeLogLevel("bogus")).toBe("info");
+  });
+});

--- a/tests/unit/lru-cache.test.ts
+++ b/tests/unit/lru-cache.test.ts
@@ -204,4 +204,24 @@ describe("LRUCache", () => {
       expect(cache.stats().ttl).toBe(0);
     });
   });
+
+  describe("invalid maxSize", () => {
+    // A non-positive maxSize makes set()'s eviction loop spin forever: it can
+    // never shrink an already-empty cache below the threshold. CACHE_MAX_SIZE=0
+    // reaches the constructor unvalidated, so clamp to at least 1.
+    it("clamps a non-positive maxSize to at least 1", () => {
+      expect(new LRUCache<string, number>({ maxSize: 0 }).stats().maxSize).toBe(1);
+      expect(new LRUCache<string, number>({ maxSize: -5 }).stats().maxSize).toBe(1);
+    });
+
+    it("clamps a non-finite maxSize to 1", () => {
+      expect(new LRUCache<string, number>({ maxSize: Number.NaN }).stats().maxSize).toBe(1);
+    });
+
+    it("set() stores and returns rather than hanging when maxSize was clamped", () => {
+      const cache = new LRUCache<string, number>({ maxSize: 0 });
+      cache.set("a", 1);
+      expect(cache.get("a")).toBe(1);
+    });
+  });
 });

--- a/tests/unit/mastodon-adapter.test.ts
+++ b/tests/unit/mastodon-adapter.test.ts
@@ -85,3 +85,44 @@ describe("MastodonWriteAdapter.createPost", () => {
     expect(result.scheduled.scheduled_at).toBe("2099-01-01T15:00:00.000Z");
   });
 });
+
+describe("MastodonWriteAdapter.createPost idempotency", () => {
+  function captureKeys(keys: (string | null)[]) {
+    server.use(
+      http.post("https://mastodon.test/api/v1/statuses", ({ request }) => {
+        keys.push(request.headers.get("Idempotency-Key"));
+        return HttpResponse.json(sampleStatus);
+      }),
+    );
+  }
+
+  it("sends a content-derived Idempotency-Key so a retried identical post can't duplicate", async () => {
+    const keys: (string | null)[] = [];
+    captureKeys(keys);
+
+    await adapter.createPost(account, { content: "hello world" });
+    await adapter.createPost(account, { content: "hello world" }); // a retry of the same post
+
+    expect(keys[0]).toBeTruthy();
+    expect(keys[0]).toBe(keys[1]); // identical content => same key => Mastodon dedupes
+  });
+
+  it("derives a different key for different post content", async () => {
+    const keys: (string | null)[] = [];
+    captureKeys(keys);
+
+    await adapter.createPost(account, { content: "first" });
+    await adapter.createPost(account, { content: "second" });
+
+    expect(keys[0]).not.toBe(keys[1]);
+  });
+
+  it("uses an explicit idempotencyKey when the caller supplies one", async () => {
+    const keys: (string | null)[] = [];
+    captureKeys(keys);
+
+    await adapter.createPost(account, { content: "x", idempotencyKey: "explicit-key" });
+
+    expect(keys[0]).toBe("explicit-key");
+  });
+});

--- a/tests/unit/misskey-adapter.test.ts
+++ b/tests/unit/misskey-adapter.test.ts
@@ -220,6 +220,167 @@ describe("MisskeyWriteAdapter account ops", () => {
   });
 });
 
+describe("MisskeyWriteAdapter mutations", () => {
+  it("deletePost posts the noteId to notes/delete", async () => {
+    let body: Record<string, unknown> | undefined;
+    server.use(
+      http.post("https://misskey.test/api/notes/delete", async ({ request }) => {
+        body = (await request.json()) as Record<string, unknown>;
+        return new HttpResponse(null, { status: 204 });
+      }),
+    );
+    await expect(adapter.deletePost(account, "note1")).resolves.toBeUndefined();
+    expect(body?.noteId).toBe("note1");
+  });
+
+  it("deletePost surfaces a Misskey error body", async () => {
+    server.use(
+      http.post("https://misskey.test/api/notes/delete", () =>
+        HttpResponse.json({ error: { message: "No such note." } }, { status: 400 }),
+      ),
+    );
+    await expect(adapter.deletePost(account, "missing")).rejects.toThrow(/delete post/i);
+  });
+
+  it("unfollowAccount deletes the follow then reports following:false", async () => {
+    let followBody: Record<string, unknown> | undefined;
+    server.use(
+      http.post("https://misskey.test/api/following/delete", async ({ request }) => {
+        followBody = (await request.json()) as Record<string, unknown>;
+        return new HttpResponse(null, { status: 204 });
+      }),
+      http.post("https://misskey.test/api/users/relation", () =>
+        HttpResponse.json([{ isFollowing: false }]),
+      ),
+    );
+    const rel = await adapter.unfollowAccount(account, "u2");
+    expect(followBody?.userId).toBe("u2");
+    expect(rel.following).toBe(false);
+  });
+
+  it("blockAccount blocks then reports blocking:true", async () => {
+    let blockBody: Record<string, unknown> | undefined;
+    server.use(
+      http.post("https://misskey.test/api/blocking/create", async ({ request }) => {
+        blockBody = (await request.json()) as Record<string, unknown>;
+        return new HttpResponse(null, { status: 204 });
+      }),
+      http.post("https://misskey.test/api/users/relation", () =>
+        HttpResponse.json([{ isBlocking: true }]),
+      ),
+    );
+    const rel = await adapter.blockAccount(account, "u2");
+    expect(blockBody?.userId).toBe("u2");
+    expect(rel.blocking).toBe(true);
+  });
+
+  it("unblockAccount unblocks then reports blocking:false", async () => {
+    server.use(
+      http.post(
+        "https://misskey.test/api/blocking/delete",
+        () => new HttpResponse(null, { status: 204 }),
+      ),
+      http.post("https://misskey.test/api/users/relation", () =>
+        HttpResponse.json([{ isBlocking: false }]),
+      ),
+    );
+    const rel = await adapter.unblockAccount(account, "u2");
+    expect(rel.blocking).toBe(false);
+  });
+});
+
+describe("MisskeyWriteAdapter.getNotifications", () => {
+  it("normalizes notifications and maps pagination to untilId/sinceId", async () => {
+    let body: Record<string, unknown> | undefined;
+    server.use(
+      http.post("https://misskey.test/api/i/notifications", async ({ request }) => {
+        body = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json([
+          {
+            id: "n1",
+            type: "mention",
+            createdAt: "2026-01-01T00:00:00Z",
+            user: { id: "u1", username: "alice", host: null, name: "Alice" },
+            note: sampleNote,
+          },
+          // A notification with no user/note (e.g. an achievement) still normalizes.
+          { id: "n2", type: "achievementEarned", createdAt: "2026-01-01T00:01:00Z" },
+        ]);
+      }),
+    );
+    const items = await adapter.getNotifications(account, { maxId: "older", minId: "newer" });
+    expect(body?.untilId).toBe("older");
+    expect(body?.sinceId).toBe("newer");
+    expect(items).toHaveLength(2);
+    expect(items[0].type).toBe("mention");
+    expect(items[0].account.username).toBe("alice");
+    expect(items[0].status?.id).toBe("note1");
+    expect(items[1].account.username).toBe("");
+    expect(items[1].status).toBeUndefined();
+  });
+});
+
+describe("MisskeyWriteAdapter.uploadMedia", () => {
+  it("posts multipart to drive/files/create and maps the drive file to a MediaAttachment", async () => {
+    let contentType: string | null = null;
+    let filename: string | undefined;
+    let comment: string | undefined;
+    server.use(
+      http.post("https://misskey.test/api/drive/files/create", async ({ request }) => {
+        contentType = request.headers.get("content-type");
+        const form = await request.formData();
+        filename = form.get("name") as string | undefined;
+        comment = form.get("comment") as string | undefined;
+        return HttpResponse.json({
+          id: "file1",
+          type: "image/png",
+          url: "https://misskey.test/files/file1.png",
+          thumbnailUrl: "https://misskey.test/files/file1-thumb.png",
+          comment: "alt text",
+          blurhash: "LKO2",
+        });
+      }),
+    );
+
+    const media = await adapter.uploadMedia(account, Buffer.from([0x89, 0x50, 0x4e, 0x47]), {
+      filename: "pic.png",
+      description: "alt text",
+    });
+
+    expect(contentType).toContain("multipart/form-data");
+    expect(filename).toBe("pic.png");
+    expect(comment).toBe("alt text");
+    expect(media).toMatchObject({
+      id: "file1",
+      type: "image",
+      url: "https://misskey.test/files/file1.png",
+      preview_url: "https://misskey.test/files/file1-thumb.png",
+      description: "alt text",
+    });
+  });
+
+  it("maps an unrecognized drive file type to 'unknown'", async () => {
+    server.use(
+      http.post("https://misskey.test/api/drive/files/create", () =>
+        HttpResponse.json({ id: "f2", type: "application/pdf", url: "https://misskey.test/f2" }),
+      ),
+    );
+    const media = await adapter.uploadMedia(account, Buffer.from([0x25, 0x50]), {});
+    expect(media.type).toBe("unknown");
+  });
+
+  it("throws with the HTTP status when the drive upload fails", async () => {
+    server.use(
+      http.post("https://misskey.test/api/drive/files/create", () =>
+        HttpResponse.json({ error: { message: "too big" } }, { status: 413 }),
+      ),
+    );
+    await expect(adapter.uploadMedia(account, Buffer.from([0x00]), {})).rejects.toThrow(
+      /Failed to upload media: HTTP 413/,
+    );
+  });
+});
+
 describe("MisskeyWriteAdapter timeline", () => {
   it("getHomeTimeline normalizes notes", async () => {
     server.use(

--- a/tests/unit/no-dead-discussions-links.test.ts
+++ b/tests/unit/no-dead-discussions-links.test.ts
@@ -1,0 +1,26 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+/**
+ * GitHub Discussions is disabled on the repository, so any link to `/discussions`
+ * in a shipped artifact 404s — including the site footer and the troubleshooting
+ * page's "Community Support" link, exactly where a struggling user lands. Guard
+ * the public-facing artifacts against re-introducing such a link. If Discussions
+ * is ever enabled, update these links and remove this test together.
+ */
+const ARTIFACTS = [
+  "../../public/llms.txt",
+  "../../public/llms-full.txt",
+  "../../site/src/content/docs/reference/troubleshooting.mdx",
+  "../../site/layouts/BaseLayout.astro",
+];
+
+describe("public artifacts do not link to disabled GitHub Discussions", () => {
+  for (const rel of ARTIFACTS) {
+    it(`${rel} has no /discussions link`, () => {
+      const content = readFileSync(fileURLToPath(new URL(rel, import.meta.url)), "utf8");
+      expect(content).not.toContain("/discussions");
+    });
+  }
+});

--- a/tests/unit/rate-limit-guard.test.ts
+++ b/tests/unit/rate-limit-guard.test.ts
@@ -1,0 +1,39 @@
+import { ErrorCode, McpError } from "@modelcontextprotocol/sdk/types.js";
+import { describe, expect, it, vi } from "vitest";
+import { auditLogger } from "../../src/audit/logger.js";
+import { checkRateLimit } from "../../src/mcp/rate-limit-guard.js";
+import type { RateLimiter } from "../../src/resilience/rate-limiter.js";
+
+const limiter = (allowed: boolean) => ({ checkLimit: () => allowed }) as unknown as RateLimiter;
+
+describe("checkRateLimit", () => {
+  it("throws and records a rate-limit-exceeded audit event when the limit is hit", () => {
+    const spy = vi.spyOn(auditLogger, "logRateLimitExceeded");
+    try {
+      expect(() => checkRateLimit(limiter(false), "mastodon.test")).toThrow(McpError);
+      expect(spy).toHaveBeenCalledWith("mastodon.test");
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("uses the InternalError code on the thrown McpError", () => {
+    try {
+      checkRateLimit(limiter(false), "id");
+      throw new Error("expected a throw");
+    } catch (error) {
+      expect(error).toBeInstanceOf(McpError);
+      expect((error as McpError).code).toBe(ErrorCode.InternalError);
+    }
+  });
+
+  it("does nothing when the request is within the limit", () => {
+    const spy = vi.spyOn(auditLogger, "logRateLimitExceeded");
+    try {
+      expect(() => checkRateLimit(limiter(true), "mastodon.test")).not.toThrow();
+      expect(spy).not.toHaveBeenCalled();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});

--- a/tests/unit/ssrf-audit.test.ts
+++ b/tests/unit/ssrf-audit.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from "vitest";
+import { auditLogger } from "../../src/audit/logger.js";
+import { pinnedFetch } from "../../src/utils/fetch-helpers.js";
+import { SsrfBlockedError } from "../../src/validation/url.js";
+
+// Keep the real SsrfBlockedError (so pinnedFetch's instanceof catch works) but
+// force resolveAndPin to reject as if the target resolved to a private IP.
+vi.mock("../../src/validation/url.js", async (importActual) => {
+  const actual = await importActual<typeof import("../../src/validation/url.js")>();
+  return {
+    ...actual,
+    resolveAndPin: vi
+      .fn()
+      .mockRejectedValue(
+        new actual.SsrfBlockedError('Access to private IP address "10.0.0.1" is not allowed'),
+      ),
+  };
+});
+
+describe("pinnedFetch SSRF audit", () => {
+  it("records an SSRF-blocked audit event and re-throws when a target is rejected", async () => {
+    const spy = vi.spyOn(auditLogger, "logSsrfBlocked");
+    try {
+      await expect(pinnedFetch("http://attacker.test/x", {})).rejects.toBeInstanceOf(
+        SsrfBlockedError,
+      );
+      expect(spy).toHaveBeenCalledWith(
+        "http://attacker.test/x",
+        expect.stringContaining("private IP"),
+      );
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});

--- a/tests/unit/stdio-stdout-purity.test.ts
+++ b/tests/unit/stdio-stdout-purity.test.ts
@@ -1,0 +1,92 @@
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+/**
+ * A stdio MCP server speaks JSON-RPC over stdout. ANY non-protocol bytes on
+ * stdout corrupt the stream the client parses. logtape's default console sink
+ * routes info/debug to console.info/console.debug, which Node writes to stdout —
+ * so at the default LOG_LEVEL=info the server pollutes its own protocol channel
+ * (e.g. the "Server started (stdio transport)" line, plus every per-request
+ * "Fetching ..." log). All logs must go to stderr instead.
+ *
+ * This spawns the real server entrypoint, drives a single `initialize`, and
+ * asserts every line on stdout is valid JSON-RPC and that the startup log lands
+ * on stderr.
+ */
+const ENTRY = fileURLToPath(new URL("../../src/mcp-main.ts", import.meta.url));
+
+function initializeRequest(): string {
+  return `${JSON.stringify({
+    jsonrpc: "2.0",
+    id: 1,
+    method: "initialize",
+    params: {
+      protocolVersion: "2024-11-05",
+      capabilities: {},
+      clientInfo: { name: "purity-test", version: "1.0.0" },
+    },
+  })}\n`;
+}
+
+describe("stdio transport keeps stdout free of log output", () => {
+  it("writes only JSON-RPC to stdout at the default info level", async () => {
+    const { stdout, stderr } = await runServer();
+
+    const stdoutLines = stdout
+      .split("\n")
+      .map((l) => l.trim())
+      .filter(Boolean);
+    expect(stdoutLines.length).toBeGreaterThan(0); // got the initialize response
+
+    const nonJsonRpc = stdoutLines.filter((line) => {
+      try {
+        const msg = JSON.parse(line);
+        return msg.jsonrpc !== "2.0";
+      } catch {
+        return true; // unparseable => a leaked log line
+      }
+    });
+    expect(nonJsonRpc).toEqual([]);
+
+    // The startup log must still be emitted — just on stderr.
+    expect(stderr).toContain("stdio transport");
+  }, 20000);
+});
+
+function runServer(): Promise<{ stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, ["--import", "tsx", ENTRY], {
+      env: { ...process.env, LOG_LEVEL: "info", MCP_TRANSPORT_MODE: "stdio" },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+    let settle: NodeJS.Timeout | undefined;
+    const hardStop = setTimeout(() => finish(), 8000);
+
+    const finish = () => {
+      clearTimeout(hardStop);
+      if (settle) clearTimeout(settle);
+      child.kill("SIGKILL");
+      resolve({ stdout, stderr });
+    };
+
+    child.stdout.on("data", (d) => {
+      stdout += d.toString();
+      // Once the initialize response arrives, wait briefly for any interleaved
+      // log line, then assess.
+      if (stdout.includes('"id":1')) {
+        if (settle) clearTimeout(settle);
+        settle = setTimeout(finish, 400);
+      }
+    });
+    child.stderr.on("data", (d) => {
+      stderr += d.toString();
+    });
+    child.on("error", reject);
+
+    child.stdin.write(initializeRequest());
+  });
+}


### PR DESCRIPTION
A correctness/observability patch. The headline fix is a real, reproduced defect on the primary (stdio) transport; the rest are confirmed-and-verified findings from a codebase review, each landed test-first.

## Fixes

### High — logs corrupted the stdio JSON-RPC stream
logtape's console sink maps `info`/`debug` to `console.info`/`console.debug`, which Node writes to **stdout** — the same channel the stdio transport uses for MCP JSON-RPC. At the default `LOG_LEVEL=info`, the startup line and every per-request "Fetching …" log were emitted onto that stream. Reproduced against the real built server (the `INF … Server started (stdio transport)` line landed on stdout while stderr was empty). All log levels now route to stderr; a spawn test drives the real entrypoint and asserts stdout carries only JSON-RPC.

### `CACHE_MAX_SIZE=0` hung the server
The value reached the LRU cache unvalidated, and a non-positive `maxSize` made the eviction loop spin forever on the first cache write — the server hung on its first request (e.g. first WebFinger lookup). A non-positive or non-finite `maxSize` is now clamped to 1.

### Mastodon posts never sent an idempotency key
The adapter read `options.idempotencyKey` but no caller set it, so a retried post (model- or transport-driven) could duplicate. A key derived from the post's content is now sent, so an identical retry collapses to the original status server-side.

### SSRF + rate-limit denials were missing from the audit trail
`logSsrfBlocked` and `logRateLimitExceeded` existed but had zero callers, so the two most security-relevant events never appeared in the log. SSRF rejections are now audited at the central pinned-fetch path (initial URL and every redirect hop), and the three duplicated `checkRateLimit` helpers are unified into one guard that audits before rejecting.

### `LOG_LEVEL=warn` is now valid
The CLI documents `warn`, but logtape's level is `warning`. The env value is normalized (`warn` → `warning`, unknown values → `info`) so a documented or mistyped level can't misconfigure logging.

### Dead GitHub Discussions links removed
Discussions is disabled on the repo, so the `/discussions` links in the site footer, the troubleshooting page, and both `llms.txt` artifacts 404'd — including the "Community Support" link a struggling user clicks. Repointed to GitHub Issues, with a test guarding against reintroducing them.

## Tests
- New regression tests for each fix (stdout purity, idempotency key, SSRF/rate-limit audit, LRU clamp, LOG_LEVEL normalization, dead-link guard).
- Backfilled the previously-untested Misskey write-adapter paths (delete/unfollow/block/unblock, `getNotifications`, multipart `uploadMedia`).
- Full suite **872 passing**; typecheck, lint, version-consistency, and `tsc` build all green.