### PR TITLE
v3.1.5: dependency + toolchain maintenance release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.1.5] - 2026-06-15
+
+Maintenance release: dependency, toolchain, and CI/security hardening. No runtime
+behavior changes — the published server is functionally identical to 3.1.4.
+
+### Changed
+
+- Migrated the build to **TypeScript 6** and refreshed the dev/test/build dependency
+  groups (vitest, msw, biome, astro, and others via Dependabot).
+- Cleaned up `tsconfig.json` for TypeScript 6: explicit `rootDir`, dropped the
+  deprecated `baseUrl` and an unused path alias.
+
+### Security
+
+- Deduplicated **esbuild** to the patched `0.28.1`, clearing two dev-toolchain
+  advisories (GHSA-gv7w-rqvm-qjhr, GHSA-g7r4-m6w7-qqqr). esbuild is build-time only and
+  never shipped, but the dependency tree is now clean.
+- Scoped the blocking CI `npm audit` gate to **production** dependencies (what ships in
+  `dist/`), so dev-only docs-site advisories no longer block releases. The strict
+  production audit remains required and is clean.
+
 ## [3.1.4] - 2026-06-10
 
 Security, correctness, and distribution patch from a second end-to-end review.

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.2",
   "name": "activitypub-mcp",
   "display_name": "ActivityPub MCP",
-  "version": "3.1.4",
+  "version": "3.1.5",
   "description": "Read-only-by-default MCP server: let LLMs explore the Fediverse — Mastodon, Misskey, Pleroma.",
   "long_description": "Lets an LLM explore and interact with the existing Fediverse — Mastodon, Misskey, Foundkey, Pleroma, and compatible servers. Read-only by default; write tools are opt-in. Untrusted fediverse content is wrapped in an <untrusted-content> envelope before it reaches the model.",
   "author": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "activitypub-mcp",
-  "version": "3.1.4",
+  "version": "3.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "activitypub-mcp",
-      "version": "3.1.4",
+      "version": "3.1.5",
       "license": "MIT",
       "dependencies": {
         "@logtape/logtape": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activitypub-mcp",
-  "version": "3.1.4",
+  "version": "3.1.5",
   "description": "Model Context Protocol (MCP) server for the Fediverse — let Claude and other LLMs explore and post to Mastodon, Misskey, and Pleroma. Read-only by default.",
   "mcpName": "io.github.cameronrye/activitypub-mcp",
   "main": "dist/mcp-main.js",

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -116,7 +116,7 @@ Upgrading from v1.x? See [MIGRATION-v2.md](https://github.com/cameronrye/activit
 
 ---
 
-**Version:** 3.1.4
+**Version:** 3.1.5
 **License:** MIT
 **Maintainer:** Cameron Rye (https://rye.dev/)
 **Repository:** https://github.com/cameronrye/activitypub-mcp

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.cameronrye/activitypub-mcp",
   "description": "Read-only-by-default MCP server: let LLMs explore the Fediverse — Mastodon, Misskey, Pleroma.",
-  "version": "3.1.4",
+  "version": "3.1.5",
   "repository": {
     "url": "https://github.com/cameronrye/activitypub-mcp",
     "source": "github"
@@ -12,7 +12,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "activitypub-mcp",
-      "version": "3.1.4",
+      "version": "3.1.5",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/site/src/content/docs/reference/changelog.mdx
+++ b/site/src/content/docs/reference/changelog.mdx
@@ -9,6 +9,20 @@ order: 2
 
 All notable changes to the ActivityPub MCP Server are documented here. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### v3.1.5 - 2026-06-15
+
+**Maintenance release** — dependency, toolchain, and CI/security hardening with no runtime behavior changes; the published server is functionally identical to v3.1.4. See [CHANGELOG.md](https://github.com/cameronrye/activitypub-mcp/blob/main/CHANGELOG.md) for the complete entry.
+
+#### Changed
+
+- Migrated the build to **TypeScript 6** and refreshed the dev/test/build dependency groups (vitest, msw, biome, astro, and others via Dependabot).
+- Cleaned up `tsconfig.json` for TypeScript 6: explicit `rootDir`, dropped the deprecated `baseUrl` and an unused path alias.
+
+#### Security
+
+- Deduplicated **esbuild** to the patched `0.28.1`, clearing two dev-toolchain advisories (GHSA-gv7w-rqvm-qjhr, GHSA-g7r4-m6w7-qqqr). esbuild is build-time only and never shipped.
+- Scoped the blocking CI `npm audit` gate to **production** dependencies (what ships in `dist/`), so dev-only docs-site advisories no longer block releases; the strict production audit remains required and clean.
+
 ### v3.1.4 - 2026-06-10
 
 **Security, correctness, and distribution patch** from a second end-to-end review. Restores real `fetch-timeline` content, un-breaks subsystem logging and Windows login, hardens read timeouts, the thread privacy gate, the Mastodon read path, SSRF range coverage, the Windows installer, and the release supply chain. See [CHANGELOG.md](https://github.com/cameronrye/activitypub-mcp/blob/main/CHANGELOG.md) for the complete entry.

--- a/src/config.ts
+++ b/src/config.ts
@@ -90,7 +90,7 @@ function parseBoolEnv(value: string | undefined, defaultValue: boolean): boolean
 export const SERVER_NAME = process.env.MCP_SERVER_NAME || "activitypub-mcp";
 
 /** MCP Server version */
-export const SERVER_VERSION = process.env.MCP_SERVER_VERSION || "3.1.4";
+export const SERVER_VERSION = process.env.MCP_SERVER_VERSION || "3.1.5";
 
 /**
  * Directory for the persisted credential store (accounts.json).


### PR DESCRIPTION
## Release v3.1.5 — maintenance

Bumps the version to **3.1.5** and captures the post-3.1.4 housekeeping. **No runtime behavior changes** — the published server is functionally identical to 3.1.4 (no `src/` runtime changes since the last release).

### Included since v3.1.4
- **TypeScript 6** migration + refreshed dev/test/build dependency groups (the 9 merged Dependabot PRs #174–182)
- **esbuild** deduped to patched `0.28.1` (#184) — cleared GHSA-gv7w-rqvm-qjhr + GHSA-g7r4-m6w7-qqqr
- CI `npm audit` gate scoped to **production** deps; `tsconfig.json` made TS6-clean (#183)

### Version stamps (all bumped to 3.1.5)
`package.json` · `package-lock.json` (×2) · `server.json` (×2) · `manifest.json` · `src/config.ts` · `public/llms.txt` · `site/.../changelog.mdx` · `CHANGELOG.md` — `validate:version` ✓ and the llms/changelog drift tests ✓.

### Verification (local)
`validate:version` ✓ · build ✓ · typecheck ✓ · lint ✓ · format:check ✓ · **915/915 tests** ✓ · `check-tarball-contents` ✓ · `smoke-test-bin` ✓

> On merge, `auto-release.yml` tags **v3.1.5** and publishes to **npm** (with provenance) + the **MCP registry**, and creates the GitHub release with the `.tgz` + `.mcpb` assets.
