### PR TITLE
v3.1.4: fix empty fetch-timeline + dropped logs, harden read/SSRF/install/release

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -5,14 +5,21 @@ on:
     branches: [ main, v2 ]
     paths: [ 'package.json' ]
 
-# Add permissions for GitHub token
+# Least privilege at the workflow level; the one job that pushes a tag elevates
+# to contents:write itself, and the reusable-workflow calls declare their own.
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   check-version:
     name: Check Version and Create Tag
     runs-on: ubuntu-latest
+    # Needs write to push the tag — but the token is NOT persisted into .git/config
+    # (persist-credentials: false below), so the full `npm ci` + test/lint/build
+    # that run in this job can't be read by a compromised dev dependency. The tag
+    # push authenticates inline, in its own step only.
+    permissions:
+      contents: write
     outputs:
       should_release: ${{ steps.decide.outputs.should_release }}
       version: ${{ steps.current_version.outputs.version }}
@@ -23,7 +30,7 @@ jobs:
       uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       with:
         fetch-depth: 0  # Fetch all history for version comparison
-        token: ${{ secrets.GITHUB_TOKEN }}
+        persist-credentials: false
     
     - name: Setup Node.js
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
@@ -115,20 +122,23 @@ jobs:
     
     - name: Create and push tag
       if: steps.check_tag.outputs.exists == 'false' && steps.version_changed.outputs.changed == 'true' && steps.validate_version.outputs.valid == 'true'
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         TAG_NAME="${{ steps.check_tag.outputs.tag_name }}"
         VERSION="${{ steps.current_version.outputs.version }}"
-        
+
         # Configure git
         git config user.name "github-actions[bot]"
         git config user.email "github-actions[bot]@users.noreply.github.com"
-        
+
         # Create annotated tag
         git tag -a "$TAG_NAME" -m "Release version $VERSION"
-        
-        # Push tag
-        git push origin "$TAG_NAME"
-        
+
+        # Push using a token supplied ONLY for this step — the checkout did not
+        # persist credentials, so the earlier npm ci / tests never had push access.
+        git push "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git" "$TAG_NAME"
+
         echo "Created and pushed tag: $TAG_NAME"
     
     - name: Decide whether to release
@@ -165,10 +175,10 @@ jobs:
     name: Publish release
     needs: check-version
     if: needs.check-version.outputs.should_release == 'true'
+    # Only what release.yml actually uses: contents:write for the GitHub release,
+    # id-token:write for npm provenance. (No packages:write / pull-requests:read.)
     permissions:
       contents: write
-      packages: write
-      pull-requests: read
       id-token: write
     uses: ./.github/workflows/release.yml
     with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,20 +81,46 @@ jobs:
         retention-days: 7
         if-no-files-found: error
 
-  lint:
-    name: Lint and Format Check
+  coverage:
+    name: Coverage thresholds
     runs-on: ubuntu-latest
-    
+    timeout-minutes: 30
+
     steps:
     - name: Checkout code
       uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-    
+
     - name: Setup Node.js
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
       with:
         node-version: '20.x'
         cache: 'npm'
-    
+
+    - name: Install dependencies
+      run: npm ci
+
+    # The matrix `test` job runs vitest without coverage, so the per-directory
+    # thresholds in vitest.config.ts were never actually enforced. This job fails
+    # CI when coverage drops below those floors.
+    - name: Run tests with coverage enforcement
+      run: npm run test:coverage
+      env:
+        NODE_OPTIONS: --max-old-space-size=4096
+
+  lint:
+    name: Lint and Format Check
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+    - name: Setup Node.js
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      with:
+        node-version: '20.x'
+        cache: 'npm'
+
     - name: Install dependencies
       run: npm ci
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,21 +17,25 @@ on:
   # Manual fallback: run against the vX.Y.Z tag to publish without a re-push.
   workflow_dispatch:
 
-# id-token: write is required for OIDC-based npm provenance attestations.
+# Least privilege at the workflow level; individual jobs elevate only what they
+# need. The token-bearing publish/release jobs get their grants per-job below.
 permissions:
-  contents: write
-  packages: write
-  pull-requests: read
-  id-token: write
+  contents: read
 
 jobs:
   test:
     name: Test before release
     runs-on: ubuntu-latest
+    # The test job runs the full dev dependency tree with lifecycle scripts; it
+    # must never hold a write token a compromised dependency could read.
+    permissions:
+      contents: read
 
     steps:
     - name: Checkout code
       uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      with:
+        persist-credentials: false
 
     - name: Setup Node.js
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
@@ -75,6 +79,8 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      with:
+        persist-credentials: false
 
     - name: Setup Node.js
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
@@ -101,12 +107,19 @@ jobs:
     name: Create GitHub Release
     needs: [test, publish-npm]
     runs-on: ubuntu-latest
+    # Only the release-creation needs write; npm publish + provenance live in the
+    # separate publish-npm job, so no id-token/packages here.
+    permissions:
+      contents: write
 
     steps:
     - name: Checkout code
       uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       with:
         fetch-depth: 0
+        # The release upload authenticates via the env GITHUB_TOKEN, not git, so
+        # don't persist a write credential while npm ci / the mcpb build run.
+        persist-credentials: false
 
     - name: Setup Node.js
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
@@ -155,7 +168,11 @@ jobs:
       # (ESM entrypoint needs its own package.json + prod node_modules) per the
       # steps in docs/distribution.md §3.
       run: |
-        npm install -g @anthropic-ai/mcpb
+        # Pin the exact version and skip lifecycle scripts: this job holds a
+        # contents:write token and produces the one-click .mcpb users install, so
+        # an unpinned/script-running mcpb would be a supply-chain RCE/tamper vector
+        # (publish-mcp.yml pins mcp-publisher for the same reason).
+        npm install -g @anthropic-ai/mcpb@2.1.2 --ignore-scripts
         stage="$(mktemp -d)"
         cp manifest.json package.json package-lock.json "$stage"/
         cp -R dist "$stage"/dist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,69 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.1.4] - 2026-06-10
+
+Security, correctness, and distribution patch from a second end-to-end review.
+
+### Fixed
+
+- **`fetch-timeline` shows real post content again.** Outbox items are activities
+  (`Create`/`Announce`), so reading `content` straight off the wrapper rendered every
+  post as `[Create] (empty)` against real Mastodon/Pleroma/Misskey servers. The
+  formatter now unwraps the nested object (and renders boosts by their URL).
+- **Subsystem logs are no longer silently dropped.** logtape categories are
+  array-based, so `getLogger("activitypub-mcp:http")` was a sibling of the configured
+  logger with no sink — about 13 subsystems (including the operator security and audit
+  warnings) emitted nothing. All call sites now use the array-child form, with a
+  regression test guarding against the colon form returning.
+- **Read timeouts now cover the response body, not just the headers.** A hostile
+  instance could send headers promptly then trickle the body forever, evading
+  `REQUEST_TIMEOUT` and pinning the tool call. The request deadline now spans the
+  body read across every AP-native read.
+- **`get-scheduled-posts` works without `ACTIVITYPUB_ENABLE_WRITES`.** It is an
+  authenticated read (`readOnlyHint`), but was registered inside the write-gated block,
+  contradicting the docs. It now ships with the other authenticated reads.
+- **`post-thread` resource resolves the real ActivityPub URI.** It built a
+  `/web/statuses/{id}` SPA URL that modern Mastodon does not serve as ActivityPub (it
+  302s to HTML), so the resource timed out and retried. It now resolves the canonical
+  `uri` via the REST API and validates `{statusId}` against path-segment injection.
+- **Windows `login` opens the browser correctly.** `cmd /c start` treated the OAuth
+  URL's `&` separators as command separators, truncating the URL and breaking login on
+  every Windows machine. It now uses rundll32's FileProtocolHandler (no shell parsing).
+
+### Security
+
+- **Thread reads no longer beacon to attacker-chosen hosts.** The cross-origin gate
+  added in 3.1.3 covered ancestors and reply items but not the root post's
+  `replies`-collection URL; with `THREAD_CROSS_ORIGIN_FETCH` off (the default) that URL
+  is now skipped when off-origin.
+- **SSRF private-range coverage corrected.** The IPv4 multicast (`224.0.0.0/4`) and
+  reserved (`240.0.0.0/4`) blocks, and the IPv6 multicast (`ff00::/8`) and Teredo
+  (`2001::/32`) blocks, matched only a fraction of each CIDR; they now cover the full
+  ranges.
+- **Mastodon read adapter hardened to parity with Misskey.** Public timeline, trending,
+  and search results from a (default-adapter) hostile server are now structurally
+  validated, count-coerced, and capped at the requested limit instead of passed through
+  unbounded.
+- **`install.ps1` no longer wipes other MCP servers on Windows PowerShell 5.1.** The
+  `ConvertFrom-Json -AsHashtable` path is PowerShell 6+ only; on 5.1 it threw and the
+  fallback overwrote the user's config with only our entry. Install/uninstall now
+  delegate to the shared Node merge helper, which preserves existing servers and
+  refuses to clobber unparseable configs.
+- **Release supply chain tightened.** The `.mcpb` builder (`@anthropic-ai/mcpb`) is now
+  version-pinned and installed with `--ignore-scripts`; the release/auto-release jobs
+  drop workflow-level write permissions to least privilege and check out with
+  `persist-credentials: false`, so the full dependency tree and tests never run with a
+  push-capable token.
+
+### Changed
+
+- CI now enforces the per-directory coverage thresholds (a dedicated coverage job runs
+  `vitest --coverage`); previously the matrix ran tests without coverage so the floors
+  were never checked.
+- The README "Add to Cursor" one-click button uses Cursor's `https://cursor.com/install-mcp`
+  wrapper; GitHub strips the raw `cursor://` href, leaving a dead button.
+
 ## [3.1.3] - 2026-06-09
 
 Security & correctness hardening patch from an end-to-end review.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ npx -y activitypub-mcp
 
 **One-click install:**
 
-[![Add to Cursor](https://cursor.com/deeplink/mcp-install-dark.svg)](cursor://anysphere.cursor-deeplink/mcp/install?name=activitypub-mcp&config=eyJjb21tYW5kIjoibnB4IiwiYXJncyI6WyIteSIsImFjdGl2aXR5cHViLW1jcCJdfQ==)
+[![Add to Cursor](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/install-mcp?name=activitypub-mcp&config=eyJjb21tYW5kIjoibnB4IiwiYXJncyI6WyIteSIsImFjdGl2aXR5cHViLW1jcCJdfQ==)
 [![Install in VS Code](https://img.shields.io/badge/VS_Code-Install-0098FF?style=flat-square&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=activitypub-mcp&config=%7B%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22activitypub-mcp%22%5D%7D)
 
 ### Claude Desktop

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.2",
   "name": "activitypub-mcp",
   "display_name": "ActivityPub MCP",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "description": "Read-only-by-default MCP server: let LLMs explore the Fediverse — Mastodon, Misskey, Pleroma.",
   "long_description": "Lets an LLM explore and interact with the existing Fediverse — Mastodon, Misskey, Foundkey, Pleroma, and compatible servers. Read-only by default; write tools are opt-in. Untrusted fediverse content is wrapped in an <untrusted-content> envelope before it reaches the model.",
   "author": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "activitypub-mcp",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "activitypub-mcp",
-      "version": "3.1.3",
+      "version": "3.1.4",
       "license": "MIT",
       "dependencies": {
         "@logtape/logtape": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activitypub-mcp",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "description": "Model Context Protocol (MCP) server for the Fediverse — let Claude and other LLMs explore and post to Mastodon, Misskey, and Pleroma. Read-only by default.",
   "mcpName": "io.github.cameronrye/activitypub-mcp",
   "main": "dist/mcp-main.js",

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -116,7 +116,7 @@ Upgrading from v1.x? See [MIGRATION-v2.md](https://github.com/cameronrye/activit
 
 ---
 
-**Version:** 3.1.3
+**Version:** 3.1.4
 **License:** MIT
 **Maintainer:** Cameron Rye (https://rye.dev/)
 **Repository:** https://github.com/cameronrye/activitypub-mcp

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -140,50 +140,35 @@ function Ensure-Directory {
 # Update configuration file
 function Update-Config {
     param([string]$ConfigPath)
-    
+
     $configDir = Split-Path $ConfigPath -Parent
-    
+
     Write-Step "Updating configuration: $ConfigPath"
-    
+
     Ensure-Directory $configDir
-    
-    # Create server configuration
-    $serverConfig = @{
-        command = "npx"
-        args = @("-y", $PACKAGE_NAME)
-        env = @{
-            LOG_LEVEL = "info"
-        }
-    }
-    
+
     if ($DryRun) {
-        Write-Info "[DRY RUN] Would update config at: $ConfigPath"
-        Write-Info "[DRY RUN] Server config: $($serverConfig | ConvertTo-Json -Depth 3)"
+        Write-Info "[DRY RUN] Would add '$SERVER_NAME' to MCP config at: $ConfigPath (preserving existing servers)"
         return
     }
-    
-    # Read existing config or create empty one
-    $existingConfig = @{}
-    if (Test-Path $ConfigPath) {
-        try {
-            $existingConfig = Get-Content $ConfigPath -Raw | ConvertFrom-Json -AsHashtable
-        } catch {
-            Write-Warn "Could not parse existing config, creating new one"
-            $existingConfig = @{}
-        }
+
+    # Delegate the JSON merge to the shared, env-driven Node helper (Node is a
+    # prerequisite). It preserves every existing mcpServers entry and REFUSES to
+    # overwrite a config it can't parse. The old `ConvertFrom-Json -AsHashtable`
+    # path is PowerShell 6+ only — on stock Windows PowerShell 5.1 it threw, the
+    # catch reset the config to empty, and the script then wiped every other MCP
+    # server the user had configured. This is the same helper install.sh uses.
+    $merge = Join-Path $PSScriptRoot "merge-mcp-config.mjs"
+    $env:AP_MCP_CONFIG_PATH = $ConfigPath
+    $env:AP_MCP_SERVER_NAME = $SERVER_NAME
+    $env:AP_MCP_PACKAGE_NAME = $PACKAGE_NAME
+    $env:AP_MCP_ACTION = "add"
+    node $merge
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "Failed to update configuration (existing config left untouched)."
+        exit 1
     }
-    
-    # Initialize mcpServers if it doesn't exist
-    if (-not $existingConfig.ContainsKey("mcpServers")) {
-        $existingConfig["mcpServers"] = @{}
-    }
-    
-    # Add or update the ActivityPub server configuration
-    $existingConfig["mcpServers"][$SERVER_NAME] = $serverConfig
-    
-    # Write updated configuration
-    $existingConfig | ConvertTo-Json -Depth 4 | Set-Content $ConfigPath -Encoding UTF8
-    
+
     Write-Info "Configuration updated successfully!"
 }
 
@@ -242,23 +227,22 @@ function Uninstall-Server {
     }
     
     if (Test-Path $configPath) {
-        try {
-            $config = Get-Content $configPath -Raw | ConvertFrom-Json -AsHashtable
-            if ($config.ContainsKey("mcpServers") -and $config["mcpServers"].ContainsKey($SERVER_NAME)) {
-                $config["mcpServers"].Remove($SERVER_NAME)
-                $config | ConvertTo-Json -Depth 4 | Set-Content $configPath -Encoding UTF8
-                Write-Info "Server configuration removed successfully!"
-            } else {
-                Write-Warn "Server configuration not found in config file"
-            }
-        } catch {
-            Write-Error "Failed to update config file: $_"
+        # Delegate to the same Node helper as the add path: it removes only our
+        # entry, preserves the rest, and refuses to clobber unparseable JSON —
+        # avoiding the PowerShell 5.1 -AsHashtable failure that wiped configs.
+        $merge = Join-Path $PSScriptRoot "merge-mcp-config.mjs"
+        $env:AP_MCP_CONFIG_PATH = $configPath
+        $env:AP_MCP_SERVER_NAME = $SERVER_NAME
+        $env:AP_MCP_ACTION = "remove"
+        node $merge
+        if ($LASTEXITCODE -ne 0) {
+            Write-Error "Failed to update config file (existing config left untouched)."
             exit 1
         }
     } else {
         Write-Warn "Config file not found: $configPath"
     }
-    
+
     Write-Info "Uninstallation completed!"
 }
 

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.cameronrye/activitypub-mcp",
   "description": "Read-only-by-default MCP server: let LLMs explore the Fediverse — Mastodon, Misskey, Pleroma.",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "repository": {
     "url": "https://github.com/cameronrye/activitypub-mcp",
     "source": "github"
@@ -12,7 +12,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "activitypub-mcp",
-      "version": "3.1.3",
+      "version": "3.1.4",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/site/src/content/docs/reference/changelog.mdx
+++ b/site/src/content/docs/reference/changelog.mdx
@@ -9,6 +9,32 @@ order: 2
 
 All notable changes to the ActivityPub MCP Server are documented here. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### v3.1.4 - 2026-06-10
+
+**Security, correctness, and distribution patch** from a second end-to-end review. Restores real `fetch-timeline` content, un-breaks subsystem logging and Windows login, hardens read timeouts, the thread privacy gate, the Mastodon read path, SSRF range coverage, the Windows installer, and the release supply chain. See [CHANGELOG.md](https://github.com/cameronrye/activitypub-mcp/blob/main/CHANGELOG.md) for the complete entry.
+
+#### Fixed
+
+- **`fetch-timeline` renders real content again** — outbox items are `Create`/`Announce` activities, so reading `content` off the wrapper showed every post as `[Create] (empty)`; the nested object is now unwrapped.
+- **Subsystem logs are no longer silently dropped** — logtape categories are array-based, so `getLogger("activitypub-mcp:http")` had no sink; ~13 subsystems (including security/audit warnings) now log via the array-child form.
+- **Read timeouts cover the response body, not just headers** — a hostile instance could send headers then trickle the body forever to pin a tool call; the deadline now spans the body read.
+- **`get-scheduled-posts` works without `ACTIVITYPUB_ENABLE_WRITES`** — it is an authenticated read but was registered inside the write-gated block.
+- **`post-thread` resource resolves the canonical ActivityPub URI** via the REST API instead of the dead `/web/statuses/` SPA route, and validates `{statusId}` against path-segment injection.
+- **Windows `login` opens the browser correctly** — `cmd /c start` split the OAuth URL at its `&` separators; it now uses rundll32's FileProtocolHandler (no shell parsing).
+
+#### Security
+
+- **Thread reads don't beacon to attacker-chosen hosts** — the cross-origin gate now also covers the root post's `replies`-collection URL (default-off).
+- **SSRF private-range coverage corrected** — IPv4 `224.0.0.0/4` & `240.0.0.0/4` and IPv6 `ff00::/8` & Teredo `2001::/32` now match their full ranges.
+- **Mastodon read adapter hardened to parity with Misskey** — timeline/trending/search results are structurally validated, count-coerced, and capped at the requested limit.
+- **`install.ps1` no longer wipes other MCP servers on Windows PowerShell 5.1** — it delegates to the shared Node merge helper, which preserves existing servers and refuses to clobber unparseable configs.
+- **Release supply chain tightened** — the `.mcpb` builder is version-pinned and installed with `--ignore-scripts`; release jobs drop to least-privilege permissions and check out with `persist-credentials: false`.
+
+#### Changed
+
+- CI enforces the per-directory coverage thresholds via a dedicated coverage job.
+- The README "Add to Cursor" button uses Cursor's `https://cursor.com/install-mcp` wrapper (GitHub strips raw `cursor://` hrefs).
+
 ### v3.1.3 - 2026-06-09
 
 **Security & correctness hardening patch** from an end-to-end review. Fixes a stdio shutdown hang, hardens `upload-media` (size cap + path-leak fix), gates cross-origin thread fetches, hardens the Misskey read path, and tightens the install/release supply chain. See [CHANGELOG.md](https://github.com/cameronrye/activitypub-mcp/blob/main/CHANGELOG.md) for the complete entry.

--- a/src/activitypub/read-adapter.ts
+++ b/src/activitypub/read-adapter.ts
@@ -112,19 +112,91 @@ function asArray<T>(data: unknown): T[] {
   return Array.isArray(data) ? (data as T[]) : [];
 }
 
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return !!v && typeof v === "object";
+}
+
 // =============================================================================
 // Mastodon read adapter (existing REST behaviour, lifted into the adapter)
 // =============================================================================
 
+const SEARCH_LIMIT = 20;
+
+/**
+ * Validate + normalize ONE untrusted Mastodon status. A hostile or non-conformant
+ * server (the default adapter for ALL detection failures) controls this JSON, so
+ * we drop records lacking a string id or an attributable author rather than
+ * surfacing authorless attacker content, and coerce every count through toCount.
+ * Returns null for a record that should be dropped.
+ */
+function normalizeMastodonPost(raw: unknown, domain: string): NormalizedPost | null {
+  if (!isRecord(raw) || typeof raw.id !== "string") return null;
+  const account = isRecord(raw.account) ? raw.account : undefined;
+  if (!account || typeof account.username !== "string") return null;
+  return {
+    id: raw.id,
+    content: typeof raw.content === "string" ? raw.content : "",
+    account: {
+      username: account.username,
+      acct: typeof account.acct === "string" ? account.acct : account.username,
+      display_name: typeof account.display_name === "string" ? account.display_name : undefined,
+      url: typeof account.url === "string" ? account.url : `https://${domain}`,
+    },
+    created_at: typeof raw.created_at === "string" ? raw.created_at : "",
+    reblogs_count: toCount(raw.reblogs_count),
+    favourites_count: toCount(raw.favourites_count),
+    replies_count: toCount(raw.replies_count),
+    url: typeof raw.url === "string" ? raw.url : `https://${domain}/@${account.username}/${raw.id}`,
+    spoiler_text: typeof raw.spoiler_text === "string" ? raw.spoiler_text : undefined,
+  };
+}
+
+/** Normalize a batch of untrusted statuses, dropping malformed records and
+ * capping the result so a server that ignores `limit` can't flood the model. */
+function normalizeMastodonPosts(data: unknown, domain: string, limit: number): NormalizedPost[] {
+  const out: NormalizedPost[] = [];
+  for (const raw of asArray<unknown>(data)) {
+    const post = normalizeMastodonPost(raw, domain);
+    if (post) out.push(post);
+    if (out.length >= limit) break;
+  }
+  return out;
+}
+
+/** Validate + normalize untrusted Mastodon trend tags, dropping malformed
+ * records and capping the result. */
+function normalizeMastodonHashtags(
+  data: unknown,
+  domain: string,
+  limit: number,
+): NormalizedHashtag[] {
+  const out: NormalizedHashtag[] = [];
+  for (const raw of asArray<unknown>(data)) {
+    if (!isRecord(raw) || typeof raw.name !== "string") continue;
+    out.push({
+      name: raw.name,
+      url:
+        typeof raw.url === "string"
+          ? raw.url
+          : `https://${domain}/tags/${encodeURIComponent(raw.name)}`,
+      history: Array.isArray(raw.history)
+        ? (raw.history as NormalizedHashtag["history"])
+        : undefined,
+    });
+    if (out.length >= limit) break;
+  }
+  return out;
+}
+
 export const mastodonReadAdapter: ReadAdapter = {
   async fetchTrendingHashtags(domain, { limit = 20, offset = 0 }) {
     const url = `https://${domain}/api/v1/trends/tags?limit=${limit}&offset=${offset}`;
-    return { hashtags: asArray<NormalizedHashtag>(await getJson(url)) };
+    return { hashtags: normalizeMastodonHashtags(await getJson(url), domain, limit) };
   },
 
   async fetchTrendingPosts(domain, { limit = 20, offset = 0 }) {
     const url = `https://${domain}/api/v1/trends/statuses?limit=${limit}&offset=${offset}`;
-    return { posts: asArray<NormalizedPost>(await getJson(url)) };
+    return { posts: normalizeMastodonPosts(await getJson(url), domain, limit) };
   },
 
   async fetchPublicTimeline(domain, scope, { limit = 20, maxId, sinceId, minId }) {
@@ -134,17 +206,43 @@ export const mastodonReadAdapter: ReadAdapter = {
     if (sinceId) params.set("since_id", sinceId);
     if (minId) params.set("min_id", minId);
     const url = `https://${domain}/api/v1/timelines/public?${params.toString()}`;
-    const posts = asArray<NormalizedPost>(await getJson(url));
+    const raw = asArray<unknown>(await getJson(url));
+    const posts = normalizeMastodonPosts(raw, domain, limit);
     return {
       posts,
-      hasMore: posts.length === limit,
+      // "more" reflects whether the server returned a full page, not how many
+      // survived normalization.
+      hasMore: raw.length >= limit,
       nextMaxId: posts.length > 0 ? posts[posts.length - 1]?.id : undefined,
     };
   },
 
   async searchInstance(domain, query, type) {
-    const url = `https://${domain}/api/v2/search?q=${encodeURIComponent(query)}&type=${type}&limit=20`;
-    return (await getJson<SearchResult>(url)) ?? {};
+    const url = `https://${domain}/api/v2/search?q=${encodeURIComponent(query)}&type=${type}&limit=${SEARCH_LIMIT}`;
+    const raw = await getJson<unknown>(url);
+    if (!isRecord(raw)) return {};
+    const result: SearchResult = {};
+    if (Array.isArray(raw.accounts)) {
+      result.accounts = raw.accounts
+        .filter(isRecord)
+        .filter((a) => typeof a.username === "string")
+        .slice(0, SEARCH_LIMIT)
+        .map((a) => ({
+          username: a.username as string,
+          acct: typeof a.acct === "string" ? a.acct : (a.username as string),
+          display_name: typeof a.display_name === "string" ? a.display_name : undefined,
+          note: typeof a.note === "string" ? a.note : undefined,
+          followers_count: typeof a.followers_count === "number" ? a.followers_count : undefined,
+          statuses_count: typeof a.statuses_count === "number" ? a.statuses_count : undefined,
+        }));
+    }
+    if (Array.isArray(raw.statuses)) {
+      result.statuses = normalizeMastodonPosts(raw.statuses, domain, SEARCH_LIMIT);
+    }
+    if (Array.isArray(raw.hashtags)) {
+      result.hashtags = normalizeMastodonHashtags(raw.hashtags, domain, SEARCH_LIMIT);
+    }
+    return result;
   },
 };
 

--- a/src/activitypub/remote-client.ts
+++ b/src/activitypub/remote-client.ts
@@ -27,7 +27,16 @@ import {
   resolveReadAdapter,
 } from "./read-adapter.js";
 
-const logger = getLogger("activitypub-mcp");
+const logger = getLogger(["activitypub-mcp", "remote-client"]);
+
+// Minimal Mastodon-compatible REST status shape: we only need the canonical
+// ActivityPub identifier (`uri`) and the web `url` to resolve a thread.
+const StatusUriSchema = z
+  .object({
+    uri: z.string().optional(),
+    url: z.string().optional(),
+  })
+  .passthrough();
 
 // ActivityPub Collection schema
 const ActivityPubCollectionSchema = z.object({
@@ -529,21 +538,27 @@ export class RemoteActivityPubClient {
 
     // Fetch from all endpoints in parallel
     const results = await Promise.allSettled(
-      endpoints.map(async (endpoint) => {
-        const response = await this.fetchWithTimeout(endpoint, {
-          headers: {
-            Accept: "application/json",
-            "User-Agent": USER_AGENT,
+      endpoints.map((endpoint) =>
+        this.fetchWithTimeout(
+          endpoint,
+          {
+            headers: {
+              Accept: "application/json",
+              "User-Agent": USER_AGENT,
+            },
           },
-        });
-
-        if (!response.ok) {
-          throw new Error(`HTTP ${response.status}`);
-        }
-
-        const data = await readJsonWithLimit<Record<string, unknown>>(response, MAX_RESPONSE_SIZE);
-        return { endpoint, data };
-      }),
+          async (response) => {
+            if (!response.ok) {
+              throw new Error(`HTTP ${response.status}`);
+            }
+            const data = await readJsonWithLimit<Record<string, unknown>>(
+              response,
+              MAX_RESPONSE_SIZE,
+            );
+            return { endpoint, data };
+          },
+        ),
+      ),
     );
 
     // Find the first successful result
@@ -563,6 +578,40 @@ export class RemoteActivityPubClient {
     }
 
     throw new Error(`Failed to fetch instance information for ${domain}`);
+  }
+
+  /**
+   * Resolve a {domain, statusId} pair to the status's canonical ActivityPub URI
+   * via the Mastodon-compatible REST API (GET /api/v1/statuses/{id}).
+   *
+   * The old `/web/statuses/{id}` SPA route is NOT an ActivityPub endpoint — it
+   * 302-redirects to an HTML page, so fetching it as AP timed out and retried.
+   * Resolving the real `uri` (falling back to `url`) here makes the post-thread
+   * resource work against the Mastodon-compatible instances it documents.
+   *
+   * @param domain - The instance domain (already validated by the caller)
+   * @param statusId - The status id (already validated by the caller)
+   * @returns The canonical ActivityPub URI for the status
+   */
+  async resolveStatusUri(domain: string, statusId: string): Promise<string> {
+    const url = `https://${domain}/api/v1/statuses/${encodeURIComponent(statusId)}`;
+    const status = await this.fetchWithRetry(
+      url,
+      {
+        headers: {
+          Accept: "application/json",
+          "User-Agent": USER_AGENT,
+        },
+      },
+      StatusUriSchema,
+    );
+    const resolved = status.uri || status.url;
+    if (!resolved) {
+      throw new Error(
+        `Status ${statusId} on ${domain} did not return a resolvable ActivityPub URI`,
+      );
+    }
+    return resolved;
   }
 
   /**
@@ -718,39 +767,41 @@ export class RemoteActivityPubClient {
 
     for (let attempt = 1; attempt <= this.maxRetries; attempt++) {
       try {
-        const response = await this.fetchWithTimeout(url, fetchOptions);
-
-        // Handle 304 Not Modified
-        if (response.status === 304) {
-          if (cached) {
-            logger.debug("Using cached response (304 Not Modified)", { url });
-            return cached.data;
-          }
-          // 304 with no cache entry — server insists it's unchanged but we have nothing.
-          // Re-fetch once without If-None-Match.
-          logger.debug("304 received but no cache entry; re-fetching", { url });
-          const freshHeaders = new Headers(options.headers);
-          freshHeaders.delete("If-None-Match");
-          const freshResponse = await this.fetchWithTimeout(url, {
-            ...options,
-            headers: freshHeaders,
-          });
-          if (freshResponse.status === 304) {
-            throw new Error(
-              `Server returned 304 on unconditional re-fetch for ${url}; server is misconfigured`,
+        return await this.fetchWithTimeout(url, fetchOptions, async (response) => {
+          // Handle 304 Not Modified
+          if (response.status === 304) {
+            if (cached) {
+              logger.debug("Using cached response (304 Not Modified)", { url });
+              return cached.data;
+            }
+            // 304 with no cache entry — server insists it's unchanged but we have nothing.
+            // Re-fetch once without If-None-Match.
+            logger.debug("304 received but no cache entry; re-fetching", { url });
+            const freshHeaders = new Headers(options.headers);
+            freshHeaders.delete("If-None-Match");
+            return await this.fetchWithTimeout(
+              url,
+              { ...options, headers: freshHeaders },
+              async (freshResponse) => {
+                if (freshResponse.status === 304) {
+                  throw new Error(
+                    `Server returned 304 on unconditional re-fetch for ${url}; server is misconfigured`,
+                  );
+                }
+                if (!freshResponse.ok) {
+                  this.throwForHttpStatus(freshResponse);
+                }
+                return await this.processResponse(freshResponse, url, schema);
+              },
             );
           }
-          if (!freshResponse.ok) {
-            this.throwForHttpStatus(freshResponse);
+
+          if (!response.ok) {
+            this.throwForHttpStatus(response);
           }
-          return await this.processResponse(freshResponse, url, schema);
-        }
 
-        if (!response.ok) {
-          this.throwForHttpStatus(response);
-        }
-
-        return await this.processResponse(response, url, schema);
+          return await this.processResponse(response, url, schema);
+        });
       } catch (error) {
         // A definitively non-retryable HTTP status (404/401/403/410, …) fails
         // fast — retrying it only wastes the budget.
@@ -769,16 +820,26 @@ export class RemoteActivityPubClient {
   }
 
   /**
-   * Fetch with timeout and response size limit.
-   * Includes SSRF protection to block requests to private/internal addresses.
-   * Uses async DNS resolution to detect DNS rebinding attacks.
-   * Validates against instance blocklist.
+   * Fetch with a timeout that spans the ENTIRE exchange — connection, headers,
+   * AND the body read performed inside `consume`. Clearing the timer when only
+   * the headers have arrived (the previous behavior) let a hostile instance send
+   * headers promptly and then trickle the body forever, evading REQUEST_TIMEOUT
+   * and pinning the tool call. Keeping the AbortController armed until `consume`
+   * resolves makes readJsonWithLimit's body read subject to the same deadline.
+   *
+   * Includes SSRF protection (DNS-pinned, redirect-revalidated) and the operator
+   * blocklist via pinnedFetch.
    *
    * @param url - The URL to fetch
    * @param options - Fetch options
-   * @returns The fetch Response
+   * @param consume - Reads/validates the response within the timeout window
+   * @returns Whatever `consume` returns
    */
-  private async fetchWithTimeout(url: string, options: RequestInit): Promise<Response> {
+  private async fetchWithTimeout<T>(
+    url: string,
+    options: RequestInit,
+    consume: (response: Response) => Promise<T>,
+  ): Promise<T> {
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), this.requestTimeout);
 
@@ -791,15 +852,16 @@ export class RemoteActivityPubClient {
         { ...options, signal: controller.signal },
         INSTANCE_BLOCKING_ENABLED ? blocklistHop : undefined,
       );
-      clearTimeout(timeoutId);
-
-      return response;
+      // Read the body under the same timeout: a stalled/trickled body aborts the
+      // signal, which surfaces as an AbortError below.
+      return await consume(response);
     } catch (error) {
-      clearTimeout(timeoutId);
       if (error instanceof Error && error.name === "AbortError") {
         throw new Error(`Request timed out: ${url}`);
       }
       throw error;
+    } finally {
+      clearTimeout(timeoutId);
     }
   }
 
@@ -987,7 +1049,23 @@ export class RemoteActivityPubClient {
       try {
         const repliesUrl =
           typeof post.replies === "string" ? post.replies : (post.replies as { id?: string }).id;
+
+        // The replies-collection URL comes from the attacker-controlled root post
+        // and can point at any host. Apply the same cross-origin gate as the
+        // ancestor walk and the reply items: with THREAD_CROSS_ORIGIN_FETCH off
+        // (the default), do NOT fetch an off-origin collection — otherwise reading
+        // any thread leaks a beacon to an attacker-chosen host and provides a
+        // fetch-amplification primitive.
+        let repliesSameOrigin = false;
         if (repliesUrl) {
+          try {
+            repliesSameOrigin = new URL(repliesUrl).origin === rootOrigin;
+          } catch {
+            repliesSameOrigin = false; // unparseable — treat as off-origin
+          }
+        }
+
+        if (repliesUrl && (repliesSameOrigin || THREAD_CROSS_ORIGIN_FETCH)) {
           const repliesCollection = await this.fetchWithRetry(
             repliesUrl,
             {
@@ -1352,24 +1430,31 @@ export class RemoteActivityPubClient {
 
     // Try fetching the URL directly with ActivityPub headers
     try {
-      const response = await this.fetchWithTimeout(webUrl, {
-        headers: {
-          Accept:
-            'application/activity+json, application/ld+json; profile="https://www.w3.org/ns/activitystreams"',
-          "User-Agent": USER_AGENT,
+      const resolved = await this.fetchWithTimeout(
+        webUrl,
+        {
+          headers: {
+            Accept:
+              'application/activity+json, application/ld+json; profile="https://www.w3.org/ns/activitystreams"',
+            "User-Agent": USER_AGENT,
+          },
         },
-      });
-
-      if (response.ok) {
-        const data = await readJsonWithLimit<{ id?: string; type?: string }>(
-          response,
-          MAX_RESPONSE_SIZE,
-        );
-        if (data.id) {
-          const type = data.type?.toLowerCase().includes("person") ? "actor" : "post";
-          return { activityPubUri: data.id, type, domain };
-        }
-      }
+        async (response) => {
+          if (!response.ok) return undefined;
+          const data = await readJsonWithLimit<{ id?: string; type?: string }>(
+            response,
+            MAX_RESPONSE_SIZE,
+          );
+          if (data.id) {
+            const type: "actor" | "post" = data.type?.toLowerCase().includes("person")
+              ? "actor"
+              : "post";
+            return { activityPubUri: data.id, type, domain };
+          }
+          return undefined;
+        },
+      );
+      if (resolved) return resolved;
     } catch {
       // Fall through to unknown
     }

--- a/src/audit/logger.ts
+++ b/src/audit/logger.ts
@@ -8,7 +8,7 @@
 import { getLogger } from "@logtape/logtape";
 import { AUDIT_LOG_ENABLED, AUDIT_LOG_MAX_ENTRIES } from "../config.js";
 
-const logger = getLogger("activitypub-mcp:audit");
+const logger = getLogger(["activitypub-mcp", "audit"]);
 
 /**
  * Types of auditable events.

--- a/src/auth/account-manager.ts
+++ b/src/auth/account-manager.ts
@@ -11,7 +11,7 @@ import { resolveWriteAdapter } from "./adapters/resolve.js";
 import type { AccountInfo } from "./adapters/write-adapter.js";
 import type { CredentialStore } from "./credential-store.js";
 
-const logger = getLogger("activitypub-mcp:account-manager");
+const logger = getLogger(["activitypub-mcp", "account-manager"]);
 
 // Re-export so existing importers (auth/index.ts) keep working; the canonical
 // definition lives in the adapter layer alongside the other normalized types.

--- a/src/auth/authenticated-client.ts
+++ b/src/auth/authenticated-client.ts
@@ -42,7 +42,7 @@ export type {
   Status,
 } from "./adapters/write-adapter.js";
 
-const logger = getLogger("activitypub-mcp:authenticated-client");
+const logger = getLogger(["activitypub-mcp", "authenticated-client"]);
 
 // Poll + scheduled-status schemas stay here — they back Mastodon-only ops.
 const PollSchema = z.object({

--- a/src/auth/credential-store.ts
+++ b/src/auth/credential-store.ts
@@ -15,7 +15,7 @@ import { getLogger } from "@logtape/logtape";
 import { z } from "zod";
 import { CONFIG_DIR } from "../config.js";
 
-const logger = getLogger("activitypub-mcp:credential-store");
+const logger = getLogger(["activitypub-mcp", "credential-store"]);
 
 export const StoredAccountSchema = z.object({
   id: z.string(),

--- a/src/auth/login/browser.ts
+++ b/src/auth/login/browser.ts
@@ -1,6 +1,10 @@
 /**
  * Opens the system browser to a URL using an argv-array spawn (never a shell
- * string), so query values containing &, %, ^ cannot be interpreted by a shell.
+ * string). On win32 it uses rundll32's FileProtocolHandler rather than
+ * `cmd /c start`: cmd treats every unquoted `&` (always present in OAuth
+ * authorize URLs) as a command separator, which truncated the URL at the first
+ * `&` and broke login on every Windows machine. rundll32 receives the URL as a
+ * single argv argument with no shell parsing, so `&`/`%`/`^` survive intact.
  * On failure the caller falls back to printing the URL.
  */
 
@@ -16,9 +20,10 @@ export function openBrowser(url: string): Promise<void> {
         args = [url];
         break;
       case "win32":
-        // `start` is a cmd builtin; "" is the (empty) window title, url is a discrete arg.
-        command = "cmd";
-        args = ["/c", "start", "", url];
+        // rundll32 url.dll,FileProtocolHandler opens the default browser without
+        // a shell, so '&' in the OAuth URL is not parsed as a command separator.
+        command = "rundll32";
+        args = ["url.dll,FileProtocolHandler", url];
         break;
       default:
         command = "xdg-open";

--- a/src/config.ts
+++ b/src/config.ts
@@ -90,7 +90,7 @@ function parseBoolEnv(value: string | undefined, defaultValue: boolean): boolean
 export const SERVER_NAME = process.env.MCP_SERVER_NAME || "activitypub-mcp";
 
 /** MCP Server version */
-export const SERVER_VERSION = process.env.MCP_SERVER_VERSION || "3.1.3";
+export const SERVER_VERSION = process.env.MCP_SERVER_VERSION || "3.1.4";
 
 /**
  * Directory for the persisted credential store (accounts.json).
@@ -431,7 +431,7 @@ export function validateConfiguration(): void {
     // Lazy import to avoid pulling logtape into config-only consumers
     // (the build is ESM/tsc, so this stays tree-shakable in dist).
     void import("@logtape/logtape").then(({ getLogger }) => {
-      const logger = getLogger("activitypub-mcp:config");
+      const logger = getLogger(["activitypub-mcp", "config"]);
       for (const warning of warnings) {
         logger.warn(warning);
       }

--- a/src/discovery/dynamic-instance-discovery.ts
+++ b/src/discovery/dynamic-instance-discovery.ts
@@ -19,7 +19,7 @@ import {
 import { blocklistHop, pinnedFetch, readJsonWithLimit } from "../utils/fetch-helpers.js";
 import { LRUCache } from "../utils/lru-cache.js";
 
-const logger = getLogger("activitypub-mcp:discovery");
+const logger = getLogger(["activitypub-mcp", "discovery"]);
 
 /**
  * Instance information from dynamic discovery

--- a/src/discovery/nodeinfo.ts
+++ b/src/discovery/nodeinfo.ts
@@ -55,7 +55,7 @@ export type InstanceSoftwareInfo = {
   reason?: string;
 };
 
-const logger = getLogger("activitypub-mcp:nodeinfo");
+const logger = getLogger(["activitypub-mcp", "nodeinfo"]);
 
 // Only NodeInfo 2.0 and 2.1 are in scope. Match these rels exactly — a prefix
 // match would also accept bogus rels like ".../2.1-evil" or ".../2.x", and a

--- a/src/discovery/webfinger.ts
+++ b/src/discovery/webfinger.ts
@@ -11,7 +11,7 @@ import { blocklistHop, pinnedFetch, readJsonWithLimit } from "../utils/fetch-hel
 import { LRUCache } from "../utils/lru-cache.js";
 import { ActorIdentifierSchema } from "../validation/schemas.js";
 
-const logger = getLogger("activitypub-mcp");
+const logger = getLogger(["activitypub-mcp", "webfinger"]);
 
 // WebFinger response schema
 const WebFingerResponseSchema = z.object({

--- a/src/mcp-main.ts
+++ b/src/mcp-main.ts
@@ -6,7 +6,7 @@ import { SERVER_NAME, SERVER_VERSION, validateConfiguration } from "./config.js"
 import ActivityPubMCPServer from "./mcp-server.js";
 import "./telemetry/logging.js";
 
-const logger = getLogger("activitypub-mcp");
+const logger = getLogger(["activitypub-mcp"]);
 
 /**
  * Print version information and exit

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -27,7 +27,7 @@ import { registerPrompts, registerResources, registerTools } from "./mcp/index.j
 import { RateLimiter } from "./resilience/rate-limiter.js";
 import { HttpTransportServer } from "./transport/http.js";
 
-const logger = getLogger("activitypub-mcp");
+const logger = getLogger(["activitypub-mcp"]);
 
 /**
  * Configuration for the MCP server, loaded from environment variables.

--- a/src/mcp/resources.ts
+++ b/src/mcp/resources.ts
@@ -19,7 +19,7 @@ import { extractSingleValue, validateActorIdentifier } from "../validation/valid
 import { capabilitiesRegistry, trackedMcpServer } from "./capabilities.js";
 import { checkRateLimit } from "./rate-limit-guard.js";
 
-const logger = getLogger("activitypub-mcp:resources");
+const logger = getLogger(["activitypub-mcp", "resources"]);
 
 /**
  * Configuration for MCP resources.
@@ -672,19 +672,33 @@ function registerPostThreadResource(mcpServer: McpServer, rateLimiter: RateLimit
           );
         }
 
-        const postUrl = `https://${domain}/web/statuses/${statusId}`;
-        const parsedUrl = new URL(postUrl);
-        checkRateLimit(rateLimiter, parsedUrl.hostname);
+        // Validate both path params. The domain goes through the shared schema;
+        // the statusId must be an opaque id (Mastodon snowflake / Pleroma FlakeID)
+        // — reject anything that could inject extra path segments or a scheme.
+        const validDomain = DomainSchema.parse(domain);
+        if (!/^[A-Za-z0-9_-]{1,64}$/.test(statusId)) {
+          throw new McpError(
+            ErrorCode.InvalidParams,
+            "post-thread {statusId} must be an alphanumeric id (letters, digits, '-' or '_').",
+          );
+        }
+
+        checkRateLimit(rateLimiter, validDomain);
+
+        // Resolve the canonical ActivityPub URI via the REST API. The old
+        // /web/statuses/{id} SPA route is not an AP endpoint (it 302s to HTML),
+        // so it timed out and retried instead of returning the thread.
+        const postUrl = await remoteClient.resolveStatusUri(validDomain, statusId);
 
         logger.info("Fetching post thread", { postUrl });
 
-        const threadData = await remoteClient.fetchPostThread(parsedUrl.href, {
+        const threadData = await remoteClient.fetchPostThread(postUrl, {
           depth: 2,
           maxReplies: 50,
         });
 
         const resourceData = {
-          postUrl: parsedUrl.href,
+          postUrl,
           timestamp: new Date().toISOString(),
           post: threadData.post,
           ancestors: threadData.ancestors,
@@ -699,7 +713,7 @@ function registerPostThreadResource(mcpServer: McpServer, rateLimiter: RateLimit
               mimeType: "application/json",
               text: wrapUntrustedBlock(
                 JSON.stringify(resourceData, null, 2),
-                `post-thread/${parsedUrl.hostname}`,
+                `post-thread/${validDomain}`,
               ),
             },
           ],

--- a/src/mcp/tools-write.ts
+++ b/src/mcp/tools-write.ts
@@ -19,7 +19,7 @@ import { sanitizeInline, wrapUntrusted } from "../utils/untrusted.js";
 import { trackedMcpServer } from "./capabilities.js";
 import { checkRateLimit } from "./rate-limit-guard.js";
 
-const logger = getLogger("activitypub-mcp:tools-write");
+const logger = getLogger(["activitypub-mcp", "tools-write"]);
 
 /**
  * Registers all write operation tools.
@@ -36,6 +36,10 @@ export function registerWriteTools(mcpServer: McpServer, rateLimiter: RateLimite
   registerGetBookmarksTool(mcpServer, rateLimiter);
   registerGetFavouritesTool(mcpServer, rateLimiter);
   registerGetRelationshipTool(mcpServer, rateLimiter);
+  // Authenticated READ (readOnlyHint, gated by requireAuthEnabled): listing
+  // scheduled posts is a GET, so it ships without ENABLE_WRITES — only the
+  // scheduled-post mutators below are write-gated.
+  registerGetScheduledPostsTool(mcpServer, rateLimiter);
 
   if (!ENABLE_WRITES) {
     logger.info("Write tools disabled (set ACTIVITYPUB_ENABLE_WRITES=true to enable)");
@@ -61,7 +65,6 @@ export function registerWriteTools(mcpServer: McpServer, rateLimiter: RateLimite
   registerUnblockAccountTool(mcpServer, rateLimiter);
   registerVoteOnPollTool(mcpServer, rateLimiter);
   registerUploadMediaTool(mcpServer, rateLimiter);
-  registerGetScheduledPostsTool(mcpServer, rateLimiter);
   registerCancelScheduledPostTool(mcpServer, rateLimiter);
   registerUpdateScheduledPostTool(mcpServer, rateLimiter);
 }

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -24,7 +24,46 @@ import { trackedMcpServer } from "./capabilities.js";
 import { checkRateLimit } from "./rate-limit-guard.js";
 import { registerWriteTools } from "./tools-write.js";
 
-const logger = getLogger("activitypub-mcp:tools");
+const logger = getLogger(["activitypub-mcp", "tools"]);
+
+/**
+ * Reduce an outbox item to a display type + content string.
+ *
+ * Real Mastodon/Pleroma/Misskey outboxes return ACTIVITIES, not bare Notes:
+ *   - `Create`/`Update` wrap the object inline → content lives at object.content
+ *   - `Announce` (boost) carries the boosted object's URL (a string) or object
+ *   - some servers/fixtures put a bare Note directly in the collection
+ * Reading content straight off the activity wrapper renders every post as
+ * "(empty)". This unwraps the nested object so real content surfaces.
+ */
+export function summarizeOutboxItem(item: unknown): { type: string; content: string } {
+  const it = (item ?? {}) as Record<string, unknown>;
+  const activityType = typeof it.type === "string" ? it.type : "";
+  const obj = it.object;
+
+  // Activity wrapping an inlined object (Create/Update of a Note, etc.)
+  if (obj && typeof obj === "object") {
+    const o = obj as Record<string, unknown>;
+    const content =
+      (typeof o.content === "string" && o.content) ||
+      (typeof o.summary === "string" && o.summary) ||
+      "";
+    const objType = typeof o.type === "string" ? o.type : "";
+    return { type: objType || activityType || "Post", content };
+  }
+
+  // Announce (boost) of a remote object referenced by URL.
+  if (typeof obj === "string" && obj) {
+    return { type: activityType || "Announce", content: `🔁 ${obj}` };
+  }
+
+  // Bare object (Note) directly in the collection.
+  const content =
+    (typeof it.content === "string" && it.content) ||
+    (typeof it.summary === "string" && it.summary) ||
+    "";
+  return { type: activityType || "Post", content };
+}
 
 /**
  * Registers all MCP tools on the server.
@@ -221,16 +260,15 @@ function registerFetchTimelineTool(mcpServer: McpServer, rateLimiter: RateLimite
         const paginationSection =
           paginationInfo.length > 0 ? `**Pagination:**\n${paginationInfo.join("\n")}\n` : "";
 
-        // Format posts section
+        // Format posts section. Outbox items are activities (Create/Announce/…)
+        // so unwrap the nested object before rendering — otherwise every post
+        // shows as "(empty)".
         const postsSection = posts
           .map((post: unknown, index: number) => {
-            const p = post as { type?: string; content?: string; summary?: string; id?: string };
-            const content = wrapUntrusted(
-              p.content || p.summary || "",
-              `post by ${validIdentifier}`,
-            );
-            const postType = sanitizeInline(p.type || "") || "Post";
-            return `${index + 1}. [${postType}] ${content}`;
+            const { type, content } = summarizeOutboxItem(post);
+            const wrapped = wrapUntrusted(content, `post by ${validIdentifier}`);
+            const postType = sanitizeInline(type) || "Post";
+            return `${index + 1}. [${postType}] ${wrapped}`;
           })
           .join("\n\n");
 

--- a/src/policy/instance-blocklist.ts
+++ b/src/policy/instance-blocklist.ts
@@ -10,7 +10,7 @@ import { z } from "zod";
 import { auditLogger } from "../audit/logger.js";
 import { BLOCKED_INSTANCES } from "../config.js";
 
-const logger = getLogger("activitypub-mcp:blocklist");
+const logger = getLogger(["activitypub-mcp", "blocklist"]);
 
 /**
  * Zod schema for validating BlockedInstance entries during import.

--- a/src/resilience/rate-limiter.ts
+++ b/src/resilience/rate-limiter.ts
@@ -6,7 +6,7 @@
 import { getLogger } from "@logtape/logtape";
 import { RATE_LIMIT_CLEANUP_INTERVAL } from "../config.js";
 
-const logger = getLogger("activitypub-mcp:rate-limiter");
+const logger = getLogger(["activitypub-mcp", "rate-limiter"]);
 
 export interface RateLimitConfig {
   enabled: boolean;

--- a/src/telemetry/logging.ts
+++ b/src/telemetry/logging.ts
@@ -3,6 +3,16 @@ import { configure, getConsoleSink } from "@logtape/logtape";
 
 export type LogLevel = "debug" | "info" | "warning" | "error" | "fatal";
 
+/**
+ * Root logger category. logtape's hierarchy is ARRAY-based: only this category
+ * and its array children (e.g. ["activitypub-mcp", "http"]) inherit the sink
+ * configured below. A colon string like "activitypub-mcp:http" is a single-
+ * segment SIBLING category with NO sink — its records are silently dropped.
+ * Subsystem loggers must therefore use the array form getLogger([LOG_ROOT_CATEGORY,
+ * "<scope>"]), never getLogger("activitypub-mcp:<scope>").
+ */
+export const LOG_ROOT_CATEGORY = "activitypub-mcp";
+
 const LOG_LEVEL_ALIASES: Record<string, LogLevel> = {
   debug: "debug",
   info: "info",
@@ -44,7 +54,9 @@ await configure({
   filters: {},
   loggers: [
     {
-      category: "activitypub-mcp",
+      // The root category. Array-child loggers (["activitypub-mcp", "<scope>"])
+      // inherit this sink; "activitypub-mcp:<scope>" colon strings do NOT.
+      category: LOG_ROOT_CATEGORY,
       lowestLevel: logLevel,
       sinks: ["console"],
     },

--- a/src/transport/http.ts
+++ b/src/transport/http.ts
@@ -25,7 +25,7 @@ import {
 import { isLoopbackIPv4 } from "../validation/url.js";
 import { checkBearerAuth } from "./auth-middleware.js";
 
-const logger = getLogger("activitypub-mcp:http");
+const logger = getLogger(["activitypub-mcp", "http"]);
 
 const LOOPBACK_HOSTS = new Set(["::1", "[::1]", "localhost"]);
 

--- a/src/validation/url.ts
+++ b/src/validation/url.ts
@@ -50,9 +50,8 @@ const PRIVATE_IPV4_RANGES = [
   /^198\.1[89]\./, // Benchmarking (198.18.0.0/15, RFC 2544)
   /^198\.51\.100\./, // Documentation (TEST-NET-2)
   /^203\.0\.113\./, // Documentation (TEST-NET-3)
-  /^224\./, // Multicast (224.0.0.0/4)
-  /^240\./, // Reserved for future use (240.0.0.0/4)
-  /^255\.255\.255\.255$/, // Broadcast
+  /^2(2[4-9]|3\d)\./, // Multicast (224.0.0.0/4 — first octet 224-239)
+  /^2(4\d|5[0-5])\./, // Reserved + broadcast (240.0.0.0/4 — first octet 240-255)
 ];
 
 /**
@@ -67,9 +66,9 @@ const PRIVATE_IPV6_RANGES = [
   /^::1$/i, // Loopback
   /^::$/i, // Unspecified address
   /^::ffff:/i, // IPv4-mapped IPv6 addresses (check the mapped IPv4)
-  /^ff0[\da-f]:/i, // Multicast (ff00::/8)
+  /^ff[\da-f]{2}:/i, // Multicast (ff00::/8 — any flag/scope nibbles)
   /^2001:db8:/i, // Documentation (2001:db8::/32)
-  /^2001::/i, // Teredo tunneling (2001::/32) - could be abused
+  /^2001:(:|0{1,4}:)/i, // Teredo tunneling (2001::/32) - both "2001::" and "2001:0:" text forms
   /^64:ff9b:/i, // NAT64 (64:ff9b::/96)
   /^100::/i, // Discard prefix (100::/64)
   /^2002:/i, // 6to4 (2002::/16) - deprecated, could be abused

--- a/tests/unit/browser.test.ts
+++ b/tests/unit/browser.test.ts
@@ -52,15 +52,23 @@ describe("openBrowser", () => {
     expect(spawnMock.mock.calls[0][0]).toBe("xdg-open");
   });
 
-  it("uses cmd /c start on win32 with the URL as a discrete arg", async () => {
+  it("opens on win32 without routing the URL through cmd's parser", async () => {
     vi.stubGlobal("process", { ...process, platform: "win32" });
     const { openBrowser } = await import(
       /* @vite-ignore */ `../../src/auth/login/browser.js?ts=${Date.now()}`
     );
-    await openBrowser("https://x.test/?a=1&b=2");
+    // An OAuth authorize URL always contains '&' separators. `cmd /c start`
+    // treats every unquoted '&' as a command separator, truncating the URL at
+    // the first one and breaking login on every Windows machine.
+    const url = "https://x.test/oauth/authorize?response_type=code&client_id=abc&state=xyz";
+    await openBrowser(url);
     const [cmd, args] = spawnMock.mock.calls[0];
-    expect(cmd).toBe("cmd");
-    expect(args).toEqual(["/c", "start", "", "https://x.test/?a=1&b=2"]);
+    // Must NOT shell out to cmd, where '&' is a metacharacter.
+    expect(cmd).not.toBe("cmd");
+    expect(cmd).toBe("rundll32");
+    // The full URL (every '&' intact) must reach the opener as one discrete arg.
+    expect(args).toContain(url);
+    expect(args).toEqual(["url.dll,FileProtocolHandler", url]);
   });
 
   it("rejects when the opener cannot be spawned (so the caller can fall back)", async () => {

--- a/tests/unit/ipv6-private-ranges.test.ts
+++ b/tests/unit/ipv6-private-ranges.test.ts
@@ -47,4 +47,18 @@ describe("isPrivateIPv6 — full CIDR coverage", () => {
   it("rejects a URL whose host is in the previously-reachable ULA hole", () => {
     expect(() => validateExternalUrlSync("https://[fc12:3456::1]/internal")).toThrow();
   });
+
+  it("blocks the entire multicast ff00::/8 range, not just ff00::/12", () => {
+    for (const ip of ["ff02::1", "ff12::1", "ff15::101", "ff32::8000:1", "ffff::1"]) {
+      expect(isPrivateIPv6(ip), ip).toBe(true);
+    }
+  });
+
+  it("blocks Teredo 2001::/32 in both canonical text forms", () => {
+    for (const ip of ["2001::1", "2001:0:4136:e378:8000:63bf:3fff:fdd2"]) {
+      expect(isPrivateIPv6(ip), ip).toBe(true);
+    }
+    // 2001:4860::/32 is Google — only the zero second hextet is Teredo.
+    expect(isPrivateIPv6("2001:4860:4860::8888")).toBe(false);
+  });
 });

--- a/tests/unit/logging-categories.test.ts
+++ b/tests/unit/logging-categories.test.ts
@@ -1,0 +1,59 @@
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { getLogger } from "@logtape/logtape";
+import { afterEach, describe, expect, it, vi } from "vitest";
+// Side-effect import: runs configure() so the "activitypub-mcp" root sink exists.
+import "../../src/telemetry/logging.js";
+
+/**
+ * logtape's category hierarchy is ARRAY-based. getLogger("activitypub-mcp:http")
+ * creates the single-segment ROOT category ["activitypub-mcp:http"], a SIBLING
+ * of the configured ["activitypub-mcp"] logger — so it inherits no sink and every
+ * record is silently dropped (this blinded ~13 subsystems, incl. security/audit
+ * warnings). getLogger(["activitypub-mcp", "http"]) is the child that inherits.
+ *
+ * The configured sink routes everything to console.error (stderr), so a working
+ * logger surfaces as a console.error call and a broken one does not.
+ */
+describe("logtape subsystem categories", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("emits records from array-child categories but drops colon-string siblings", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    getLogger(["activitypub-mcp", "http"]).error("child {m}", { m: "child-emitted" });
+    getLogger("activitypub-mcp:http").error("sibling {m}", { m: "sibling-dropped" });
+
+    const emitted = spy.mock.calls.map((c) => c.join(" ")).join("\n");
+    expect(emitted).toContain("child-emitted");
+    expect(emitted).not.toContain("sibling-dropped");
+  });
+});
+
+/**
+ * Static guard: no source file may reintroduce the colon-category form, which
+ * compiles and runs but silently drops every record.
+ */
+describe("no source file uses the silently-dropped colon category", () => {
+  const SRC = fileURLToPath(new URL("../../src", import.meta.url));
+
+  function tsFiles(dir: string): string[] {
+    return readdirSync(dir).flatMap((name) => {
+      const full = join(dir, name);
+      if (statSync(full).isDirectory()) return tsFiles(full);
+      return full.endsWith(".ts") ? [full] : [];
+    });
+  }
+
+  it('never calls getLogger with an "activitypub-mcp:" colon string', () => {
+    // Require a real scope letter after the colon so logging.ts's own
+    // "activitypub-mcp:<scope>" anti-pattern doc example isn't a false positive.
+    const offenders = tsFiles(SRC).filter((file) =>
+      /getLogger\(\s*["'`]activitypub-mcp:[a-z]/.test(readFileSync(file, "utf8")),
+    );
+    expect(offenders, `colon-category getLogger calls in: ${offenders.join(", ")}`).toEqual([]);
+  });
+});

--- a/tests/unit/mcp-resources.test.ts
+++ b/tests/unit/mcp-resources.test.ts
@@ -22,6 +22,7 @@ vi.mock("../../src/activitypub/remote-client.js", () => ({
     fetchLocalTimeline: vi.fn(),
     fetchFederatedTimeline: vi.fn(),
     fetchPostThread: vi.fn(),
+    resolveStatusUri: vi.fn(),
   },
 }));
 
@@ -433,6 +434,9 @@ describe("MCP Resources", () => {
 
   describe("post-thread resource", () => {
     it("should fetch and return post thread", async () => {
+      (remoteClient.resolveStatusUri as Mock).mockResolvedValue(
+        "https://mastodon.social/users/alice/statuses/123",
+      );
       (remoteClient.fetchPostThread as Mock).mockResolvedValue({
         post: { content: "Original post", id: "1" },
         ancestors: [],
@@ -450,7 +454,10 @@ describe("MCP Resources", () => {
       expect((thread.replies as unknown[]).length).toBe(1);
     });
 
-    it("should construct the correct Mastodon URL from {domain}/{statusId}", async () => {
+    it("resolves the canonical AP uri via the REST API instead of the dead /web/ route", async () => {
+      (remoteClient.resolveStatusUri as Mock).mockResolvedValue(
+        "https://mastodon.social/users/alice/statuses/123",
+      );
       (remoteClient.fetchPostThread as Mock).mockResolvedValue({
         post: { content: "Test" },
         ancestors: [],
@@ -462,8 +469,11 @@ describe("MCP Resources", () => {
       const uri = new URL("activitypub://post-thread/mastodon.social/123");
       await resource?.handler(uri, { domain: "mastodon.social", statusId: "123" });
 
+      expect(remoteClient.resolveStatusUri).toHaveBeenCalledWith("mastodon.social", "123");
+      // The thread is fetched with the resolved canonical URI, never the old
+      // /web/statuses/ SPA route.
       expect(remoteClient.fetchPostThread).toHaveBeenCalledWith(
-        "https://mastodon.social/web/statuses/123",
+        "https://mastodon.social/users/alice/statuses/123",
         { depth: 2, maxReplies: 50 },
       );
     });
@@ -476,10 +486,23 @@ describe("MCP Resources", () => {
         "post-thread requires {domain} and {statusId}",
       );
     });
+
+    it("rejects a statusId that could inject extra path segments", async () => {
+      const resource = registeredResources.get("post-thread");
+      const uri = new URL("activitypub://post-thread/mastodon.social/x");
+
+      await expect(
+        resource?.handler(uri, { domain: "mastodon.social", statusId: "123/../../admin" }),
+      ).rejects.toThrow(/alphanumeric id/);
+      expect(remoteClient.resolveStatusUri).not.toHaveBeenCalled();
+    });
   });
 
   describe("post-thread URI template (L10)", () => {
     it("accepts the new {domain}/{statusId} form", async () => {
+      (remoteClient.resolveStatusUri as Mock).mockResolvedValue(
+        "https://mastodon.social/users/alice/statuses/123456",
+      );
       (remoteClient.fetchPostThread as Mock).mockResolvedValue({
         post: { content: "Hello from mastodon" },
         ancestors: [],
@@ -497,7 +520,7 @@ describe("MCP Resources", () => {
       expect(result).toBeDefined();
       const contents = (result as { contents: { text: string }[] }).contents;
       const thread = parseWrapped(contents[0].text) as Record<string, unknown>;
-      expect(thread.postUrl).toBe("https://mastodon.social/web/statuses/123456");
+      expect(thread.postUrl).toBe("https://mastodon.social/users/alice/statuses/123456");
     });
 
     it("rejects the legacy encoded-URL form with an InvalidParams error", async () => {

--- a/tests/unit/mcp-tools.test.ts
+++ b/tests/unit/mcp-tools.test.ts
@@ -642,5 +642,44 @@ describe("MCP Tools", () => {
       // All 1000 x's must be present inside the envelope
       expect(text).toMatch(/x{900,}/);
     });
+
+    it("unwraps Create/Announce activities so real outbox content renders", async () => {
+      // Real Mastodon/Pleroma/Misskey outboxes return ACTIVITIES, not bare Notes:
+      // a Create wraps the Note at object.content; an Announce (boost) carries the
+      // boosted object's URL. Reading content off the activity wrapper yields
+      // "(empty)" for every post — the flagship read tool's headline bug.
+      (remoteClient.fetchActorOutboxPaginated as Mock).mockResolvedValue({
+        items: [
+          {
+            type: "Create",
+            id: "https://example.social/activities/1",
+            object: {
+              type: "Note",
+              id: "https://example.social/notes/1",
+              content: "hello from the nested note",
+            },
+          },
+          {
+            type: "Announce",
+            id: "https://example.social/activities/2",
+            object: "https://other.example/notes/99",
+          },
+        ],
+        totalItems: 2,
+        collectionId: "https://example.social/users/testuser/outbox",
+        hasMore: false,
+      });
+
+      const tool = registeredTools.get("fetch-timeline");
+      const result = await tool?.handler({ identifier: "user@example.social", limit: 20 });
+      const text = ((result as { content: { text: string }[] }).content[0].text ?? "") as string;
+
+      // The Create's nested content must surface, not an empty placeholder.
+      expect(text).toContain("hello from the nested note");
+      // The Announce's boosted URL must be referenced.
+      expect(text).toContain("https://other.example/notes/99");
+      // The activity wrapper must not render as bare empty content.
+      expect(text).not.toMatch(/\[Create\]\s*<untrusted-content[^>]*>\s*<\/untrusted-content>/);
+    });
   });
 });

--- a/tests/unit/read-adapter.test.ts
+++ b/tests/unit/read-adapter.test.ts
@@ -232,6 +232,55 @@ describe("read PlatformAdapter — NodeInfo routing", () => {
     });
   });
 
+  describe("Mastodon read adapter is resilient to hostile/malformed payloads", () => {
+    beforeEach(() => server.use(...nodeinfo(MASTO, "mastodon")));
+
+    const goodPost = (id: string) => ({
+      id,
+      content: `post ${id}`,
+      account: { username: "bob", acct: "bob", url: `https://${MASTO}/@bob` },
+      created_at: "2026-01-01T00:00:00Z",
+      reblogs_count: 1,
+      favourites_count: 2,
+      replies_count: 0,
+      url: `https://${MASTO}/@bob/${id}`,
+    });
+
+    it("drops a malformed status (missing account) instead of surfacing it", async () => {
+      server.use(
+        http.get(`https://${MASTO}/api/v1/trends/statuses`, () =>
+          HttpResponse.json([
+            goodPost("1"),
+            { id: "2", content: "authorless attacker content" }, // no account
+          ]),
+        ),
+      );
+      const res = await client.fetchTrendingPosts(MASTO, { limit: 5 });
+      expect(res.posts).toHaveLength(1);
+      expect(res.posts[0].id).toBe("1");
+    });
+
+    it("caps returned posts at the requested limit even if the server returns more", async () => {
+      const many = Array.from({ length: 10 }, (_, i) => goodPost(`n${i}`));
+      server.use(
+        http.get(`https://${MASTO}/api/v1/timelines/public`, () => HttpResponse.json(many)),
+      );
+      const res = await client.fetchLocalTimeline(MASTO, { limit: 3 });
+      expect(res.posts).toHaveLength(3);
+    });
+
+    it("coerces a hostile non-numeric count to a finite number", async () => {
+      server.use(
+        http.get(`https://${MASTO}/api/v1/trends/statuses`, () =>
+          HttpResponse.json([{ ...goodPost("1"), favourites_count: "not-a-number" }]),
+        ),
+      );
+      const res = await client.fetchTrendingPosts(MASTO, { limit: 5 });
+      expect(typeof res.posts[0].favourites_count).toBe("number");
+      expect(Number.isFinite(res.posts[0].favourites_count)).toBe(true);
+    });
+  });
+
   describe("Misskey read adapter is resilient to hostile/malformed payloads", () => {
     beforeEach(() => server.use(...nodeinfo(MISSKEY, "misskey")));
 

--- a/tests/unit/readme-install-buttons.test.ts
+++ b/tests/unit/readme-install-buttons.test.ts
@@ -1,0 +1,29 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+/**
+ * GitHub's README HTML sanitizer strips anchors whose href uses a non-standard
+ * scheme like `cursor://`, leaving the "Add to Cursor" badge linking to nothing
+ * (it renders pointing at the badge image itself). The one-click button must use
+ * Cursor's https wrapper instead so it actually works on the rendered README.
+ */
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const readme = readFileSync(path.join(ROOT, "README.md"), "utf-8");
+
+describe("README one-click install buttons", () => {
+  const cursorLine = readme.split("\n").find((l) => l.includes("Add to Cursor"));
+
+  it("has an Add to Cursor button", () => {
+    expect(cursorLine).toBeDefined();
+  });
+
+  it("does not use a cursor:// href (GitHub strips it)", () => {
+    expect(cursorLine).not.toContain("](cursor://");
+  });
+
+  it("uses the https cursor.com/install-mcp wrapper with the npx config", () => {
+    expect(cursorLine).toContain("](https://cursor.com/install-mcp?name=activitypub-mcp&config=");
+  });
+});

--- a/tests/unit/release-mcpb-asset.test.ts
+++ b/tests/unit/release-mcpb-asset.test.ts
@@ -29,4 +29,20 @@ describe("release workflow ships the .mcpb bundle", () => {
       /activitypub-mcp-\$\{\{\s*steps\.get_version\.outputs\.VERSION\s*\}\}\.tgz/,
     );
   });
+
+  it("installs the mcpb builder version-pinned and with --ignore-scripts (no supply-chain RCE)", () => {
+    // The .mcpb is one-click-installed into Claude Desktop, and this job holds a
+    // contents:write token, so an unpinned mcpb (or its install scripts) is an
+    // RCE/tamper vector — exactly what publish-mcp.yml already pins against.
+    const installLine = releaseYml
+      .split("\n")
+      .find((l) => l.includes("npm install -g @anthropic-ai/mcpb"));
+    expect(installLine, "mcpb install line").toBeDefined();
+    expect(installLine).toMatch(/@anthropic-ai\/mcpb@\d+\.\d+\.\d+/); // exact version pin
+    expect(installLine).toContain("--ignore-scripts");
+  });
+
+  it("does not grant the unused packages:write permission", () => {
+    expect(releaseYml).not.toMatch(/packages:\s*write/);
+  });
 });

--- a/tests/unit/remote-client-body-timeout.test.ts
+++ b/tests/unit/remote-client-body-timeout.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * A hostile instance can send response HEADERS promptly, then trickle (or never
+ * finish) the BODY. The request timeout must cover the body read, not just the
+ * headers — otherwise readJsonWithLimit hangs forever with the AbortController
+ * already disarmed, pinning the tool call (and its in-flight-dedup entry).
+ *
+ * We stub pinnedFetch to return a 200 whose body is a stream that yields nothing
+ * until the request's AbortSignal fires (mirroring how undici aborts an in-flight
+ * body read). With the timeout spanning the body read, the client must reject
+ * with a timeout well within the test budget; if it only covers headers, the
+ * read hangs and this test times out.
+ */
+
+// Small timeout + single attempt so the test resolves fast and doesn't retry.
+vi.mock("../../src/config.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../src/config.js")>()),
+  REQUEST_TIMEOUT: 120,
+  MAX_RETRIES: 1,
+}));
+
+vi.mock("../../src/utils/fetch-helpers.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../src/utils/fetch-helpers.js")>()),
+  pinnedFetch: vi.fn(),
+}));
+
+import { RemoteActivityPubClient } from "../../src/activitypub/remote-client.js";
+import { pinnedFetch } from "../../src/utils/fetch-helpers.js";
+
+function stalledBodyResponse(signal: AbortSignal | null | undefined): Response {
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      const abort = () =>
+        controller.error(
+          Object.assign(new Error("The operation was aborted"), { name: "AbortError" }),
+        );
+      if (signal?.aborted) return abort();
+      signal?.addEventListener("abort", abort, { once: true });
+      // Never enqueue: headers are "sent", the body stalls indefinitely.
+    },
+  });
+  return new Response(body, {
+    status: 200,
+    headers: { "content-type": "application/activity+json" },
+  });
+}
+
+describe("remote read timeout covers the response body, not just headers", () => {
+  beforeEach(() => {
+    vi.mocked(pinnedFetch).mockReset();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("aborts a stalled body read within the request timeout", async () => {
+    vi.mocked(pinnedFetch).mockImplementation(async (_url: string, options: RequestInit) =>
+      stalledBodyResponse(options.signal as AbortSignal | null | undefined),
+    );
+
+    const client = new RemoteActivityPubClient();
+    const started = Date.now();
+
+    await expect(client.fetchObject("https://example.social/objects/1")).rejects.toThrow(
+      /timed out/i,
+    );
+
+    // Must reject around the 120ms timeout, not hang to the test deadline.
+    expect(Date.now() - started).toBeLessThan(2000);
+  }, 5000);
+});

--- a/tests/unit/remote-client-thread.test.ts
+++ b/tests/unit/remote-client-thread.test.ts
@@ -136,6 +136,41 @@ describe("fetchPostThread cross-origin guard (M3)", () => {
     expect(thread.ancestors.some((a) => a.id === "https://b.test/post/parent")).toBe(false);
   });
 
+  it("does not fetch a cross-origin replies-collection URL when the gate is off", async () => {
+    process.env.MCP_THREAD_CROSS_ORIGIN_FETCH = "false";
+    server.use(
+      // The root post's `replies` is attacker-controlled and can point at any
+      // host. With the gate off, the replies-collection itself must not be
+      // fetched cross-origin — otherwise reading any thread leaks a beacon to an
+      // attacker-chosen host and yields a fetch-amplification primitive.
+      http.get("https://a.test/post/1", () =>
+        HttpResponse.json({
+          id: "https://a.test/post/1",
+          type: "Note",
+          replies: "https://evil.test/collection",
+        }),
+      ),
+    );
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+    const { RemoteActivityPubClient } = await import("../../src/activitypub/remote-client.js");
+    const client = new RemoteActivityPubClient();
+    const thread = await client.fetchPostThread("https://a.test/post/1", {
+      depth: 2,
+      maxReplies: 10,
+    });
+
+    const evilCalls = fetchSpy.mock.calls.filter((args) => {
+      try {
+        return new URL(String(args[0])).hostname === "evil.test";
+      } catch {
+        return false;
+      }
+    });
+    expect(evilCalls).toHaveLength(0);
+    expect(thread.replies).toHaveLength(0);
+  });
+
   it("caps total replies to THREAD_MAX_REPLIES", async () => {
     process.env.MCP_THREAD_MAX_REPLIES = "3";
     const ids = Array.from({ length: 10 }, (_, i) => `https://a.test/post/r${i}`);

--- a/tests/unit/remote-client.test.ts
+++ b/tests/unit/remote-client.test.ts
@@ -134,6 +134,32 @@ describe("RemoteActivityPubClient", () => {
     });
   });
 
+  describe("resolveStatusUri", () => {
+    it("resolves a {domain, statusId} to the canonical AP uri via the REST API", async () => {
+      server.use(
+        http.get("https://masto.example/api/v1/statuses/123", () =>
+          HttpResponse.json({
+            id: "123",
+            uri: "https://masto.example/users/alice/statuses/123",
+            url: "https://masto.example/@alice/123",
+          }),
+        ),
+      );
+      const uri = await client.resolveStatusUri("masto.example", "123");
+      expect(uri).toBe("https://masto.example/users/alice/statuses/123");
+    });
+
+    it("falls back to `url` when `uri` is absent", async () => {
+      server.use(
+        http.get("https://masto.example/api/v1/statuses/9", () =>
+          HttpResponse.json({ id: "9", url: "https://masto.example/@bob/9" }),
+        ),
+      );
+      const uri = await client.resolveStatusUri("masto.example", "9");
+      expect(uri).toBe("https://masto.example/@bob/9");
+    });
+  });
+
   describe("fetchActorOutboxPaginated", () => {
     it("should fetch paginated outbox with default options", async () => {
       const result = await client.fetchActorOutboxPaginated("testuser@example.social");

--- a/tests/unit/utils.test.ts
+++ b/tests/unit/utils.test.ts
@@ -98,6 +98,25 @@ describe("isPrivateIPv4", () => {
   it("should detect the 192.88.99.0/24 6to4-relay anycast range", () => {
     expect(isPrivateIPv4("192.88.99.1")).toBe(true);
   });
+
+  it("blocks the entire multicast 224.0.0.0/4 range, not just 224/8", () => {
+    for (const ip of ["224.0.0.1", "225.1.1.1", "233.252.0.1", "239.255.255.250"]) {
+      expect(isPrivateIPv4(ip), ip).toBe(true);
+    }
+    expect(isPrivateIPv4("223.255.255.255")).toBe(false);
+  });
+
+  it("blocks the entire reserved 240.0.0.0/4 range, not just 240/8", () => {
+    for (const ip of [
+      "240.0.0.1",
+      "241.1.1.1",
+      "250.0.0.1",
+      "254.254.254.254",
+      "255.255.255.254",
+    ]) {
+      expect(isPrivateIPv4(ip), ip).toBe(true);
+    }
+  });
 });
 
 describe("isPrivateIPv6", () => {

--- a/tests/unit/write-gating.test.ts
+++ b/tests/unit/write-gating.test.ts
@@ -56,6 +56,17 @@ describe("write gating", () => {
     expect(names.has("discover-actor")).toBe(true);
   });
 
+  it("registers get-scheduled-posts as an authenticated read, even with writes disabled", async () => {
+    // It only GETs scheduled posts (readOnlyHint: true, gated by requireAuthEnabled,
+    // not requireWriteEnabled), so it must be available without ENABLE_WRITES —
+    // matching the docs and its own read-only posture.
+    const names = await registeredToolNames(false);
+    expect(names.has("get-scheduled-posts")).toBe(true);
+    // The actual scheduled-post MUTATORS stay write-gated.
+    expect(names.has("cancel-scheduled-post")).toBe(false);
+    expect(names.has("update-scheduled-post")).toBe(false);
+  });
+
   it("includes mutation tools when writes are enabled", async () => {
     const names = await registeredToolNames(true);
     expect(names.has("post-status")).toBe(true);


### PR DESCRIPTION
Second end-to-end review batch (against clean v3.1.3 main). 14 fixes — 3 of them genuine **highs** verified against real servers — plus their regression tests. The full suite is green (915 unit tests, +15 new), typecheck/lint/format clean, build passes, coverage thresholds met.

Every fix was written test-first: a failing test reproducing the defect, then the change.

## High severity

- **`fetch-timeline` shows real content again.** Outbox items are `Create`/`Announce` activities, so reading `content` off the wrapper rendered every post as `[Create] (empty)` against real Mastodon/Pleroma/Misskey servers. The formatter now unwraps the nested object (and renders boosts by URL). — `src/mcp/tools.ts`
- **Subsystem logs are no longer silently dropped.** logtape categories are array-based, so `getLogger("activitypub-mcp:http")` was a sink-less sibling of the configured logger — ~13 subsystems (including the operator security and audit warnings) emitted nothing. All call sites now use the array-child form, with a static regression guard against the colon form returning. — `src/telemetry/logging.ts` + 16 call sites
- **Release supply chain tightened.** The `.mcpb` builder (`@anthropic-ai/mcpb`) is now version-pinned and installed with `--ignore-scripts`; release/auto-release jobs drop workflow-level write permissions to least privilege and check out with `persist-credentials: false`, so the full dependency tree and tests never run with a push-capable token. — `.github/workflows/{release,auto-release}.yml`

## Medium severity

- **Read timeouts cover the response body, not just headers** — a hostile instance could trickle the body forever to pin a tool call. — `src/activitypub/remote-client.ts`
- **Thread reads don't beacon cross-origin** — the privacy gate now also covers the root post's `replies`-collection URL. — `src/activitypub/remote-client.ts`
- **Mastodon read adapter hardened to parity with Misskey** — structural validation, count coercion, and `limit` caps on timeline/trending/search. — `src/activitypub/read-adapter.ts`
- **`post-thread` resource resolves the canonical AP `uri`** via REST instead of the dead `/web/statuses/` SPA route, and validates `{statusId}` against path injection. — `src/mcp/resources.ts`, `src/activitypub/remote-client.ts`
- **Windows `login` opens the browser correctly** — `cmd /c start` split the OAuth URL at its `&` separators; now uses rundll32's FileProtocolHandler. — `src/auth/login/browser.ts`
- **`install.ps1` no longer wipes other MCP servers on PowerShell 5.1** — the `ConvertFrom-Json -AsHashtable` path is PS6+ only; install/uninstall now delegate to the shared Node merge helper (preserves existing servers, refuses to clobber unparseable configs). — `scripts/install.ps1`
- **`get-scheduled-posts` ships without `ACTIVITYPUB_ENABLE_WRITES`** — it's an authenticated read but was registered inside the write block. — `src/mcp/tools-write.ts`

## Low severity / distribution

- **SSRF private-range coverage corrected** — IPv4 `224.0.0.0/4` & `240.0.0.0/4` and IPv6 `ff00::/8` & Teredo `2001::/32` now match their full CIDRs. — `src/validation/url.ts`
- **CI enforces the per-directory coverage thresholds** via a dedicated coverage job (the matrix ran tests without coverage). — `.github/workflows/ci.yml`
- **README "Add to Cursor" button** uses Cursor's `https://cursor.com/install-mcp` wrapper; GitHub strips the raw `cursor://` href, leaving a dead button. — `README.md`

## Notes

- Ships as **v3.1.4** (version stamps + CHANGELOG + site changelog + llms.txt updated). Per the established flow, merging auto-publishes to npm + the MCP registry.
- I deliberately did **not** change the documented "return the `first` cursor, caller descends" outbox pagination (it has an intentional test); only the content-rendering defect was fixed.
