### PR TITLE
v3.1.3: security & correctness hardening from end-to-end review

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -184,4 +184,6 @@ jobs:
       contents: read
       id-token: write
     uses: ./.github/workflows/publish-mcp.yml
-    secrets: inherit
+    # No `secrets: inherit`: this job authenticates via OIDC (id-token) only and
+    # references no named secret, so it must not receive NPM_TOKEN/other secrets —
+    # that keeps them out of the blast radius of the downloaded mcp-publisher.

--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -27,8 +27,20 @@ jobs:
       uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
     - name: Install mcp-publisher
+      # Pinned to a specific release and checksum-verified before execution. This
+      # job holds the repo's OIDC identity authorized to publish to the official
+      # registry namespace, so a moving `latest` URL piped straight into tar would
+      # be a supply-chain RCE vector if that upstream release were ever hijacked.
+      env:
+        MCP_PUBLISHER_VERSION: v1.7.9
+        MCP_PUBLISHER_SHA256: ab128162b0616090b47cf245afe0a23f3ef08936fdce19074f5ba0a4469281ac
       run: |
-        curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_linux_amd64.tar.gz" | tar -xz mcp-publisher
+        set -euo pipefail
+        url="https://github.com/modelcontextprotocol/registry/releases/download/${MCP_PUBLISHER_VERSION}/mcp-publisher_linux_amd64.tar.gz"
+        curl -fsSL "$url" -o mcp-publisher.tar.gz
+        echo "${MCP_PUBLISHER_SHA256}  mcp-publisher.tar.gz" | sha256sum -c -
+        tar -xzf mcp-publisher.tar.gz mcp-publisher
+        rm -f mcp-publisher.tar.gz
 
     - name: Authenticate via GitHub OIDC
       run: ./mcp-publisher login github-oidc

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,10 @@ jobs:
         registry-url: 'https://registry.npmjs.org'
 
     - name: Install dependencies
-      run: npm ci
+      # --ignore-scripts: this job holds NPM_TOKEN and only needs tsc + biome
+      # (neither runs install scripts), so we don't execute lifecycle scripts from
+      # the full dev dependency tree in the token-bearing publish/release jobs.
+      run: npm ci --ignore-scripts
 
     - name: Build project (clean first)
       run: npm run clean && npm run build
@@ -112,7 +115,10 @@ jobs:
         cache: 'npm'
 
     - name: Install dependencies
-      run: npm ci
+      # --ignore-scripts: this job holds NPM_TOKEN and only needs tsc + biome
+      # (neither runs install scripts), so we don't execute lifecycle scripts from
+      # the full dev dependency tree in the token-bearing publish/release jobs.
+      run: npm ci --ignore-scripts
 
     - name: Build project (clean first)
       run: npm run clean && npm run build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,72 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.1.3] - 2026-06-09
+
+Security & correctness hardening patch from an end-to-end review.
+
+### Fixed
+
+- **`Ctrl+C`/SIGTERM now actually exits the stdio server.** Graceful shutdown
+  stopped the HTTP server and rate limiter but never closed the MCP transport, so
+  the `StdioServerTransport`'s stdin listener kept the event loop alive and the
+  process hung after the first Ctrl+C (the startup hint even says "Press Ctrl+C to
+  exit"). `stop()` now closes the transport so the loop drains and the process exits.
+- **Misskey `direct` messages fail loud instead of vanishing.** Mapping Mastodon
+  `direct` to Misskey `specified` with no `visibleUserIds` produced an author-only
+  note, so the intended DM silently went nowhere. The adapter now rejects `direct`
+  with a clear "not supported on Misskey" error.
+- **One malformed remote item no longer fails an entire read.** The Misskey read
+  adapter drops a structurally-invalid note (rather than throwing), coerces
+  non-numeric reaction counts (no more string-concatenated `favourites_count`), and
+  enforces the requested `limit` even when a server ignores it.
+- **Numeric env vars are validated and clamped.** `AUDIT_LOG_MAX_ENTRIES=0` no
+  longer silently disables the audit trail, `MAX_RESPONSE_SIZE=10MB` no longer
+  parses to a 10-byte cap (non-integer values fall back to the default), and
+  negative/zero values for size/timeout knobs are floored. Out-of-range values are
+  reported as startup warnings, and enabling writes (or writes over HTTP) now warns.
+
+### Security
+
+- **`upload-media` enforces a size cap before reading a file.** It `stat`s the path
+  and refuses anything over `MAX_UPLOAD_SIZE` (default 100 MB) — and non-regular
+  files — before buffering it into memory, so a coerced/oversized path can't OOM the
+  process. The target instance still enforces its own real media limit.
+- **`upload-media` no longer leaks absolute paths or errno on failure.** Local
+  filesystem errors are rendered with the file basename only (never the absolute
+  path, never an ENOENT-vs-EACCES distinction), removing a filesystem-enumeration
+  oracle for a prompt-injected model. `formatRemoteError` stays reserved for remote
+  HTTP bodies. The audit log also records only the basename, not the full path.
+- **Cross-origin thread fetches are gated for ancestors, not just replies.** The
+  `inReplyTo` ancestor walk now honors `MCP_THREAD_CROSS_ORIGIN_FETCH=false` (the
+  default) like the reply branch, closing a privacy-control bypass / cross-origin
+  fetch-amplification primitive driven by an attacker-controlled root post.
+- **`get-scheduled-posts` is annotated read-only** (it was mislabeled
+  `destructiveHint: true` despite only performing a GET).
+- **Install/release supply-chain hardening.** `install.sh` now merges client config
+  via a standalone helper that parses the existing file with `JSON.parse` (the old
+  `node -e "const config = $existing_config"` treated the file as executable JS, a
+  code-injection vector); the registry publish job pins `mcp-publisher` to a tagged
+  release and verifies its SHA-256 before running it, and no longer inherits
+  `NPM_TOKEN`; and the token-holding npm publish/release jobs run
+  `npm ci --ignore-scripts`.
+
+### Changed
+
+- **Docs accuracy.** The site API reference no longer files the always-on
+  authenticated read tools (home timeline, notifications, bookmarks, favourites,
+  relationship, scheduled-posts) under "Write Tools / disabled by default"; the
+  on-site Security page now describes the real threat model (prompt injection, SSRF,
+  the untrusted-content envelope, read-only default) instead of generic compliance
+  boilerplate; the security/limits env vars are documented; and the `search` default
+  is corrected (10, not 20).
+
+### Known limitations
+
+- The HTTP transport still serves a single MCP session per process; proper
+  multi-session support is tracked for a focused follow-up. The default stdio
+  transport is unaffected.
+
 ## [3.1.2] - 2026-06-09
 
 ### Fixed

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -32,9 +32,11 @@ The two in-repo artifacts already exist:
 
 **Hard ordering constraint — the registry validates the _live_ npm tarball.**
 The registry checks that the published npm package's `package.json` contains a
-matching `mcpName`. 3.x has shipped to npm (`latest` is `3.1.0`); `3.0.1` was
-the first tarball to carry `mcpName`. **It must be live on npm before you
-register** — the registry has nothing to validate against otherwise.
+matching `mcpName`. 3.x has shipped to npm and the registry serves the current
+release as `isLatest`; `3.0.1` was the first tarball to carry `mcpName`, and the
+auto-publish path (npm → registry) has been validated end to end. **The matching
+npm version must be live before you register** — the registry has nothing to
+validate against otherwise.
 
 So the sequence is:
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.2",
   "name": "activitypub-mcp",
   "display_name": "ActivityPub MCP",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "Read-only-by-default MCP server: let LLMs explore the Fediverse — Mastodon, Misskey, Pleroma.",
   "long_description": "Lets an LLM explore and interact with the existing Fediverse — Mastodon, Misskey, Foundkey, Pleroma, and compatible servers. Read-only by default; write tools are opt-in. Untrusted fediverse content is wrapped in an <untrusted-content> envelope before it reaches the model.",
   "author": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "activitypub-mcp",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "activitypub-mcp",
-      "version": "3.1.2",
+      "version": "3.1.3",
       "license": "MIT",
       "dependencies": {
         "@logtape/logtape": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activitypub-mcp",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "Model Context Protocol (MCP) server for the Fediverse — let Claude and other LLMs explore and post to Mastodon, Misskey, and Pleroma. Read-only by default.",
   "mcpName": "io.github.cameronrye/activitypub-mcp",
   "main": "dist/mcp-main.js",

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -116,7 +116,7 @@ Upgrading from v1.x? See [MIGRATION-v2.md](https://github.com/cameronrye/activit
 
 ---
 
-**Version:** 3.1.2
+**Version:** 3.1.3
 **License:** MIT
 **Maintainer:** Cameron Rye (https://rye.dev/)
 **Repository:** https://github.com/cameronrye/activitypub-mcp

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -9,6 +9,9 @@ set -e
 PACKAGE_NAME="activitypub-mcp"
 SERVER_NAME="activitypub"
 
+# Directory of this script (for locating sibling helpers)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 # Colors for output
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -219,22 +222,15 @@ EOF
         return
     fi
     
-    # Read existing config or create empty one
-    local existing_config="{}"
-    if [[ -f "$config_path" ]]; then
-        existing_config=$(cat "$config_path")
-    fi
-    
-    # Use Node.js to update JSON (more reliable than jq for complex operations)
-    node -e "
-        const fs = require('fs');
-        const config = $existing_config;
-        if (!config.mcpServers) config.mcpServers = {};
-        config.mcpServers['$SERVER_NAME'] = $server_config;
-        fs.writeFileSync('$config_path', JSON.stringify(config, null, 2));
-    "
-    
-    log_info "Configuration updated successfully!"
+    # Merge via a standalone Node helper. All values are passed through the
+    # ENVIRONMENT (never interpolated into program text), and the existing file is
+    # parsed with JSON.parse as data — not eval'd as JS — so a non-canonical or
+    # hostile existing config can neither execute code nor silently break the install.
+    AP_MCP_CONFIG_PATH="$config_path" \
+    AP_MCP_SERVER_NAME="$SERVER_NAME" \
+    AP_MCP_PACKAGE_NAME="$PACKAGE_NAME" \
+    AP_MCP_ACTION="add" \
+        node "$SCRIPT_DIR/merge-mcp-config.mjs"
 }
 
 # Install package
@@ -281,22 +277,11 @@ uninstall() {
         if $DRY_RUN; then
             log_info "[DRY RUN] Would remove $SERVER_NAME from $config_path"
         else
-            # Remove server from config using Node.js
-            node -e "
-                const fs = require('fs');
-                try {
-                    const config = JSON.parse(fs.readFileSync('$config_path', 'utf8'));
-                    if (config.mcpServers && config.mcpServers['$SERVER_NAME']) {
-                        delete config.mcpServers['$SERVER_NAME'];
-                        fs.writeFileSync('$config_path', JSON.stringify(config, null, 2));
-                        console.log('Removed $SERVER_NAME from configuration');
-                    } else {
-                        console.log('$SERVER_NAME not found in configuration');
-                    }
-                } catch (error) {
-                    console.error('Failed to update configuration:', error.message);
-                }
-            "
+            # Remove server from config via the same safe, env-driven helper.
+            AP_MCP_CONFIG_PATH="$config_path" \
+            AP_MCP_SERVER_NAME="$SERVER_NAME" \
+            AP_MCP_ACTION="remove" \
+                node "$SCRIPT_DIR/merge-mcp-config.mjs"
         fi
     else
         log_info "Configuration file not found: $config_path"

--- a/scripts/merge-mcp-config.mjs
+++ b/scripts/merge-mcp-config.mjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+/**
+ * Safely add or remove the activitypub-mcp entry in an MCP client config file.
+ *
+ * Used by scripts/install.sh. All inputs arrive via the environment — NEVER
+ * interpolated into program text — and the existing file is read with JSON.parse
+ * (as data), not eval'd as JavaScript. This replaces the previous
+ * `node -e "... const config = $existing_config ..."` in install.sh, which
+ * treated the user's config file as trusted source and could execute arbitrary
+ * code (or break the install) for any non-canonical existing config.
+ *
+ * Environment:
+ *   AP_MCP_CONFIG_PATH   path to the client config JSON (required)
+ *   AP_MCP_SERVER_NAME   key under mcpServers to add/remove (required)
+ *   AP_MCP_PACKAGE_NAME  npm package for the `add` action (required for add)
+ *   AP_MCP_ACTION        "add" (default) or "remove"
+ */
+import fs from "node:fs";
+
+const configPath = process.env.AP_MCP_CONFIG_PATH;
+const serverName = process.env.AP_MCP_SERVER_NAME;
+const packageName = process.env.AP_MCP_PACKAGE_NAME;
+const action = process.env.AP_MCP_ACTION || "add";
+
+if (!configPath || !serverName) {
+  console.error("merge-mcp-config: AP_MCP_CONFIG_PATH and AP_MCP_SERVER_NAME are required");
+  process.exit(2);
+}
+
+function readExisting(path) {
+  if (!fs.existsSync(path)) return {};
+  let raw;
+  try {
+    raw = fs.readFileSync(path, "utf8");
+  } catch (error) {
+    console.error(`merge-mcp-config: cannot read ${path}: ${error.message}`);
+    process.exit(1);
+  }
+  if (raw.trim() === "") return {};
+  try {
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      throw new Error("config root is not a JSON object");
+    }
+    return parsed;
+  } catch (error) {
+    // Refuse to clobber a file we don't understand — surface it instead.
+    console.error(
+      `merge-mcp-config: existing config at ${path} is not valid JSON, refusing to overwrite it: ${error.message}`,
+    );
+    process.exit(1);
+  }
+}
+
+const config = readExisting(configPath);
+if (!config.mcpServers || typeof config.mcpServers !== "object") {
+  config.mcpServers = {};
+}
+
+if (action === "remove") {
+  if (config.mcpServers[serverName]) {
+    delete config.mcpServers[serverName];
+    fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
+    console.log(`Removed ${serverName} from configuration`);
+  } else {
+    console.log(`${serverName} not found in configuration`);
+  }
+} else {
+  if (!packageName) {
+    console.error("merge-mcp-config: AP_MCP_PACKAGE_NAME is required for the add action");
+    process.exit(2);
+  }
+  config.mcpServers[serverName] = {
+    command: "npx",
+    args: ["-y", packageName],
+    env: { LOG_LEVEL: "info" },
+  };
+  fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
+  console.log("Configuration updated successfully!");
+}

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.cameronrye/activitypub-mcp",
   "description": "Read-only-by-default MCP server: let LLMs explore the Fediverse — Mastodon, Misskey, Pleroma.",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "repository": {
     "url": "https://github.com/cameronrye/activitypub-mcp",
     "source": "github"
@@ -12,7 +12,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "activitypub-mcp",
-      "version": "3.1.2",
+      "version": "3.1.3",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/site/src/content/docs/api/tools.mdx
+++ b/site/src/content/docs/api/tools.mdx
@@ -256,7 +256,7 @@ Unified search across accounts, posts, and hashtags in a single query. Combines 
 | `domain` | string | No | Instance domain to search. Defaults to `mastodon.social`. |
 | `query` | string | Yes | Search query |
 | `type` | enum | No | Filter results: "all", "accounts", "posts", "hashtags" (default: "all") |
-| `limit` | number | No | Results per type (default: 20, max: 40) |
+| `limit` | number | No | Results per type (default: 10, max: 40) |
 | `resolve` | boolean | No | Attempt WebFinger lookup for remote accounts |
 
 #### Examples
@@ -321,13 +321,19 @@ discover-instances --maxUsers 5000 --sortBy users
 
 </div>
 
-## Write Tools
+## Authenticated Tools
 
-Write tools are **disabled by default** and only registered when `ACTIVITYPUB_ENABLE_WRITES=true` is set in the server environment.
-They also require an authenticated account. The recommended way to authenticate is the CLI flow — `activitypub-mcp login <instance>` (Mastodon OAuth2 / Misskey MiAuth), which stores credentials in the on-disk credential store; alternatively set `ACTIVITYPUB_ACCOUNTS` (or `ACTIVITYPUB_DEFAULT_INSTANCE` + `ACTIVITYPUB_DEFAULT_TOKEN`).
+These tools require an authenticated account. The recommended way to authenticate is the CLI flow — `activitypub-mcp login <instance>` (Mastodon OAuth2 / Misskey MiAuth), which stores credentials in the on-disk credential store; alternatively set `ACTIVITYPUB_ACCOUNTS` (or `ACTIVITYPUB_DEFAULT_INSTANCE` + `ACTIVITYPUB_DEFAULT_TOKEN`).
 See the [Authentication](/activitypub-mcp/docs/getting-started/authentication/) and [Configuration Options](/activitypub-mcp/docs/getting-started/configuration/) pages for setup instructions.
 
-### Account Management
+They split into two tiers:
+
+- **Authenticated reads — always available with an account, no `ACTIVITYPUB_ENABLE_WRITES` needed:** `list-accounts`, `switch-account`, `verify-account`, `get-home-timeline`, `get-notifications`, `get-bookmarks`, `get-favourites`, `get-relationship`, and `get-scheduled-posts`. (Reading your own home timeline or notifications does **not** require enabling writes.)
+- **Write/mutation tools — disabled by default**, registered only when `ACTIVITYPUB_ENABLE_WRITES=true` is set in the server environment: `post-status`, `reply-to-post`, `delete-post`, the boost/favourite/bookmark pairs, `follow-account`/`mute-account`/`block-account` (and their inverses), `vote-on-poll`, `upload-media`, `update-scheduled-post`, and `cancel-scheduled-post`.
+
+> Some authenticated tools are Mastodon-family only and return an "unsupported on platform" error on Misskey/Foundkey accounts: `get-bookmarks`, `get-favourites`, `vote-on-poll`, and the scheduled-post tools. `get-home-timeline`, `get-notifications`, and `get-relationship` work across both.
+
+### Account Management (authenticated read — no `ENABLE_WRITES` required)
 
 <div class="tool-reference">
 
@@ -691,7 +697,7 @@ unblock-account --acct "user@mastodon.social"
 
 </div>
 
-### Authenticated Timelines
+### Authenticated Timelines (authenticated reads — no `ENABLE_WRITES` required)
 
 <div class="tool-reference">
 

--- a/site/src/content/docs/development/security.mdx
+++ b/site/src/content/docs/development/security.mdx
@@ -1,296 +1,92 @@
 ---
-title: "Security Audit Checklist"
-description: "Comprehensive security audit checklist for the ActivityPub MCP Server."
+title: "Security Model"
+description: "The real threat model for the ActivityPub MCP Server: prompt injection from fediverse content, SSRF protection, the untrusted-content envelope, and the read-only default."
 group: "Development"
 order: 4
 ---
 
-## Security Overview
-
-### Core Security Principles
-
-- **Least Privilege:** Minimal necessary permissions
-- **Defense in Depth:** Multiple security layers
-- **Fail Secure:** Secure defaults and error handling
-- **Zero Trust:** Verify all requests and data
+## Threat model — prompt injection is the primary risk
 
-### Threat Model
-
-- **Data Exposure:** Unauthorized access to cached data
-- **Service Abuse:** Resource exhaustion attacks
-- **Injection Attacks:** Malicious input processing
-- **Privacy Violations:** Unauthorized data collection
-
-### Compliance Considerations
-
-- **GDPR:** Data protection and privacy rights
-- **CCPA:** California consumer privacy
-- **SOC 2:** Security and availability controls
-- **ISO 27001:** Information security management
-
-## Input Validation & Sanitization
-
-### Actor Identifier Validation
-
-- Validate @username@domain format
-- Sanitize special characters in usernames
-- Check domain name validity (DNS resolution)
-- Prevent directory traversal in URLs
-- Validate URL schemes (https only for production)
-- Limit identifier length to prevent buffer overflows
-- Block known malicious domains
-
-### HTTP Request Security
-
-- Validate Content-Type headers
-- Limit request body size
-- Sanitize HTTP headers
-- Implement request timeout limits
-- Validate SSL/TLS certificates
-- Use secure HTTP client configuration
-- Implement proper error handling
-
-### Data Processing Security
-
-- Validate JSON structure and content
-- Sanitize text content for XSS prevention
-- Limit data structure depth (prevent DoS)
-- Validate ActivityPub object types
-- Check for malicious embedded content
-- Implement content size limits
-- Validate date/time formats
-
-## Access Control & Authentication
-
-### MCP Client Authentication
-
-- Verify MCP client identity
-- Implement secure communication channels
-- Validate client permissions
-- Log authentication attempts
-- Implement session management
-- Use secure token handling
-
-### Resource Access Control
-
-- Implement resource-level permissions
-- Validate access to cached data
-- Control server information exposure
-- Implement rate limiting per client
-- Log resource access attempts
-- Prevent unauthorized data enumeration
-
-### Network Security
-
-- Use HTTPS for all external requests
-- Implement certificate pinning where appropriate
-- Configure secure TLS settings
-- Validate SSL certificate chains
-- Implement connection timeouts
-- Use secure DNS resolution
-
-## Data Protection & Privacy
-
-### Data Collection & Storage
-
-- Minimize data collection (only necessary data)
-- Implement data retention policies
-- Secure cache storage mechanisms
-- Encrypt sensitive data at rest
-- Implement secure data deletion
-- Prevent data leakage in logs
-- Document data flows and storage
-
-### Privacy Compliance
-
-- Implement data subject rights (GDPR)
-- Provide data portability mechanisms
-- Implement right to erasure
-- Maintain consent records
-- Implement privacy by design
-- Conduct privacy impact assessments
-- Document legal basis for processing
-
-### Data Transmission Security
-
-- Encrypt data in transit
-- Implement secure communication protocols
-- Validate data integrity
-- Prevent man-in-the-middle attacks
-- Use secure serialization formats
-- Implement message authentication
-
-## Rate Limiting & DoS Protection
-
-### Rate Limiting Implementation
-
-- Implement per-client rate limits
-- Configure per-endpoint rate limits
-- Implement sliding window rate limiting
-- Configure burst protection
-- Implement graceful degradation
-- Log rate limit violations
-- Implement automatic blocking for abuse
-
-### Resource Protection
-
-- Limit concurrent connections
-- Implement memory usage limits
-- Configure CPU usage thresholds
-- Limit cache size and growth
-- Implement request timeout limits
-- Monitor resource consumption
-- Implement circuit breakers
-
-## Logging & Monitoring
-
-### Security Event Logging
-
-- Log authentication attempts
-- Log authorization failures
-- Log rate limit violations
-- Log suspicious request patterns
-- Log data access events
-- Log configuration changes
-- Log error conditions
-
-### Log Security
-
-- Sanitize sensitive data in logs
-- Implement log integrity protection
-- Secure log storage and transmission
-- Implement log retention policies
-- Control access to log files
-- Implement log monitoring and alerting
-- Regular log review procedures
-
-### Monitoring & Alerting
-
-- Monitor for security anomalies
-- Implement real-time threat detection
-- Configure security alerts
-- Monitor system resource usage
-- Track performance degradation
-- Implement incident response procedures
-- Regular security metric reviews
-
-## Configuration Security
-
-### Environment Configuration
-
-- Use secure default configurations
-- Disable unnecessary features
-- Configure secure environment variables
-- Implement configuration validation
-- Use secure random number generation
-- Configure proper file permissions
-- Implement configuration change tracking
-
-### Deployment Security
-
-- Use minimal container images
-- Implement container security scanning
-- Configure secure runtime environments
-- Implement network segmentation
-- Use secure orchestration platforms
-- Implement secrets management
-- Regular security updates
-
-## Security Testing
-
-### Automated Security Testing
-
-```bash
-# Dependency vulnerability scanning
-npm audit
-
-# Static code analysis
-npm run lint:security
-
-# Container security scanning
-docker scan activitypub-mcp:latest
-
-# Network security testing
-nmap -sS -O target-host
-```
-
-### Manual Security Testing
-
-- Input validation testing
-- Authentication bypass testing
-- Authorization testing
-- Rate limiting testing
-- Data exposure testing
-- Error handling testing
-- Configuration security review
-
-### Penetration Testing
-
-- External penetration testing
-- Internal security assessment
-- Social engineering testing
-- Physical security assessment
-- Wireless security testing
-- Application security testing
-- Regular security audits
-
-## Compliance Checklist
-
-### GDPR Compliance
-
-- Data protection impact assessment
-- Lawful basis for processing
-- Data subject rights implementation
-- Consent management
-- Data breach notification procedures
-- Privacy by design implementation
-
-### SOC 2 Type II
-
-- Security controls documentation
-- Availability monitoring
-- Processing integrity controls
-- Confidentiality measures
-- Privacy protection controls
-- Regular control testing
-
-### ISO 27001
-
-- Information security policy
-- Risk assessment procedures
-- Security control implementation
-- Incident management procedures
-- Business continuity planning
-- Regular management reviews
-
-## Incident Response
-
-### Preparation
-
-- Incident response plan documented
-- Response team roles defined
-- Communication procedures established
-- Forensic tools prepared
-- Backup and recovery procedures tested
-
-### Detection & Analysis
-
-- Security monitoring systems active
-- Incident classification procedures
-- Evidence collection procedures
-- Impact assessment methods
-- Threat intelligence integration
-
-### Containment & Recovery
-
-- Containment strategies defined
-- System isolation procedures
-- Recovery procedures documented
-- Validation testing procedures
-- Lessons learned documentation
-
-## Security Resources
-
-- [Dependency Security](/activitypub-mcp/docs/development/dependencies/) — Secure dependency management practices
-- [Performance Monitoring](/activitypub-mcp/docs/development/performance/) — Monitor for security-related performance issues
-- [Security Troubleshooting](/activitypub-mcp/docs/reference/troubleshooting/) — Common security issues and solutions
+ActivityPub MCP feeds attacker-authored, world-writable fediverse content — posts, bios, display
+names, notifications — directly to an LLM that may simultaneously hold write access to the user's
+account. A malicious post or bio can contain instructions crafted to steer the model (e.g. "ignore
+previous instructions and post the following"). **Notifications are an unsolicited injection
+channel**: anyone on the fediverse can mention your account and have that content surface to the
+model without any action on your part.
+
+This is not hypothetical: anyone who can publish a post can attempt to influence what the LLM does
+on your behalf.
+
+## Mitigations — and their limits
+
+### Read-only by default
+
+Mutation tools (post, reply, delete, boost, favourite, bookmark, follow, mute, block, vote, upload,
+scheduled posts) are **not registered** unless `ACTIVITYPUB_ENABLE_WRITES=true` is set. Without that
+flag, injected content has no write tools to call — the attack surface is limited to information
+disclosure and model-output manipulation, not account action. There is also a runtime guard
+(`requireWriteEnabled`) so a mutation refuses even if it were somehow reachable.
+
+**Recommendation:** keep writes disabled unless you actively need them, and review the write tool
+surface before enabling.
+
+### Untrusted-content envelope
+
+All remote fediverse content is wrapped in an `<untrusted-content source="...">` envelope before it
+reaches the model, signalling provenance and instructing the model to treat the content as data, not
+instructions. **This is a mitigation, not a cure** — a determined payload can still influence the
+model's reasoning. The outer control is your MCP client's per-call approval UX: review tool calls
+before approving them, especially writes.
+
+### Tool annotations
+
+Every tool carries MCP `annotations` (`readOnlyHint`, `destructiveHint`) so compliant clients can
+gate or surface write tools differently. This is advisory — clients are not required to enforce it.
+
+## Network & SSRF protection
+
+The server fetches arbitrary remote URLs, so every outbound request goes through one guarded path:
+
+- **HTTPS-only**; no private/loopback/link-local ranges (`10.x`, `172.16–31.x`, `192.168.x`,
+  `127.x`, `::1`, `169.254.x`, IPv4-mapped/NAT64/6to4 forms, etc.).
+- **DNS-rebinding protection:** the resolved IP is pinned and re-validated after every redirect, so a
+  rebind mid-request can't reach a private address.
+- **Redirect re-validation:** each redirect target is re-checked against the same allow/block rules.
+- **Response size caps** to prevent memory exhaustion; **`upload-media`** stats files and refuses
+  anything over `MAX_UPLOAD_SIZE` before reading them.
+- **Operator instance blocklist** (`BLOCKED_INSTANCES`, exact domain or `*.wildcard`). Note: an apex
+  entry does *not* cover its subdomains — use `*.example.com` to block a whole instance family.
+- **Cross-origin thread fetches are off by default** (`MCP_THREAD_CROSS_ORIGIN_FETCH=false`): both the
+  reply branch and the in-reply-to ancestor walk stay on the root post's origin, so a hostile root
+  can't steer the server into fetching arbitrary third-party hosts.
+
+## Credential storage & audit
+
+OAuth/MiAuth tokens are stored at `${XDG_CONFIG_HOME:-~/.config}/activitypub-mcp/accounts.json` with
+mode `0600`; the server refuses to open a symlink at that path. Audit logs redact tokens and post
+content and store only file basenames (never absolute paths) — secrets are never written to log
+output. Set `AUDIT_LOG_ENABLED=false` to disable the in-memory audit trail (not recommended when
+writes are enabled).
+
+## HTTP transport
+
+When running in HTTP mode:
+
+- A bearer secret is required (minimum 16 characters); requests without a valid
+  `Authorization: Bearer <secret>` header are rejected.
+- The MCP SDK's DNS-rebinding protection is active. For non-localhost binds, set
+  `MCP_HTTP_ALLOWED_HOSTS` and `MCP_HTTP_ALLOWED_ORIGINS`.
+- For local use (Claude Desktop, Cursor), **stdio transport is recommended** — no network exposure.
+
+## Reporting a vulnerability
+
+Report security issues **privately** — do not open a public issue. Use
+[GitHub Security Advisories](https://github.com/cameronrye/activitypub-mcp/security) ("Report a
+vulnerability") or email `c@meron.io` with subject `[SECURITY] ActivityPub MCP — <brief description>`.
+The canonical, always-current policy lives in
+[`SECURITY.md`](https://github.com/cameronrye/activitypub-mcp/blob/main/SECURITY.md).
+
+## Security resources
+
+- [Dependency Security](/activitypub-mcp/docs/development/dependencies/) — secure dependency management
+- [Security Troubleshooting](/activitypub-mcp/docs/reference/troubleshooting/) — common security issues

--- a/site/src/content/docs/getting-started/configuration.mdx
+++ b/site/src/content/docs/getting-started/configuration.mdx
@@ -87,6 +87,21 @@ By default, the server registers only read-only tools. Write tools (posting, fol
 |----------|---------|-------------|
 | `ACTIVITYPUB_ENABLE_WRITES` | `false` | Set to `true` to register write tools (post-status, reply-to-post, follow-account, boost-post, etc.). Also requires at least one authenticated account — from `ACTIVITYPUB_ACCOUNTS`, the `ACTIVITYPUB_DEFAULT_INSTANCE`/`ACTIVITYPUB_DEFAULT_TOKEN` pair, or `activitypub-mcp login`. |
 
+### Security & Limits
+
+Hardening knobs for the SSRF/abuse and prompt-injection threat model (see the
+[Security Model](/activitypub-mcp/docs/development/security/)). Defaults are safe; tune only if you
+understand the tradeoff. Out-of-range numeric values are clamped to a safe floor at startup.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `INSTANCE_BLOCKING_ENABLED` | `true` | Enforce the operator instance blocklist on every fetch (and redirect hop). |
+| `BLOCKED_INSTANCES` | _empty_ | Comma-separated domains to refuse. Exact match or `*.example.com` wildcard. An apex entry does **not** cover its subdomains — use the wildcard for a whole instance family. |
+| `MAX_RESPONSE_SIZE` | `10485760` | Max bytes read from any remote response, to prevent memory exhaustion (10 MB). |
+| `MAX_UPLOAD_SIZE` | `104857600` | Max bytes `upload-media` will read from a local file before sniffing/forwarding it (100 MB). Files over the cap are refused before being read. Raise it if your instance accepts larger media. |
+| `AUDIT_LOG_ENABLED` | `true` | Record tool invocations (writes/uploads, SSRF blocks, rate-limit denials) in the in-memory audit trail. |
+| `AUDIT_LOG_MAX_ENTRIES` | `10000` | Max audit entries kept in memory (oldest evicted). Floored at 1. |
+
 ## Logging Configuration
 
 ### Log Levels

--- a/site/src/content/docs/reference/changelog.mdx
+++ b/site/src/content/docs/reference/changelog.mdx
@@ -9,6 +9,29 @@ order: 2
 
 All notable changes to the ActivityPub MCP Server are documented here. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### v3.1.3 - 2026-06-09
+
+**Security & correctness hardening patch** from an end-to-end review. Fixes a stdio shutdown hang, hardens `upload-media` (size cap + path-leak fix), gates cross-origin thread fetches, hardens the Misskey read path, and tightens the install/release supply chain. See [CHANGELOG.md](https://github.com/cameronrye/activitypub-mcp/blob/main/CHANGELOG.md) for the complete entry.
+
+#### Fixed
+
+- **`Ctrl+C` now exits the stdio server** — graceful shutdown never closed the MCP transport, so the stdin listener kept the process alive and SIGINT/SIGTERM hung. The transport is now closed on shutdown.
+- **Misskey `direct` messages fail loud** instead of silently posting to no one (a `specified` note with no recipients is author-only); the tool now reports that DMs aren't wired up for Misskey.
+- **Malformed remote items no longer fail a whole read** — the Misskey read adapter drops a bad note/coerces non-numeric reaction counts and enforces the requested `limit`, instead of throwing on one record.
+- **Numeric env vars are validated and clamped** — `AUDIT_LOG_MAX_ENTRIES=0` no longer silently disables the audit trail, `MAX_RESPONSE_SIZE=10MB` no longer parses to 10 bytes, and negative timeouts are rejected.
+
+#### Security
+
+- **`upload-media` caps file size before reading** (`MAX_UPLOAD_SIZE`, default 100 MB), so a coerced/oversized path can't exhaust memory.
+- **`upload-media` errors no longer leak absolute filesystem paths or errno** — a prompt-injected model can't use them as a filesystem-enumeration oracle; the audit log records only the file basename.
+- **Cross-origin thread fetches are gated for ancestors too** — the `inReplyTo` walk now honors `MCP_THREAD_CROSS_ORIGIN_FETCH=false` like the reply branch, closing a fetch-amplification/privacy-control bypass.
+- **`get-scheduled-posts` is annotated read-only** (was mislabeled destructive).
+- **Supply chain:** the install script parses existing config with `JSON.parse` (no more `node -e` interpolation), the registry publish job pins and checksum-verifies `mcp-publisher` and drops `secrets: inherit`, and the token-holding release jobs run `npm ci --ignore-scripts`.
+
+#### Known limitations
+
+- The HTTP transport still serves one MCP session per process; proper multi-session support is tracked for a follow-up. The default stdio transport is unaffected.
+
 ### v3.1.2 - 2026-06-09
 
 **Correctness, logging, and audit patch.** Fixes a logging bug that polluted the stdio JSON-RPC stream, a cache misconfiguration that could hang startup, and a missing post idempotency key; records SSRF and rate-limit denials in the audit trail; and removes dead support links. See [CHANGELOG.md](https://github.com/cameronrye/activitypub-mcp/blob/main/CHANGELOG.md) for the complete entry.

--- a/src/activitypub/read-adapter.ts
+++ b/src/activitypub/read-adapter.ts
@@ -183,7 +183,27 @@ interface MisskeyTrendTag {
   usersCount?: number;
 }
 
-function misskeyAccount(user: MisskeyUser, domain: string): NormalizedPost["account"] {
+/**
+ * Coerce an untrusted remote count to a finite, non-negative integer. Remote
+ * JSON is typed `number` but a hostile/buggy instance can send a string, null,
+ * or object; without this, summing reaction counts can string-concatenate
+ * ("0"+"5"->"05") or produce NaN, and that value is shown to the model as a
+ * numeric count.
+ */
+function toCount(v: unknown): number {
+  const n = typeof v === "number" ? v : Number(v);
+  return Number.isFinite(n) && n > 0 ? Math.trunc(n) : 0;
+}
+
+function misskeyAccount(
+  user: MisskeyUser | null | undefined,
+  domain: string,
+): NormalizedPost["account"] {
+  // A hostile/non-conformant instance can omit user; don't let that throw and
+  // poison the whole batch.
+  if (!user || typeof user.username !== "string") {
+    return { username: "unknown", acct: "unknown", url: `https://${domain}` };
+  }
   const acct = user.host ? `${user.username}@${user.host}` : user.username;
   const base = user.host ? `https://${user.host}` : `https://${domain}`;
   return {
@@ -195,21 +215,49 @@ function misskeyAccount(user: MisskeyUser, domain: string): NormalizedPost["acco
 }
 
 function misskeyNoteToPost(note: MisskeyNote, domain: string): NormalizedPost {
-  const reactionsTotal = note.reactions
-    ? Object.values(note.reactions).reduce((a, b) => a + b, 0)
-    : 0;
+  const reactionsTotal =
+    note.reactions && typeof note.reactions === "object"
+      ? Object.values(note.reactions).reduce((a: number, b) => a + toCount(b), 0)
+      : 0;
   const fallbackUrl = `https://${domain}/notes/${note.id}`;
   return {
     id: note.id,
     content: note.text ?? "",
     account: misskeyAccount(note.user, domain),
     created_at: note.createdAt,
-    reblogs_count: note.renoteCount ?? 0,
+    reblogs_count: toCount(note.renoteCount),
     favourites_count: reactionsTotal,
-    replies_count: note.repliesCount ?? 0,
+    replies_count: toCount(note.repliesCount),
     url: note.url ?? note.uri ?? fallbackUrl,
     spoiler_text: note.cw ?? undefined,
   };
+}
+
+/**
+ * Normalize a batch of remote notes, dropping (rather than throwing on) any
+ * single malformed item so one bad record can't fail the entire timeline/
+ * trending/search read.
+ */
+function normalizeNotes(notes: MisskeyNote[], domain: string): NormalizedPost[] {
+  const out: NormalizedPost[] = [];
+  for (const note of notes) {
+    try {
+      // Drop structurally-malformed records (no id, or no attributable author)
+      // rather than surfacing authorless attacker content to the model.
+      if (
+        !note ||
+        typeof note.id !== "string" ||
+        !note.user ||
+        typeof note.user.username !== "string"
+      ) {
+        continue;
+      }
+      out.push(misskeyNoteToPost(note, domain));
+    } catch {
+      // skip any other malformed item rather than poisoning the whole batch
+    }
+  }
+  return out;
 }
 
 export const misskeyReadAdapter: ReadAdapter = {
@@ -235,7 +283,9 @@ export const misskeyReadAdapter: ReadAdapter = {
     const notes = asArray<MisskeyNote>(
       await postJson(`https://${domain}/api/notes/featured`, { limit }),
     );
-    return { posts: notes.map((n) => misskeyNoteToPost(n, domain)) };
+    // Enforce the cap defensively: a server that ignores `limit` can't flood the
+    // model with attacker-influenced notes.
+    return { posts: normalizeNotes(notes, domain).slice(0, limit) };
   },
 
   async fetchPublicTimeline(domain, scope, { limit = 20, maxId, sinceId, minId }) {
@@ -248,10 +298,12 @@ export const misskeyReadAdapter: ReadAdapter = {
     const notes = asArray<MisskeyNote>(
       await postJson(`https://${domain}/api/notes/${endpoint}`, body),
     );
-    const posts = notes.map((n) => misskeyNoteToPost(n, domain));
+    const posts = normalizeNotes(notes, domain).slice(0, limit);
     return {
       posts,
-      hasMore: posts.length === limit,
+      // "more" reflects whether the server returned a full page, not how many
+      // survived normalization.
+      hasMore: notes.length >= limit,
       nextMaxId: notes.length > 0 ? notes[notes.length - 1]?.id : undefined,
     };
   },
@@ -279,7 +331,7 @@ export const misskeyReadAdapter: ReadAdapter = {
       const notes = asArray<MisskeyNote>(
         await postJson(`https://${domain}/api/notes/search`, { query, limit: 20 }),
       );
-      return { statuses: notes.map((n) => misskeyNoteToPost(n, domain)) };
+      return { statuses: normalizeNotes(notes, domain) };
     }
     // hashtags: Misskey returns an array of tag-name strings.
     const tags = asArray<string>(

--- a/src/activitypub/remote-client.ts
+++ b/src/activitypub/remote-client.ts
@@ -953,6 +953,21 @@ export class RemoteActivityPubClient {
     const maxAncestors = 10;
 
     while (currentInReplyTo && ancestorDepth < maxAncestors) {
+      // Apply the same cross-origin gate the replies branch uses. The root post
+      // is attacker-controlled, so its inReplyTo chain can point at ANY host;
+      // without this, with THREAD_CROSS_ORIGIN_FETCH off (the default), the
+      // ancestor walk still fired up to maxAncestors attacker-directed
+      // cross-origin fetches per call — defeating the documented privacy control
+      // and turning one thread read into a fetch-amplification primitive.
+      let ancestorOrigin = "";
+      try {
+        ancestorOrigin = new URL(currentInReplyTo).origin;
+      } catch {
+        break; // unparseable URL — stop walking
+      }
+      if (ancestorOrigin !== rootOrigin && !THREAD_CROSS_ORIGIN_FETCH) {
+        break; // stop at the first off-origin ancestor instead of fetching it
+      }
       try {
         const ancestor = await this.fetchObject(currentInReplyTo);
         ancestors.unshift(ancestor); // Add to beginning to maintain chronological order

--- a/src/auth/adapters/misskey-adapter.ts
+++ b/src/auth/adapters/misskey-adapter.ts
@@ -223,6 +223,13 @@ export class MisskeyWriteAdapter implements WriteAdapter {
     if (options.scheduledAt) {
       throw new UnsupportedOnPlatformError("Scheduled posts", "Misskey");
     }
+    // A Misskey 'specified' note needs explicit visibleUserIds; mapping
+    // Mastodon 'direct' to 'specified' with no recipients makes the note visible
+    // to the author ONLY, so the intended DM silently goes nowhere. We can't
+    // reliably derive recipients here, so fail loud rather than drop the message.
+    if (options.visibility === "direct") {
+      throw new UnsupportedOnPlatformError("Direct messages (visibility: direct)", "Misskey");
+    }
     const body: Record<string, unknown> = {
       text: options.content,
       visibility: mastodonToMisskeyVisibility(options.visibility),

--- a/src/config.ts
+++ b/src/config.ts
@@ -13,13 +13,63 @@ import { join } from "node:path";
 // =============================================================================
 
 /**
- * Parse an integer from environment variable with fallback.
- * Returns the default value if parsing fails or results in NaN.
+ * Coercions/rejections recorded while parsing numeric env vars, surfaced as
+ * warnings by validateConfiguration() (logtape isn't safe to import at module
+ * load on the stdio transport, so we defer emitting these).
  */
-function parseIntEnv(value: string | undefined, defaultValue: number): number {
-  if (!value) return defaultValue;
-  const parsed = Number.parseInt(value, 10);
-  return Number.isNaN(parsed) ? defaultValue : parsed;
+const numericEnvWarnings: string[] = [];
+
+/**
+ * Parse an integer from an environment variable with a fallback, validating and
+ * clamping the result.
+ *
+ * Plain `Number.parseInt` is too permissive for security-relevant knobs: it
+ * parses the prefix of `"10MB"` as `10` (so MAX_RESPONSE_SIZE='10MB' silently
+ * becomes a 10-BYTE cap), and it happily returns 0 or a negative number that can
+ * disable the audit trail (AUDIT_LOG_MAX_ENTRIES=0) or abort every request
+ * (REQUEST_TIMEOUT=-5). This rejects non-integer strings outright and clamps the
+ * result into [min, max], recording a warning for either case.
+ *
+ * @param name  Env var name (for warning messages)
+ * @param value Raw env value
+ * @param defaultValue Fallback when unset/invalid
+ * @param opts.min Inclusive lower bound (clamped up)
+ * @param opts.max Inclusive upper bound (clamped down)
+ */
+function parseIntEnv(
+  name: string,
+  value: string | undefined,
+  defaultValue: number,
+  opts: { min?: number; max?: number } = {},
+): number {
+  const clamp = (n: number): number => {
+    let v = n;
+    if (opts.min !== undefined && v < opts.min) {
+      numericEnvWarnings.push(
+        `${name}=${n} is below the minimum ${opts.min}; clamped to ${opts.min}.`,
+      );
+      v = opts.min;
+    }
+    if (opts.max !== undefined && v > opts.max) {
+      numericEnvWarnings.push(
+        `${name}=${n} is above the maximum ${opts.max}; clamped to ${opts.max}.`,
+      );
+      v = opts.max;
+    }
+    return v;
+  };
+
+  if (value === undefined || value === null || value.trim() === "") return clamp(defaultValue);
+  const trimmed = value.trim();
+  // Require the WHOLE string to be an integer — reject "10MB", "5s", "abc",
+  // "1.5" so a typo'd suffix can't silently become a misleading prefix value.
+  if (!/^[+-]?\d+$/.test(trimmed)) {
+    numericEnvWarnings.push(`${name}="${value}" is not an integer; using default ${defaultValue}.`);
+    return clamp(defaultValue);
+  }
+  const parsed = Number.parseInt(trimmed, 10);
+  if (Number.isNaN(parsed)) return clamp(defaultValue);
+  return clamp(parsed);
 }
 
 /**
@@ -40,7 +90,7 @@ function parseBoolEnv(value: string | undefined, defaultValue: boolean): boolean
 export const SERVER_NAME = process.env.MCP_SERVER_NAME || "activitypub-mcp";
 
 /** MCP Server version */
-export const SERVER_VERSION = process.env.MCP_SERVER_VERSION || "3.1.2";
+export const SERVER_VERSION = process.env.MCP_SERVER_VERSION || "3.1.3";
 
 /**
  * Directory for the persisted credential store (accounts.json).
@@ -61,29 +111,63 @@ export const LOG_LEVEL = process.env.LOG_LEVEL || "info";
 export const USER_AGENT = process.env.USER_AGENT || `ActivityPub-MCP-Client/${SERVER_VERSION}`;
 
 /** Request timeout in milliseconds (default: 10 seconds) */
-export const REQUEST_TIMEOUT = parseIntEnv(process.env.REQUEST_TIMEOUT, 10000);
+export const REQUEST_TIMEOUT = parseIntEnv("REQUEST_TIMEOUT", process.env.REQUEST_TIMEOUT, 10000, {
+  min: 1,
+});
 
 /** Maximum response size in bytes to prevent DoS attacks (default: 10MB) */
-export const MAX_RESPONSE_SIZE = parseIntEnv(process.env.MAX_RESPONSE_SIZE, 10 * 1024 * 1024);
+export const MAX_RESPONSE_SIZE = parseIntEnv(
+  "MAX_RESPONSE_SIZE",
+  process.env.MAX_RESPONSE_SIZE,
+  10 * 1024 * 1024,
+  // Floor at 1: prevents the silent footguns (0/negative reject every body;
+  // "10MB" is already rejected as a non-integer and falls back to the default),
+  // without overriding a deliberately small operator value.
+  { min: 1 },
+);
+
+/**
+ * Maximum size (bytes) of a local file upload-media will read into memory before
+ * sniffing/forwarding it (default: 100MB). Guards against a coerced/oversized
+ * path OOM-ing the process; the target instance still enforces its own real
+ * media limit. Raise it if your instance accepts larger media.
+ */
+export const MAX_UPLOAD_SIZE = parseIntEnv(
+  "MAX_UPLOAD_SIZE",
+  process.env.MAX_UPLOAD_SIZE,
+  100 * 1024 * 1024,
+  { min: 1 },
+);
 
 /** Maximum number of retry attempts for failed requests */
-export const MAX_RETRIES = parseIntEnv(process.env.MAX_RETRIES, 3);
+export const MAX_RETRIES = parseIntEnv("MAX_RETRIES", process.env.MAX_RETRIES, 3, { min: 0 });
 
 /** Base delay for retry backoff in milliseconds */
-export const RETRY_BASE_DELAY = parseIntEnv(process.env.RETRY_BASE_DELAY, 1000);
+export const RETRY_BASE_DELAY = parseIntEnv(
+  "RETRY_BASE_DELAY",
+  process.env.RETRY_BASE_DELAY,
+  1000,
+  {
+    min: 0,
+  },
+);
 
 /** Maximum delay for retry backoff in milliseconds (default: 30 seconds) */
-export const RETRY_MAX_DELAY = parseIntEnv(process.env.RETRY_MAX_DELAY, 30000);
+export const RETRY_MAX_DELAY = parseIntEnv("RETRY_MAX_DELAY", process.env.RETRY_MAX_DELAY, 30000, {
+  min: 0,
+});
 
 // =============================================================================
 // Cache Configuration
 // =============================================================================
 
 /** Cache TTL in milliseconds (default: 5 minutes) */
-export const CACHE_TTL = parseIntEnv(process.env.CACHE_TTL, 300000);
+export const CACHE_TTL = parseIntEnv("CACHE_TTL", process.env.CACHE_TTL, 300000, { min: 0 });
 
 /** Maximum number of items in LRU caches */
-export const CACHE_MAX_SIZE = parseIntEnv(process.env.CACHE_MAX_SIZE, 1000);
+export const CACHE_MAX_SIZE = parseIntEnv("CACHE_MAX_SIZE", process.env.CACHE_MAX_SIZE, 1000, {
+  min: 1,
+});
 
 // =============================================================================
 // Rate Limiting Configuration
@@ -93,15 +177,24 @@ export const CACHE_MAX_SIZE = parseIntEnv(process.env.CACHE_MAX_SIZE, 1000);
 export const RATE_LIMIT_ENABLED = parseBoolEnv(process.env.RATE_LIMIT_ENABLED, true);
 
 /** Maximum requests per window */
-export const RATE_LIMIT_MAX = parseIntEnv(process.env.RATE_LIMIT_MAX, 100);
+export const RATE_LIMIT_MAX = parseIntEnv("RATE_LIMIT_MAX", process.env.RATE_LIMIT_MAX, 100, {
+  min: 1,
+});
 
 /** Rate limit window in milliseconds (default: 15 minutes) */
-export const RATE_LIMIT_WINDOW = parseIntEnv(process.env.RATE_LIMIT_WINDOW, 900000);
+export const RATE_LIMIT_WINDOW = parseIntEnv(
+  "RATE_LIMIT_WINDOW",
+  process.env.RATE_LIMIT_WINDOW,
+  900000,
+  { min: 1 },
+);
 
 /** Rate limit cleanup interval in milliseconds (default: 1 minute) */
 export const RATE_LIMIT_CLEANUP_INTERVAL = parseIntEnv(
+  "RATE_LIMIT_CLEANUP_INTERVAL",
   process.env.RATE_LIMIT_CLEANUP_INTERVAL,
   60000,
+  { min: 1 },
 );
 
 // =============================================================================
@@ -125,10 +218,22 @@ export const MAX_INSTANCE_RESULTS = 20;
 // =============================================================================
 
 /** Maximum recursion depth when fetching a post thread (default: 5) */
-export const THREAD_MAX_DEPTH = parseIntEnv(process.env.MCP_THREAD_MAX_DEPTH, 5);
+export const THREAD_MAX_DEPTH = parseIntEnv(
+  "MCP_THREAD_MAX_DEPTH",
+  process.env.MCP_THREAD_MAX_DEPTH,
+  5,
+  {
+    min: 0,
+  },
+);
 
 /** Maximum total replies fetched per thread, across all depths (default: 50) */
-export const THREAD_MAX_REPLIES = parseIntEnv(process.env.MCP_THREAD_MAX_REPLIES, 50);
+export const THREAD_MAX_REPLIES = parseIntEnv(
+  "MCP_THREAD_MAX_REPLIES",
+  process.env.MCP_THREAD_MAX_REPLIES,
+  50,
+  { min: 0 },
+);
 
 /**
  * Whether to follow replies whose origin differs from the root post.
@@ -148,7 +253,10 @@ export const THREAD_CROSS_ORIGIN_FETCH = parseBoolEnv(
 export const TRANSPORT_MODE = (process.env.MCP_TRANSPORT_MODE || "stdio") as "stdio" | "http";
 
 /** HTTP server port (default: 3000) */
-export const HTTP_PORT = parseIntEnv(process.env.MCP_HTTP_PORT, 3000);
+export const HTTP_PORT = parseIntEnv("MCP_HTTP_PORT", process.env.MCP_HTTP_PORT, 3000, {
+  min: 0,
+  max: 65535,
+});
 
 /** HTTP server host (default: 127.0.0.1 for security) */
 export const HTTP_HOST = process.env.MCP_HTTP_HOST || "127.0.0.1";
@@ -212,12 +320,19 @@ export const INSTANCES_SOCIAL_TOKEN = process.env.INSTANCES_SOCIAL_TOKEN || "";
 
 /** Cache TTL for dynamic instance data in milliseconds (default: 1 hour) */
 export const DYNAMIC_INSTANCE_CACHE_TTL = parseIntEnv(
+  "DYNAMIC_INSTANCE_CACHE_TTL",
   process.env.DYNAMIC_INSTANCE_CACHE_TTL,
   3600000,
+  { min: 0 },
 );
 
 /** Maximum instances to fetch from external API */
-export const MAX_DYNAMIC_INSTANCES = parseIntEnv(process.env.MAX_DYNAMIC_INSTANCES, 100);
+export const MAX_DYNAMIC_INSTANCES = parseIntEnv(
+  "MAX_DYNAMIC_INSTANCES",
+  process.env.MAX_DYNAMIC_INSTANCES,
+  100,
+  { min: 1 },
+);
 
 // =============================================================================
 // Instance Software Detection (NodeInfo) Configuration
@@ -228,8 +343,10 @@ export const MAX_DYNAMIC_INSTANCES = parseIntEnv(process.env.MAX_DYNAMIC_INSTANC
  * Default: 24h. Negative-cache TTL (for detection failures) is hardcoded at 1h.
  */
 export const INSTANCE_SOFTWARE_TTL = parseIntEnv(
+  "MCP_INSTANCE_SOFTWARE_TTL_MS",
   process.env.MCP_INSTANCE_SOFTWARE_TTL_MS,
   86_400_000,
+  { min: 0 },
 );
 
 // =============================================================================
@@ -239,8 +356,17 @@ export const INSTANCE_SOFTWARE_TTL = parseIntEnv(
 /** Whether audit logging is enabled (default: true) */
 export const AUDIT_LOG_ENABLED = parseBoolEnv(process.env.AUDIT_LOG_ENABLED, true);
 
-/** Maximum audit log entries to keep in memory */
-export const AUDIT_LOG_MAX_ENTRIES = parseIntEnv(process.env.AUDIT_LOG_MAX_ENTRIES, 10000);
+/**
+ * Maximum audit log entries to keep in memory. Floored at 1: a value of 0 made
+ * the eviction loop drop every entry on write, silently disabling the audit
+ * trail that records prompt-injection-driven write/upload calls.
+ */
+export const AUDIT_LOG_MAX_ENTRIES = parseIntEnv(
+  "AUDIT_LOG_MAX_ENTRIES",
+  process.env.AUDIT_LOG_MAX_ENTRIES,
+  10000,
+  { min: 1 },
+);
 
 // =============================================================================
 // Instance Blocklist Configuration
@@ -272,7 +398,7 @@ export const INSTANCE_BLOCKING_ENABLED = parseBoolEnv(process.env.INSTANCE_BLOCK
  * Validates configuration on startup and logs warnings for missing recommended settings.
  */
 export function validateConfiguration(): void {
-  const warnings: string[] = [];
+  const warnings: string[] = [...numericEnvWarnings];
 
   // Check for recommended environment variables
   if (!process.env.NODE_ENV) {
@@ -282,6 +408,20 @@ export function validateConfiguration(): void {
   // Warn if rate limiting is disabled in production
   if (process.env.NODE_ENV === "production" && !RATE_LIMIT_ENABLED) {
     warnings.push("Rate limiting is disabled in production environment");
+  }
+
+  // Surface the highest-risk config combinations for the prompt-injection threat
+  // model so an operator who enables writes (or exposes them over HTTP) sees it.
+  if (ENABLE_WRITES) {
+    warnings.push(
+      "ACTIVITYPUB_ENABLE_WRITES=true: mutation tools (post, follow, delete, …) are registered. " +
+        "Untrusted fediverse content the model reads could attempt to drive them — keep accounts least-privilege.",
+    );
+    if (TRANSPORT_MODE === "http") {
+      warnings.push(
+        "Writes are enabled on the HTTP transport — ensure MCP_HTTP_SECRET is strong and the port is not publicly reachable.",
+      );
+    }
   }
 
   // Log warnings via logtape — never via console.warn, which on stdio

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -172,6 +172,18 @@ class ActivityPubMCPServer {
   async stop(): Promise<void> {
     logger.info("Stopping ActivityPub MCP Server...");
 
+    // Close the MCP transport. For stdio this removes the StdioServerTransport's
+    // stdin 'data' listener and pauses stdin; without it that listener keeps the
+    // event loop alive and the process hangs after SIGINT (the shutdown handler
+    // deliberately doesn't call process.exit, so the loop must be able to drain).
+    try {
+      await this.mcpServer.close();
+    } catch (error) {
+      logger.warn("Error closing MCP transport", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+
     // Stop HTTP server if running
     if (this.httpServer) {
       await this.httpServer.stop();

--- a/src/mcp/tools-write.ts
+++ b/src/mcp/tools-write.ts
@@ -11,9 +11,9 @@ import { type CallToolResult, ErrorCode, McpError } from "@modelcontextprotocol/
 import { z } from "zod";
 import { auditLogger } from "../audit/logger.js";
 import { accountManager, authenticatedClient } from "../auth/index.js";
-import { ENABLE_WRITES } from "../config.js";
+import { ENABLE_WRITES, MAX_UPLOAD_SIZE } from "../config.js";
 import type { RateLimiter } from "../resilience/rate-limiter.js";
-import { formatRemoteError, getErrorMessage } from "../utils/errors.js";
+import { formatRemoteError, getErrorMessage, LocalMediaError } from "../utils/errors.js";
 import { sniffMediaType } from "../utils/media-type.js";
 import { sanitizeInline, wrapUntrusted } from "../utils/untrusted.js";
 import { trackedMcpServer } from "./capabilities.js";
@@ -1847,7 +1847,12 @@ function registerUploadMediaTool(mcpServer: McpServer, rateLimiter: RateLimiter)
     async ({ filePath, description, focusX, focusY, accountId }) => {
       requireWriteEnabled();
       const startTime = Date.now();
-      const auditParams = { filePath, description, focusX, focusY, accountId };
+      const path = await import("node:path");
+      const baseName = path.basename(filePath);
+      // Record only the basename: the absolute path the model was asked to read
+      // is sensitive (it leaks the OS user/home and lets a prompt-injected model
+      // probe the filesystem). The basename is the security-relevant fact.
+      const auditParams = { filePath: baseName, description, focusX, focusY, accountId };
 
       const account = accountId
         ? accountManager.getAccount(accountId)
@@ -1868,11 +1873,32 @@ function registerUploadMediaTool(mcpServer: McpServer, rateLimiter: RateLimiter)
       checkRateLimit(rateLimiter, account.instance);
 
       try {
-        // Read the file
         const fs = await import("node:fs/promises");
-        const path = await import("node:path");
 
-        const fileBuffer = await fs.readFile(filePath);
+        // Stat before reading: reject anything over the cap (or not a regular
+        // file) so a coerced/oversized path can't OOM the process by being
+        // buffered whole into memory. Local fs errors are converted to a
+        // LocalMediaError carrying only the basename — never an absolute path
+        // or a distinguishable errno (which would be a filesystem-enumeration
+        // oracle for a prompt-injected model).
+        let fileBuffer: Buffer;
+        try {
+          const stats = await fs.stat(filePath);
+          if (!stats.isFile()) {
+            throw new LocalMediaError(`could not read media file ${baseName}: not a regular file`);
+          }
+          if (stats.size > MAX_UPLOAD_SIZE) {
+            throw new LocalMediaError(
+              `media file ${baseName} is too large (${stats.size} bytes; maximum is ${MAX_UPLOAD_SIZE}). ` +
+                "Set MAX_UPLOAD_SIZE to raise the cap if your instance accepts larger media.",
+            );
+          }
+          fileBuffer = await fs.readFile(filePath);
+        } catch (fsError) {
+          if (fsError instanceof LocalMediaError) throw fsError;
+          // A genuine fs error (ENOENT/EACCES/EISDIR/…): sanitize to basename.
+          throw new LocalMediaError(`could not read media file ${baseName}`);
+        }
 
         // Validate by content, not extension: only forward actual media. A
         // model coaxed by prompt-injected fediverse content could otherwise
@@ -1881,12 +1907,12 @@ function registerUploadMediaTool(mcpServer: McpServer, rateLimiter: RateLimiter)
         // before its bytes are handed to the instance.
         const mediaType = sniffMediaType(fileBuffer);
         if (!mediaType) {
-          throw new Error(
-            `File is not a recognized media file (image, video, or audio): ${path.basename(filePath)}. upload-media only accepts media files.`,
+          throw new LocalMediaError(
+            `File is not a recognized media file (image, video, or audio): ${baseName}. upload-media only accepts media files.`,
           );
         }
 
-        const filename = path.basename(filePath);
+        const filename = baseName;
 
         const focus =
           focusX !== undefined && focusY !== undefined ? { x: focusX, y: focusY } : undefined;
@@ -1930,13 +1956,16 @@ post-status content="Your post" mediaIds=["${media.id}"]
           duration: Date.now() - startTime,
           error: message,
         });
+        // LocalMediaError messages are locally-originated and pre-sanitized
+        // (basename only) — render them verbatim. formatRemoteError is reserved
+        // for attacker-controlled REMOTE bodies; passing a local fs error
+        // through it would leak the absolute path it embeds.
+        const text =
+          error instanceof LocalMediaError
+            ? `❌ Failed to upload media: ${message}`
+            : `❌ Failed to upload media: ${formatRemoteError(error)}`;
         return {
-          content: [
-            {
-              type: "text",
-              text: `❌ Failed to upload media: ${formatRemoteError(error)}`,
-            },
-          ],
+          content: [{ type: "text", text }],
           isError: true,
         };
       }
@@ -1958,7 +1987,10 @@ function registerGetScheduledPostsTool(mcpServer: McpServer, rateLimiter: RateLi
         limit: z.number().min(1).max(40).optional().describe("Number of posts (default: 20)"),
         accountId: z.string().optional().describe("Account ID"),
       },
-      annotations: { readOnlyHint: false, destructiveHint: true, openWorldHint: true },
+      // Read-only: this tool only fetches scheduled posts (a GET). It must not
+      // carry the destructive annotation the actual mutators use, or clients
+      // that gate destructive tools behind confirmation will friction a read.
+      annotations: { readOnlyHint: true },
     },
     async ({ limit = 20, accountId }) => {
       requireAuthEnabled();

--- a/src/transport/http.ts
+++ b/src/transport/http.ts
@@ -276,6 +276,14 @@ export class HttpTransportServer {
         // The SDK options are marked @deprecated in favour of external middleware,
         // but they are still fully functional and provide defence-in-depth against
         // DNS-rebinding attacks at the SDK layer.
+        //
+        // KNOWN LIMITATION (tracked for a follow-up): a single stateful transport
+        // is shared for the process, so the HTTP server handles ONE MCP session at
+        // a time — a second concurrent client gets "already initialized", and a new
+        // session can't start until the process restarts. The default (and
+        // recommended) transport is stdio; HTTP is opt-in and bearer-gated. Proper
+        // multi-session support needs a per-session transport map + a per-session
+        // McpServer, which is an isolated change to this security-sensitive surface.
         this.transport = new StreamableHTTPServerTransport({
           sessionIdGenerator: () => crypto.randomUUID(),
           enableDnsRebindingProtection: true,

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -162,6 +162,22 @@ export function formatRemoteError(error: unknown, source = "remote instance erro
 }
 
 /**
+ * Thrown for problems reading a local media file in upload-media (missing,
+ * unreadable, not a regular file, too large). The message is pre-sanitized to a
+ * file BASENAME only — never an absolute path and never a distinguishable errno —
+ * so a prompt-injected model cannot use upload-media's error output as a
+ * filesystem-enumeration oracle (ENOENT vs EACCES) or to recover absolute paths.
+ * Rendered to the model verbatim (NOT through formatRemoteError, which is for
+ * attacker-controlled REMOTE bodies, not locally-originated fs errors).
+ */
+export class LocalMediaError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "LocalMediaError";
+  }
+}
+
+/**
  * Thrown when an operation has no equivalent on the target fediverse software
  * (e.g. poll voting or scheduled posts on Misskey). Surfaced to the LLM as a
  * clear, actionable error instead of an opaque HTTP failure.

--- a/tests/unit/config-env-drift.test.ts
+++ b/tests/unit/config-env-drift.test.ts
@@ -62,4 +62,26 @@ describe("getting-started docs env-var drift guard", () => {
       expect(phantom, `phantom/removed env vars documented in ${file}`).toEqual([]);
     });
   }
+
+  // Reverse direction (security subset): an operator can't harden what they don't
+  // know is configurable, so the security/forensics knobs must stay documented.
+  it("documents the security-relevant env vars in configuration.mdx", () => {
+    const SECURITY_VARS = [
+      "INSTANCE_BLOCKING_ENABLED",
+      "BLOCKED_INSTANCES",
+      "MAX_RESPONSE_SIZE",
+      "MAX_UPLOAD_SIZE",
+      "AUDIT_LOG_ENABLED",
+      "AUDIT_LOG_MAX_ENTRIES",
+      "ACTIVITYPUB_ENABLE_WRITES",
+      "MCP_THREAD_CROSS_ORIGIN_FETCH",
+    ];
+    // Sanity: each is actually read by the code (catches a rename in src).
+    const notRead = SECURITY_VARS.filter((v) => !real.has(v));
+    expect(notRead, "security vars listed here but not read by src").toEqual([]);
+
+    const documented = new Set(documentedEnvVars("configuration.mdx"));
+    const undocumented = SECURITY_VARS.filter((v) => !documented.has(v));
+    expect(undocumented, "security-relevant env vars missing from configuration.mdx").toEqual([]);
+  });
 });

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -80,6 +80,50 @@ describe("config", () => {
   });
 });
 
+describe("numeric env validation & clamping", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("falls back to the default for a non-integer value like '10MB' instead of parsing the '10' prefix", async () => {
+    process.env.MAX_RESPONSE_SIZE = "10MB";
+    const mod = await import("../../src/config.js");
+    expect(mod.MAX_RESPONSE_SIZE).toBe(10 * 1024 * 1024);
+  });
+
+  it("clamps AUDIT_LOG_MAX_ENTRIES to at least 1 so 0 cannot silently disable the audit trail", async () => {
+    process.env.AUDIT_LOG_MAX_ENTRIES = "0";
+    const mod = await import("../../src/config.js");
+    expect(mod.AUDIT_LOG_MAX_ENTRIES).toBeGreaterThanOrEqual(1);
+  });
+
+  it("clamps a non-positive MAX_RESPONSE_SIZE up to a safe floor (0 would reject every body)", async () => {
+    process.env.MAX_RESPONSE_SIZE = "0";
+    const mod = await import("../../src/config.js");
+    expect(mod.MAX_RESPONSE_SIZE).toBeGreaterThan(0);
+  });
+
+  it("clamps a negative REQUEST_TIMEOUT up to at least 1ms (negative aborts every request immediately)", async () => {
+    process.env.REQUEST_TIMEOUT = "-5";
+    const mod = await import("../../src/config.js");
+    expect(mod.REQUEST_TIMEOUT).toBeGreaterThanOrEqual(1);
+  });
+
+  it("MAX_UPLOAD_SIZE defaults to a finite positive cap", async () => {
+    delete process.env.MAX_UPLOAD_SIZE;
+    const mod = await import("../../src/config.js");
+    expect(mod.MAX_UPLOAD_SIZE).toBeGreaterThan(0);
+    expect(Number.isFinite(mod.MAX_UPLOAD_SIZE)).toBe(true);
+  });
+});
+
 describe("Thread traversal config (M3)", () => {
   const originalEnv = process.env;
 

--- a/tests/unit/install-config-merge.test.ts
+++ b/tests/unit/install-config-merge.test.ts
@@ -1,0 +1,101 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+/**
+ * install.sh used to splice the user's existing config file contents straight
+ * into a `node -e "... const config = $existing_config ..."` program, treating
+ * the file as trusted JS source — a code-injection / install-breakage vector.
+ * The JSON merge now lives in this standalone, env-driven script that reads the
+ * file with JSON.parse. These tests pin the safe behavior.
+ */
+const SCRIPT = fileURLToPath(new URL("../../scripts/merge-mcp-config.mjs", import.meta.url));
+
+function run(env: Record<string, string>): void {
+  execFileSync(process.execPath, [SCRIPT], {
+    env: { ...process.env, ...env },
+    encoding: "utf8",
+    stdio: "pipe",
+  });
+}
+
+describe("merge-mcp-config.mjs (safe config update for install.sh)", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "apmcp-cfg-"));
+  });
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("adds the server to a missing config file", () => {
+    const cfg = path.join(dir, "config.json");
+    run({
+      AP_MCP_CONFIG_PATH: cfg,
+      AP_MCP_SERVER_NAME: "activitypub",
+      AP_MCP_PACKAGE_NAME: "activitypub-mcp",
+      AP_MCP_ACTION: "add",
+    });
+    const out = JSON.parse(fs.readFileSync(cfg, "utf8"));
+    expect(out.mcpServers.activitypub.command).toBe("npx");
+    expect(out.mcpServers.activitypub.args).toEqual(["-y", "activitypub-mcp"]);
+  });
+
+  it("preserves existing servers when adding", () => {
+    const cfg = path.join(dir, "config.json");
+    fs.writeFileSync(cfg, JSON.stringify({ mcpServers: { other: { command: "x" } } }));
+    run({
+      AP_MCP_CONFIG_PATH: cfg,
+      AP_MCP_SERVER_NAME: "activitypub",
+      AP_MCP_PACKAGE_NAME: "activitypub-mcp",
+      AP_MCP_ACTION: "add",
+    });
+    const out = JSON.parse(fs.readFileSync(cfg, "utf8"));
+    expect(out.mcpServers.other.command).toBe("x");
+    expect(out.mcpServers.activitypub).toBeDefined();
+  });
+
+  it("does not execute code in the existing config and refuses to clobber malformed JSON", () => {
+    const cfg = path.join(dir, "config.json");
+    const pwned = path.join(dir, "pwned");
+    // The old interpolated `node -e` would EXECUTE this. JSON.parse must reject it.
+    fs.writeFileSync(cfg, `{}; require('fs').writeFileSync(${JSON.stringify(pwned)}, 'x'); ({})`);
+    expect(() =>
+      run({
+        AP_MCP_CONFIG_PATH: cfg,
+        AP_MCP_SERVER_NAME: "activitypub",
+        AP_MCP_PACKAGE_NAME: "activitypub-mcp",
+        AP_MCP_ACTION: "add",
+      }),
+    ).toThrow();
+    expect(fs.existsSync(pwned)).toBe(false);
+    // The malformed file must be left untouched, not overwritten.
+    expect(fs.readFileSync(cfg, "utf8")).toContain("require(");
+  });
+
+  it("removes the server entry without touching others", () => {
+    const cfg = path.join(dir, "config.json");
+    fs.writeFileSync(
+      cfg,
+      JSON.stringify({ mcpServers: { activitypub: { command: "npx" }, other: {} } }),
+    );
+    run({ AP_MCP_CONFIG_PATH: cfg, AP_MCP_SERVER_NAME: "activitypub", AP_MCP_ACTION: "remove" });
+    const out = JSON.parse(fs.readFileSync(cfg, "utf8"));
+    expect(out.mcpServers.activitypub).toBeUndefined();
+    expect(out.mcpServers.other).toBeDefined();
+  });
+
+  it("handles a config path containing a single quote without breaking", () => {
+    const weird = path.join(dir, "o'brien.json");
+    run({
+      AP_MCP_CONFIG_PATH: weird,
+      AP_MCP_SERVER_NAME: "activitypub",
+      AP_MCP_PACKAGE_NAME: "activitypub-mcp",
+      AP_MCP_ACTION: "add",
+    });
+    expect(fs.existsSync(weird)).toBe(true);
+  });
+});

--- a/tests/unit/mcp-tools-write.test.ts
+++ b/tests/unit/mcp-tools-write.test.ts
@@ -755,6 +755,57 @@ describe("MCP Write Tools", () => {
       // The file's bytes must never be handed to the upload client.
       expect(uploadMediaMock).not.toHaveBeenCalled();
     });
+
+    it("rejects a file larger than the upload cap without reading or uploading it", async () => {
+      const uploadMediaMock = authenticatedClient.uploadMedia as Mock;
+      uploadMediaMock.mockClear();
+      // A sparse file just over the 100MB default cap: ftruncate reserves the
+      // size without allocating real bytes, so this is instant and cheap.
+      const bigPath = path.join(os.tmpdir(), "activitypub-mcp-test-big.bin");
+      const fd = fs.openSync(bigPath, "w");
+      fs.ftruncateSync(fd, 100 * 1024 * 1024 + 1);
+      fs.closeSync(fd);
+      try {
+        const tool = registeredTools.get("upload-media");
+        const result = await tool?.handler({ filePath: bigPath });
+
+        expect((result as { isError: boolean }).isError).toBe(true);
+        expect((result as { content: { text: string }[] }).content[0].text).toMatch(
+          /too large|exceeds|over the .*limit|maximum/i,
+        );
+        expect(uploadMediaMock).not.toHaveBeenCalled();
+      } finally {
+        fs.rmSync(bigPath, { force: true });
+      }
+    });
+
+    it("does not leak the absolute path or errno when a file can't be read", async () => {
+      const tool = registeredTools.get("upload-media");
+      const secretDir = path.join(os.tmpdir(), "activitypub-mcp-secret-dir-xyz");
+      const missing = path.join(secretDir, "id_rsa.png");
+
+      const result = await tool?.handler({ filePath: missing });
+      const text = (result as { content: { text: string }[] }).content[0].text;
+
+      expect((result as { isError: boolean }).isError).toBe(true);
+      expect(text).toContain("id_rsa.png"); // basename is fine to echo back
+      expect(text).not.toContain(secretDir); // but never the absolute directory
+      expect(text).not.toMatch(/ENOENT|EACCES|no such file|permission denied/i); // no errno oracle
+    });
+
+    it("records only the basename (not the absolute path) in the audit log", async () => {
+      auditLoggerMock.logToolInvocation.mockClear();
+      const tool = registeredTools.get("upload-media");
+      await tool?.handler({ filePath: PNG_FIXTURE_PATH });
+
+      const call = auditLoggerMock.logToolInvocation.mock.calls.find(
+        (c) => c[0] === "upload-media",
+      );
+      expect(call).toBeDefined();
+      const params = call?.[1] as { filePath?: string };
+      expect(params.filePath).toBe(path.basename(PNG_FIXTURE_PATH));
+      expect(params.filePath).not.toContain(path.sep);
+    });
   });
 
   describe("get-scheduled-posts tool", () => {

--- a/tests/unit/misskey-adapter.test.ts
+++ b/tests/unit/misskey-adapter.test.ts
@@ -87,6 +87,25 @@ describe("MisskeyWriteAdapter.createPost", () => {
     expect(createCalled).toBe(false);
   });
 
+  it("rejects a 'direct' DM instead of silently posting to nobody", async () => {
+    let createCalled = false;
+    server.use(
+      http.post("https://misskey.test/api/notes/create", () => {
+        createCalled = true;
+        return HttpResponse.json({ createdNote: sampleNote });
+      }),
+    );
+
+    // Misskey 'specified' notes need explicit visibleUserIds; mapping 'direct'
+    // to 'specified' with no recipients makes the note visible to the author
+    // only — the intended recipient never gets the DM. Fail loud instead.
+    await expect(
+      adapter.createPost(account, { content: "secret", visibility: "direct" }),
+    ).rejects.toThrow(/not supported on Misskey/i);
+
+    expect(createCalled).toBe(false);
+  });
+
   it("extracts Misskey error messages", async () => {
     server.use(
       http.post("https://misskey.test/api/notes/create", () =>

--- a/tests/unit/read-adapter.test.ts
+++ b/tests/unit/read-adapter.test.ts
@@ -231,4 +231,42 @@ describe("read PlatformAdapter — NodeInfo routing", () => {
       expect(res.hashtags?.map((h) => h.name)).toEqual(["art", "music"]);
     });
   });
+
+  describe("Misskey read adapter is resilient to hostile/malformed payloads", () => {
+    beforeEach(() => server.use(...nodeinfo(MISSKEY, "misskey")));
+
+    it("drops a malformed note (missing user) instead of failing the whole batch", async () => {
+      server.use(
+        http.post(`https://${MISSKEY}/api/notes/featured`, () =>
+          HttpResponse.json([
+            misskeyNote,
+            { id: "bad", createdAt: "2026-01-01T00:00:00Z", text: "no user", reactions: {} },
+          ]),
+        ),
+      );
+      const res = await client.fetchTrendingPosts(MISSKEY, { limit: 5 });
+      expect(res.posts).toHaveLength(1);
+      expect(res.posts[0].id).toBe("note1");
+    });
+
+    it("coerces non-numeric reaction counts instead of string-concatenating", async () => {
+      server.use(
+        http.post(`https://${MISSKEY}/api/notes/featured`, () =>
+          HttpResponse.json([{ ...misskeyNote, reactions: { "👍": "3", "🎉": 2 } }]),
+        ),
+      );
+      const res = await client.fetchTrendingPosts(MISSKEY, { limit: 5 });
+      expect(res.posts[0].favourites_count).toBe(5);
+      expect(typeof res.posts[0].favourites_count).toBe("number");
+    });
+
+    it("caps returned posts at the requested limit even if the server returns more", async () => {
+      const many = Array.from({ length: 10 }, (_, i) => ({ ...misskeyNote, id: `n${i}` }));
+      server.use(
+        http.post(`https://${MISSKEY}/api/notes/local-timeline`, () => HttpResponse.json(many)),
+      );
+      const res = await client.fetchLocalTimeline(MISSKEY, { limit: 3 });
+      expect(res.posts).toHaveLength(3);
+    });
+  });
 });

--- a/tests/unit/remote-client-thread.test.ts
+++ b/tests/unit/remote-client-thread.test.ts
@@ -102,6 +102,40 @@ describe("fetchPostThread cross-origin guard (M3)", () => {
     expect((stub as { fetched?: boolean }).fetched).toBe(false);
   });
 
+  it("does not fetch a cross-origin ancestor (inReplyTo) when the gate is off", async () => {
+    process.env.MCP_THREAD_CROSS_ORIGIN_FETCH = "false";
+    server.use(
+      // Root post on a.test replies to a post on b.test — an attacker-controlled
+      // root can point its inReplyTo chain at any host.
+      http.get("https://a.test/post/1", () =>
+        HttpResponse.json({
+          id: "https://a.test/post/1",
+          type: "Note",
+          inReplyTo: "https://b.test/post/parent",
+        }),
+      ),
+    );
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+    const { RemoteActivityPubClient } = await import("../../src/activitypub/remote-client.js");
+    const client = new RemoteActivityPubClient();
+    const thread = await client.fetchPostThread("https://a.test/post/1", {
+      depth: 1,
+      maxReplies: 10,
+    });
+
+    // b.test must never be contacted, and the off-origin ancestor must not appear.
+    const bTestCalls = fetchSpy.mock.calls.filter((args) => {
+      try {
+        return new URL(String(args[0])).hostname === "b.test";
+      } catch {
+        return false;
+      }
+    });
+    expect(bTestCalls).toHaveLength(0);
+    expect(thread.ancestors.some((a) => a.id === "https://b.test/post/parent")).toBe(false);
+  });
+
   it("caps total replies to THREAD_MAX_REPLIES", async () => {
     process.env.MCP_THREAD_MAX_REPLIES = "3";
     const ids = Array.from({ length: 10 }, (_, i) => `https://a.test/post/r${i}`);

--- a/tests/unit/ssrf-redirect-integration.test.ts
+++ b/tests/unit/ssrf-redirect-integration.test.ts
@@ -1,0 +1,57 @@
+import { HttpResponse, http } from "msw";
+import { describe, expect, it, vi } from "vitest";
+import { auditLogger } from "../../src/audit/logger.js";
+import { pinnedFetch } from "../../src/utils/fetch-helpers.js";
+import { SsrfBlockedError } from "../../src/validation/url.js";
+import { server } from "../mocks/server.js";
+
+/**
+ * The canonical SSRF bypass: a PUBLIC host that 302-redirects to a PRIVATE IP.
+ * The pieces are unit-tested in isolation — resolveAndPin rejects private IPs
+ * (url-pinning), fetchWithRedirectGuard calls its validator per hop with a mock
+ * validator (fetch-helpers) — but nothing proved they COMPOSE inside pinnedFetch,
+ * which wires resolveAndPin in as the real per-hop validator. A regression that
+ * skipped re-validation on a redirect hop would pass every other test.
+ *
+ * This drives the REAL pinnedFetch with the REAL resolveAndPin, mocking only DNS
+ * so the initial host resolves public and the redirect target resolves to a
+ * private IP, and asserts the redirect is blocked + audited.
+ */
+vi.mock("node:dns/promises", () => ({
+  lookup: async (hostname: string) => {
+    if (hostname === "internal.test") return [{ address: "10.0.0.1", family: 4 }];
+    // Everything else resolves to a public IP so the initial hop succeeds.
+    return [{ address: "93.184.216.34", family: 4 }];
+  },
+}));
+
+describe("pinnedFetch blocks a public→private-IP redirect (integrated)", () => {
+  it("rejects with SsrfBlockedError and audits the block when a 302 points at a private IP", async () => {
+    server.use(
+      http.get(
+        "https://public.test/start",
+        () =>
+          new HttpResponse(null, {
+            status: 302,
+            headers: { Location: "https://internal.test/secret" },
+          }),
+      ),
+      // If the guard were broken and the redirect were followed, this would be
+      // hit — its presence lets us assert it is NEVER reached (private IP target).
+      http.get("https://internal.test/secret", () => HttpResponse.json({ leaked: true })),
+    );
+
+    const spy = vi.spyOn(auditLogger, "logSsrfBlocked");
+    try {
+      await expect(pinnedFetch("https://public.test/start", {})).rejects.toBeInstanceOf(
+        SsrfBlockedError,
+      );
+      expect(spy).toHaveBeenCalledWith(
+        "https://public.test/start",
+        expect.stringContaining("private IP"),
+      );
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});

--- a/tests/unit/stdio-shutdown.test.ts
+++ b/tests/unit/stdio-shutdown.test.ts
@@ -1,0 +1,73 @@
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+/**
+ * The default stdio transport must terminate cleanly on SIGINT/SIGTERM. The
+ * server installs its own SIGINT handler (which suppresses Node's default
+ * terminate action), so if the graceful-shutdown path never closes the MCP
+ * transport, the StdioServerTransport's stdin 'data' listener keeps the event
+ * loop alive forever and the process hangs after Ctrl+C — the startup hint even
+ * tells users "Press Ctrl+C to exit", which would be a lie.
+ *
+ * This spawns the real entrypoint, drives an `initialize`, sends SIGINT, and
+ * asserts the process exits on its own within a short window (the test never has
+ * to SIGKILL it).
+ */
+const ENTRY = fileURLToPath(new URL("../../src/mcp-main.ts", import.meta.url));
+
+function initializeRequest(): string {
+  return `${JSON.stringify({
+    jsonrpc: "2.0",
+    id: 1,
+    method: "initialize",
+    params: {
+      protocolVersion: "2024-11-05",
+      capabilities: {},
+      clientInfo: { name: "shutdown-test", version: "1.0.0" },
+    },
+  })}\n`;
+}
+
+describe("stdio transport shuts down cleanly on SIGINT", () => {
+  it("exits on its own after SIGINT instead of hanging", async () => {
+    const result = await runUntilExitOnSigint();
+    expect(result.killedByTest).toBe(false); // the test never had to force-kill it
+    expect(result.exited).toBe(true);
+  }, 20000);
+});
+
+function runUntilExitOnSigint(): Promise<{ exited: boolean; killedByTest: boolean }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, ["--import", "tsx", ENTRY], {
+      env: { ...process.env, LOG_LEVEL: "info", MCP_TRANSPORT_MODE: "stdio" },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let sentSigint = false;
+    let killedByTest = false;
+
+    // If the process doesn't exit a while after SIGINT, it hung — force-kill so
+    // the test can fail (and so we don't leak a process).
+    const giveUp = setTimeout(() => {
+      killedByTest = true;
+      child.kill("SIGKILL");
+    }, 10000);
+
+    child.stdout.on("data", (d) => {
+      stdout += d.toString();
+      if (!sentSigint && stdout.includes('"id":1')) {
+        sentSigint = true;
+        child.kill("SIGINT");
+      }
+    });
+    child.on("error", reject);
+    child.on("exit", () => {
+      clearTimeout(giveUp);
+      resolve({ exited: true, killedByTest });
+    });
+
+    child.stdin.write(initializeRequest());
+  });
+}

--- a/tests/unit/tool-annotations.test.ts
+++ b/tests/unit/tool-annotations.test.ts
@@ -36,4 +36,15 @@ describe("tool annotations", () => {
     expect(ann.get("delete-post")?.destructiveHint).toBe(true);
     expect(ann.get("post-status")?.readOnlyHint).toBe(false);
   });
+
+  it("marks authenticated read tools readOnly, not destructive", async () => {
+    const ann = await collectAnnotations();
+    // get-scheduled-posts only fetches scheduled posts (a GET) — it must not be
+    // annotated as a destructive mutation like delete-post.
+    expect(ann.get("get-scheduled-posts")?.readOnlyHint).toBe(true);
+    expect(ann.get("get-scheduled-posts")?.destructiveHint).not.toBe(true);
+    // Siblings that are already correct, asserted to lock the convention.
+    expect(ann.get("get-home-timeline")?.readOnlyHint).toBe(true);
+    expect(ann.get("get-relationship")?.readOnlyHint).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary

End-to-end review hardening batch (→ **v3.1.3**). Fixes the real issues a deep multi-agent review surfaced; engineering remained A‑/A with **zero confirmed high/critical** findings, so these are the medium/low fixes worth shipping. Every change is test-first; **894 unit tests pass**, typecheck/lint/build clean.

## What's in it

**Reliability / UX**
- **`Ctrl+C`/SIGTERM now exits the stdio server.** `stop()` never closed the MCP transport, so the stdin listener kept the loop alive and the process hung after Ctrl+C (the startup hint literally says "Press Ctrl+C to exit").
- **Misskey `direct` messages fail loud** instead of silently posting to no one.
- **One malformed remote item no longer fails a whole read** — the Misskey read adapter drops bad notes, coerces non-numeric reaction counts, and enforces the requested `limit`.
- **Numeric env vars are validated/clamped** — `AUDIT_LOG_MAX_ENTRIES=0` no longer disables the audit trail, `MAX_RESPONSE_SIZE=10MB` no longer becomes a 10-byte cap, negative timeouts are floored; dangerous combinations warn at startup.

**Security**
- **`upload-media` size cap** (`MAX_UPLOAD_SIZE`, default 100 MB) before reading a file into memory (OOM guard).
- **`upload-media` no longer leaks absolute paths or errno** on failure (filesystem-enumeration oracle); audit records the basename only.
- **Cross-origin thread fetches gated for ancestors too** — the `inReplyTo` walk honors `MCP_THREAD_CROSS_ORIGIN_FETCH=false`, closing a fetch-amplification / privacy-control bypass.
- **`get-scheduled-posts` annotated read-only** (was mislabeled destructive).
- **Supply chain:** `install.sh` merges config via a `JSON.parse` helper (no more `node -e` interpolation = code-injection vector); the registry publish job pins + checksum-verifies `mcp-publisher` and drops `secrets: inherit`; token-holding release jobs run `npm ci --ignore-scripts`.

**Docs accuracy**
- Authenticated read tools no longer filed under "Write Tools / disabled by default"; on-site Security page rewritten to the real threat model (prompt injection, SSRF, untrusted-content envelope, read-only default); security/limits env vars documented; `search` default corrected (10).

**Tests added:** stdio shutdown, integrated SSRF redirect-to-private-IP regression, config clamping, upload-media size/leak, Misskey direct DM, read-adapter resilience, thread ancestor gate, install config-merge safety, annotation.

## Deferred (own follow-up)

- **HTTP transport single-session.** Proper multi-session support is an architectural inversion (per-session `McpServer` factory + manual body parsing) on the network-exposed, bearer-gated, opt-in surface — it deserves an isolated PR with focused review rather than riding in this batch. The limitation is documented in code + CHANGELOG. The default **stdio** transport is unaffected.
- **Mastodon least-privilege scopes** (requires existing users to re-login) — separate change.

## Note on merge

Merging bumps to 3.1.3 and **triggers the auto-publish to npm + the MCP registry**. Hold the merge until you're ready to release.
