### PR TITLE
feat: document + test raw-ActivityPub read coverage; add Smithery config

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,14 @@ Alternatively, set `ACTIVITYPUB_DEFAULT_INSTANCE` and `ACTIVITYPUB_DEFAULT_TOKEN
 
 ---
 
+## Platform support
+
+`discover-actor` and `fetch-timeline` speak plain ActivityPub (WebFinger → actor → outbox), so they read **any** conformant ActivityPub server — Mastodon, Misskey, Foundkey, Pleroma/Akkoma, **Lemmy** (communities and users), **PeerTube** (channels and accounts), **GoToSocial**, and **Pixelfed**.
+
+The instance-API read tools (`search`, `get-trending-hashtags`, `get-trending-posts`, `get-public-timeline`) and every write tool require a **Mastodon- or Misskey-API** instance, since they call those platforms' REST APIs. Login uses OAuth (Mastodon-family) or MiAuth (Misskey).
+
+---
+
 ## Example
 
 After adding the server to your MCP client, try:

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,36 @@
+# Smithery configuration (https://smithery.ai/docs).
+# Runs the npm-published stdio server via npx. Read-only by default — the same
+# posture as the MCP registry entry (server.json) and the Claude Desktop bundle
+# (manifest.json). Writes additionally require a logged-in account, which is not
+# available in Smithery's ephemeral runtime, so the practical Smithery profile is
+# read-only Fediverse exploration.
+startCommand:
+  type: stdio
+  configSchema:
+    type: object
+    required: []
+    properties:
+      enableWrites:
+        type: boolean
+        default: false
+        description: >-
+          Register write/mutation tools (post, reply, follow, boost, block). Off
+          by default — read-only unless enabled. Writes also require a logged-in
+          account (npx activitypub-mcp login). See SECURITY.md.
+      logLevel:
+        type: string
+        enum: [debug, info, warn, error]
+        default: info
+        description: Logging verbosity (logs are written to stderr).
+  commandFunction: |-
+    (config) => ({
+      command: 'npx',
+      args: ['-y', 'activitypub-mcp'],
+      env: {
+        ...(config.enableWrites ? { ACTIVITYPUB_ENABLE_WRITES: 'true' } : {}),
+        ...(config.logLevel ? { LOG_LEVEL: config.logLevel } : {})
+      }
+    })
+exampleConfig:
+  enableWrites: false
+  logLevel: info

--- a/tests/unit/platform-read-coverage.test.ts
+++ b/tests/unit/platform-read-coverage.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Raw-ActivityPub read coverage across non-Mastodon/Misskey platforms.
+ *
+ * `discover-actor` (WebFinger -> actor) and `fetch-timeline` (actor -> outbox)
+ * use plain ActivityPub, not the Mastodon/Misskey instance APIs, so they read
+ * ANY conformant ActivityPub server. These tests pin that contract for Lemmy
+ * (Group/community actors with Page posts), PeerTube (Person actors with Video
+ * posts), and GoToSocial (Mastodon-compatible Person actors with Note posts).
+ *
+ * Each test drives the REAL RemoteActivityPubClient (WebFinger lookup + actor
+ * fetch + outbox fetch + schema validation) and the REAL summarizeOutboxItem
+ * renderer — so a regression that hardcoded the read path to Mastodon shapes
+ * would fail here. The instance-API tools (search, trending, get-public-timeline)
+ * remain Mastodon/Misskey-only by design and are not covered by this file.
+ */
+
+import { HttpResponse, http } from "msw";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { RemoteActivityPubClient } from "../../src/activitypub/remote-client.js";
+import { summarizeOutboxItem } from "../../src/mcp/tools.js";
+import { server } from "../mocks/server.js";
+
+// resolveAndPin resolves fixture hosts via node:dns before the (MSW-mocked)
+// fetch and fails closed when a host doesn't resolve; pin every fixture host to a
+// public IP so the pinned fetch is then intercepted by MSW. Same pattern as
+// remote-client.test.ts / read-adapter.test.ts.
+vi.mock("node:dns/promises", () => ({
+  lookup: async () => [{ address: "93.184.216.34", family: 4 }],
+}));
+
+/**
+ * Register a WebFinger -> actor -> outbox fixture chain for one platform.
+ * `actorType` exercises the schema's `type: z.string()` (Person/Group/...).
+ */
+function platformFixture(opts: {
+  domain: string;
+  username: string;
+  actorPath: string;
+  actorType: string;
+  outboxItems: unknown[];
+}) {
+  const { domain, username, actorPath, actorType, outboxItems } = opts;
+  const actorUrl = `https://${domain}${actorPath}`;
+  const outboxUrl = `${actorUrl}/outbox`;
+  return [
+    http.get(`https://${domain}/.well-known/webfinger`, () =>
+      HttpResponse.json({
+        subject: `acct:${username}@${domain}`,
+        links: [{ rel: "self", type: "application/activity+json", href: actorUrl }],
+      }),
+    ),
+    http.get(actorUrl, () =>
+      HttpResponse.json({
+        id: actorUrl,
+        type: actorType,
+        preferredUsername: username,
+        inbox: `${actorUrl}/inbox`,
+        outbox: outboxUrl,
+      }),
+    ),
+    http.get(outboxUrl, () =>
+      HttpResponse.json({
+        id: outboxUrl,
+        type: "OrderedCollection",
+        totalItems: outboxItems.length,
+        orderedItems: outboxItems,
+      }),
+    ),
+  ];
+}
+
+describe("raw-ActivityPub read coverage (non-Mastodon/Misskey platforms)", () => {
+  let client: RemoteActivityPubClient;
+
+  beforeEach(() => {
+    client = new RemoteActivityPubClient();
+  });
+
+  it("reads a Lemmy community: Group actor + Create(Page) outbox", async () => {
+    server.use(
+      ...platformFixture({
+        domain: "lemmy.example",
+        username: "technology",
+        actorPath: "/c/technology",
+        actorType: "Group",
+        outboxItems: [
+          {
+            type: "Create",
+            object: { type: "Page", name: "Headline", content: "a lemmy post body" },
+          },
+        ],
+      }),
+    );
+
+    const actor = await client.fetchRemoteActor("technology@lemmy.example");
+    expect(actor.type).toBe("Group");
+    expect(actor.preferredUsername).toBe("technology");
+
+    const timeline = await client.fetchActorOutboxPaginated("technology@lemmy.example");
+    expect(timeline.items).toHaveLength(1);
+    expect(summarizeOutboxItem(timeline.items[0]).content).toContain("a lemmy post body");
+  });
+
+  it("reads a PeerTube account: Person actor + Create(Video) outbox", async () => {
+    server.use(
+      ...platformFixture({
+        domain: "peertube.example",
+        username: "creator",
+        actorPath: "/accounts/creator",
+        actorType: "Person",
+        outboxItems: [
+          {
+            type: "Create",
+            object: { type: "Video", name: "My Video", content: "<p>video description</p>" },
+          },
+        ],
+      }),
+    );
+
+    const actor = await client.fetchRemoteActor("creator@peertube.example");
+    expect(actor.type).toBe("Person");
+
+    const timeline = await client.fetchActorOutboxPaginated("creator@peertube.example");
+    expect(timeline.items).toHaveLength(1);
+    const summary = summarizeOutboxItem(timeline.items[0]);
+    expect(summary.type).toBe("Video");
+    expect(summary.content).toContain("video description");
+  });
+
+  it("reads a GoToSocial account: Person actor + Create(Note) outbox", async () => {
+    server.use(
+      ...platformFixture({
+        domain: "gts.example",
+        username: "alice",
+        actorPath: "/users/alice",
+        actorType: "Person",
+        outboxItems: [
+          {
+            type: "Create",
+            object: { type: "Note", content: "hello from gotosocial" },
+          },
+        ],
+      }),
+    );
+
+    const actor = await client.fetchRemoteActor("alice@gts.example");
+    expect(actor.type).toBe("Person");
+    expect(actor.preferredUsername).toBe("alice");
+
+    const timeline = await client.fetchActorOutboxPaginated("alice@gts.example");
+    expect(timeline.items).toHaveLength(1);
+    expect(summarizeOutboxItem(timeline.items[0]).content).toContain("hello from gotosocial");
+  });
+});


### PR DESCRIPTION
Two agent-doable follow-ups from the 2026-06-15 review, both additive and independent of #186 (no file overlap, no version bump, no release trigger).

## 1. Documented + tested raw-ActivityPub read coverage
`discover-actor` (WebFinger → actor) and `fetch-timeline` (actor → outbox) use plain ActivityPub, not the Mastodon/Misskey instance APIs — so they already read **any** conformant ActivityPub server. This was an undersold differentiator; this PR proves and documents it.

- **New characterization tests** (`tests/unit/platform-read-coverage.test.ts`) drive the **real** `RemoteActivityPubClient` (WebFinger lookup + actor fetch + outbox fetch + schema validation) and the **real** `summarizeOutboxItem` renderer for:
  - **Lemmy** — `Group` community actor + `Create(Page)` outbox
  - **PeerTube** — `Person` account actor + `Create(Video)` outbox
  - **GoToSocial** — `Person` actor + `Create(Note)` outbox

  These assert the actor type and that post content surfaces, so a regression that hardcoded the read path to Mastodon shapes would fail here. (They also cover the `Page`/`Video`/`Note` object-type branches of `summarizeOutboxItem`.)
- **README "Platform support"** section states the read-vs-write matrix: raw-AP read tools work on Mastodon, Misskey, Foundkey, Pleroma/Akkoma, Lemmy, PeerTube, GoToSocial, and Pixelfed; the instance-API read tools (`search`, `get-trending-*`, `get-public-timeline`) and all write tools require a Mastodon- or Misskey-API instance.

## 2. Smithery registry config
`smithery.yaml` (stdio `startCommand` via `npx -y activitypub-mcp`) so the project can be listed on the [Smithery](https://smithery.ai) registry, where it is currently absent. Config schema mirrors `server.json`'s curated env vars (`ACTIVITYPUB_ENABLE_WRITES`, `LOG_LEVEL`); read-only by default. The YAML + embedded `commandFunction` were validated to parse and emit the correct env mapping.

> Note: actually **claiming** the Smithery listing still requires a maintainer GitHub-connect login on smithery.ai — this PR only adds the config file the platform reads.

## Verification
918 unit tests pass (+3 new), typecheck clean, biome + lint + format all pass.
