### PR TITLE
docs: add copy-pasteable recipes library (examples/)

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ After adding the server to your MCP client, try:
 
 The model will call `discover-actor` to fetch the profile, then `fetch-timeline` to read recent posts.
 
+See **[examples/](examples/)** for copy-pasteable recipes — Fediverse research digests, scheduled threads, notification triage, image posts with alt text, and topic curation.
+
 ---
 
 ## HTTP transport

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,34 @@
+# Recipes
+
+Copy-pasteable workflows for driving the Fediverse through an LLM with
+`activitypub-mcp`. Each recipe is written at the altitude you actually work at —
+a natural-language prompt you give the assistant — and lists the tools it
+triggers, what it needs, and what you get back.
+
+## Read-only (no account, works out of the box)
+
+| Recipe | What it does | Key tools |
+|--------|--------------|-----------|
+| [Research a topic across the Fediverse](recipes/research-a-topic.md) | Find instances, surface trending/searched posts, and digest them | `discover-instances`, `search`, `get-trending-posts`, `fetch-timeline` |
+| [Profile a single account](recipes/account-digest.md) | Summarize who someone is and what they post about | `discover-actor`, `fetch-timeline`, `get-post-thread` |
+
+These work on **any** ActivityPub server for `discover-actor` / `fetch-timeline`
+(Mastodon, Misskey, Pleroma, Lemmy, PeerTube, GoToSocial, Pixelfed). The
+instance-API tools (`search`, `get-trending-*`, `get-public-timeline`) require a
+Mastodon- or Misskey-API instance.
+
+## Write (requires `ACTIVITYPUB_ENABLE_WRITES=true` + a logged-in account)
+
+| Recipe | What it does | Key tools |
+|--------|--------------|-----------|
+| [Draft and schedule a thread](recipes/draft-and-schedule-a-thread.md) | Compose a multi-post thread and schedule it for later | `post-status`, `reply-to-post`, `get-scheduled-posts` |
+| [Triage notifications and reply](recipes/triage-notifications.md) | Read mentions in context and draft replies | `get-notifications`, `get-post-thread`, `reply-to-post` |
+| [Post an image with alt text](recipes/post-image-with-alt-text.md) | Upload media with accessibility text and attach it to a post | `upload-media`, `post-status` |
+| [Curate the best posts on a topic](recipes/curate-a-topic.md) | Find, then favourite / boost / bookmark good posts | `search`, `favourite-post`, `boost-post`, `bookmark-post` |
+
+> **Before enabling writes,** read the [threat model](../SECURITY.md). Write
+> tools mutate your real account. Log in with `npx activitypub-mcp login <instance>`.
+
+See the [full tool reference](https://cameronrye.github.io/activitypub-mcp/docs/api/tools/)
+for every parameter, and the [docs examples](https://cameronrye.github.io/activitypub-mcp/docs/guides/examples/)
+for expected-output walkthroughs.

--- a/examples/recipes/account-digest.md
+++ b/examples/recipes/account-digest.md
@@ -1,0 +1,28 @@
+# Profile a single account
+
+**Goal:** Understand who an account is and what they post about, without scrolling
+their profile yourself.
+
+**Requires:** nothing — read-only, no account.
+
+## Prompt
+
+> "Give me a profile of **@gargron@mastodon.social** — who they are, what they
+> mostly post about, and the gist of any thread they've started recently."
+
+## What happens under the hood
+
+1. `discover-actor @gargron@mastodon.social` — resolves the handle via WebFinger
+   and returns the actor (bio, name, type).
+2. `fetch-timeline @gargron@mastodon.social` — reads recent posts from the actor's
+   outbox.
+3. `get-post-thread <postUrl>` — for any post that's part of a conversation, pulls
+   the surrounding thread for context.
+4. The model summarizes themes and notable threads.
+
+## Notes
+
+- Works on **any** ActivityPub server, not just Mastodon — try a Lemmy community
+  (`@technology@lemmy.world`), a PeerTube channel, or a GoToSocial account.
+- Content warnings are surfaced with a `⚠️ CW:` marker, so sensitive posts are
+  flagged before their body is shown.

--- a/examples/recipes/curate-a-topic.md
+++ b/examples/recipes/curate-a-topic.md
@@ -1,0 +1,31 @@
+# Curate the best posts on a topic
+
+**Goal:** Find strong posts on a topic and act on them — favourite, boost to your
+followers, and bookmark for later.
+
+**Requires:** `ACTIVITYPUB_ENABLE_WRITES=true` + a logged-in account.
+
+## Prompt
+
+> "Find the most interesting recent posts about **the Fediverse** on
+> mastodon.social. Show me the top 5; for the ones I approve, favourite them,
+> boost them to my followers, and bookmark them so I can write about them later."
+
+## What happens under the hood
+
+1. `search mastodon.social "fediverse" --type statuses` (or
+   `get-trending-posts mastodon.social`) — gather candidate posts.
+2. The model presents the top picks for your approval.
+3. Per approved post:
+   - `favourite-post <postId>` — like it.
+   - `boost-post <postId>` — share to your followers.
+   - `bookmark-post <postId>` — save it for later.
+4. Review later with `get-bookmarks` / `get-favourites`. Undo with
+   `unfavourite-post`, `unboost-post`, `unbookmark-post`.
+
+## Notes
+
+- Each action is a separate write call — keep a human in the loop so boosts to
+  your followers are intentional.
+- Boosting amplifies content to everyone who follows you; prefer favourite +
+  bookmark when you only want a private signal.

--- a/examples/recipes/draft-and-schedule-a-thread.md
+++ b/examples/recipes/draft-and-schedule-a-thread.md
@@ -1,0 +1,33 @@
+# Draft and schedule a thread
+
+**Goal:** Turn an idea into a polished multi-post thread and schedule it to go out
+later.
+
+**Requires:** `ACTIVITYPUB_ENABLE_WRITES=true` + a logged-in account
+(`npx activitypub-mcp login <instance>`).
+
+## Prompt
+
+> "Draft a 3-post thread introducing my new open-source project **Foo** (a
+> local-first note app). Keep each post under 500 characters, friendly tone, and
+> schedule the first one for tomorrow at 9am my time. Show me the drafts before
+> posting."
+
+## What happens under the hood
+
+1. The model drafts the thread and shows it to you for approval.
+2. `post-status` with `scheduledAt` (ISO 8601, must be in the future) — schedules
+   the first post. Returns a **scheduled-post id** (it is not published yet).
+3. `reply-to-post` for posts 2 and 3, chaining each as a reply — or schedule them
+   too.
+4. `get-scheduled-posts` — confirm what's queued. Adjust with
+   `update-scheduled-post` or `cancel-scheduled-post`.
+
+## Notes
+
+- `scheduledAt` must be in the future; the target instance enforces its own
+  minimum lead time (typically ~5 minutes).
+- A scheduled `post-status` returns a scheduled-post id, **not** a published post —
+  replies can only chain once the parent has actually been published.
+- Keep visibility in mind: pass `visibility: "public" | "unlisted" | "private" |
+  "direct"`. Default is `public`.

--- a/examples/recipes/post-image-with-alt-text.md
+++ b/examples/recipes/post-image-with-alt-text.md
@@ -1,0 +1,29 @@
+# Post an image with alt text
+
+**Goal:** Share an image with a good accessibility description attached.
+
+**Requires:** `ACTIVITYPUB_ENABLE_WRITES=true` + a logged-in account. The image
+must be a file **on the machine running the MCP server**.
+
+## Prompt
+
+> "Post the image at **/Users/me/Pictures/sunset.jpg** with a caption about
+> tonight's sunset. Write a clear alt-text description of the image for
+> accessibility, and set the focal point to the horizon."
+
+## What happens under the hood
+
+1. `upload-media --filePath "/Users/me/Pictures/sunset.jpg" --description "<alt
+   text>"` — uploads the file and returns a **media id**. `focusX`/`focusY`
+   (-1.0..1.0) set the crop focal point; pass them together.
+2. `post-status --content "<caption>" --mediaIds ["<media id>"]` — attaches the
+   uploaded media (up to 4 ids) and posts.
+
+## Notes
+
+- `filePath` is an **absolute local path on the MCP server host** — not a URL and
+  not the user's machine. The server reads the file directly.
+- Alt text matters: the model should describe the image content, not just label
+  it. Provide the description in the prompt or let the model draft one for review.
+- Mark sensitive media with `sensitive: true` and add a `spoilerText` content
+  warning on the post when appropriate.

--- a/examples/recipes/research-a-topic.md
+++ b/examples/recipes/research-a-topic.md
@@ -1,0 +1,31 @@
+# Research a topic across the Fediverse
+
+**Goal:** Get a digest of what the Fediverse is saying about a topic, pulling
+from multiple instances and accounts.
+
+**Requires:** nothing — read-only, no account.
+
+## Prompt
+
+> "Research what people are saying about **local-first software** on the
+> Fediverse. Find a couple of active tech instances, pull recent posts and
+> trending discussion on the topic, look at a few of the most relevant authors'
+> timelines, and give me a short digest with links."
+
+## What happens under the hood
+
+1. `discover-instances --software mastodon --language en --minUsers 1000` — find
+   candidate instances (filters by software/size/language, not topic).
+2. `search <instance> "local-first" --type statuses` and
+   `get-trending-posts <instance>` — surface posts on the topic.
+3. `discover-actor <handle>` + `fetch-timeline <handle>` — read the most relevant
+   authors in their own words.
+4. The model synthesizes a digest from the gathered posts.
+
+## Notes
+
+- All fetched content is wrapped in an `<untrusted-content>` envelope — the model
+  treats posts as data, not instructions.
+- Swap in any topic and any instance. `search`/`get-trending-posts` need a
+  Mastodon- or Misskey-API instance; `discover-actor`/`fetch-timeline` work on any
+  ActivityPub server.

--- a/examples/recipes/triage-notifications.md
+++ b/examples/recipes/triage-notifications.md
@@ -1,0 +1,29 @@
+# Triage notifications and reply
+
+**Goal:** Catch up on mentions, understand each in context, and draft replies —
+without opening the app.
+
+**Requires:** `ACTIVITYPUB_ENABLE_WRITES=true` + a logged-in account.
+
+## Prompt
+
+> "Go through my recent mentions. For each one, summarize what they're asking,
+> pull the thread so you have context, and draft a reply for me to approve. Skip
+> anything that's just a boost or favourite."
+
+## What happens under the hood
+
+1. `get-notifications --types ["mention"]` — fetch just mentions (the enum also
+   supports `status`, `reblog`, `follow`, `follow_request`, `favourite`, `poll`,
+   `update`).
+2. `get-post-thread <postUrl>` — for each mention, pull the surrounding
+   conversation so the reply is in context.
+3. The model drafts a reply per mention and shows them to you.
+4. `reply-to-post` — send the approved replies.
+
+## Notes
+
+- Notifications are an **unsolicited** channel — anyone can mention you, so the
+  content is untrusted by definition. It's wrapped in the `<untrusted-content>`
+  envelope; keep a human in the loop before sending replies.
+- Always review drafts before the `reply-to-post` call actually posts.

--- a/site/src/content/docs/guides/examples.mdx
+++ b/site/src/content/docs/guides/examples.mdx
@@ -5,6 +5,11 @@ group: "Guides"
 order: 2
 ---
 
+> **Copy-pasteable recipes:** for short, task-focused recipes you can drop
+> straight into a chat — research digests, scheduled threads, notification triage,
+> image posts, and topic curation — see the
+> [`examples/` folder on GitHub](https://github.com/cameronrye/activitypub-mcp/tree/main/examples).
+
 ## Quick Start Examples
 
 ### Discover a Popular Actor


### PR DESCRIPTION
Adds a top-level `examples/` recipe library — the third agent-doable follow-up from the 2026-06-15 review. Surfaces the 20+ write tools that were previously undersold and gives users copy-pasteable starting points.

Six recipes, written at the altitude users actually work at (a natural-language prompt to the assistant), each listing the tools it triggers, what it requires, and the gotchas:

**Read-only (no account):**
- Research a topic across the Fediverse
- Profile a single account

**Write (`ACTIVITYPUB_ENABLE_WRITES=true` + login):**
- Draft and schedule a thread
- Triage notifications and reply
- Post an image with alt text
- Curate the best posts on a topic

Tool names and parameters were cross-checked against the live schemas (`content`/`spoilerText`/`mediaIds`/`scheduledAt` on `post-status`; `favourite-post`/`boost-post`/`bookmark-post`; `upload-media` local-path-only; `get-notifications` type enum). Linked from the README and the docs examples page.

Docs-only; no version bump. 930 tests pass, format clean, docs site builds.
