### PR TITLE
v3.2.0: structured tool output + durable Smithery tools manifest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,16 @@ jobs:
     - name: Build project (clean first)
       run: npm run clean && npm run build
 
+    - name: Verify .mcpb tools manifest injects exactly 18 default tools
+      # Runs the inject script against a throwaway manifest copy so a tool
+      # registration regression (count != 18, or a tool dropping its schema)
+      # fails the PR early — not only at release-tag time.
+      if: matrix.os != 'windows-latest'
+      run: |
+        cp manifest.json "${RUNNER_TEMP:-/tmp}/manifest-ci-check.json"
+        node scripts/inject-tools-manifest.js "${RUNNER_TEMP:-/tmp}/manifest-ci-check.json" dist/mcp-main.js
+        node -e "const m=require('${RUNNER_TEMP:-/tmp}/manifest-ci-check.json'); if(m.tools.length!==18) throw new Error('expected 18 tools, got '+m.tools.length)"
+
     - name: Check tarball contents
       if: matrix.node-version == '20.x' && matrix.os == 'ubuntu-latest'
       run: node scripts/check-tarball-contents.js

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,14 @@ jobs:
     - name: Build project (clean first)
       run: npm run clean && npm run build
 
+    - name: Verify .mcpb tools manifest injects exactly 18 default tools
+      # Catch a tool-registration regression here too, before the release job
+      # builds the bundle Smithery ingests.
+      run: |
+        cp manifest.json "${RUNNER_TEMP:-/tmp}/manifest-release-check.json"
+        node scripts/inject-tools-manifest.js "${RUNNER_TEMP:-/tmp}/manifest-release-check.json" dist/mcp-main.js
+        node -e "const m=require('${RUNNER_TEMP:-/tmp}/manifest-release-check.json'); if(m.tools.length!==18) throw new Error('expected 18 tools, got '+m.tools.length)"
+
     - name: Check tarball contents
       run: node scripts/check-tarball-contents.js
 
@@ -162,23 +170,33 @@ jobs:
     - name: Pack release tarball
       run: npm pack
 
-    - name: Build Claude Desktop Extension (.mcpb)
+    - name: Build .mcpb with durable tools manifest
       # The README's one-click install points at this asset on the latest
       # release, so every release MUST carry it. Build a self-contained bundle
       # (ESM entrypoint needs its own package.json + prod node_modules) per the
       # steps in docs/distribution.md §3.
+      #
+      # We do NOT use `mcpb pack` here: `mcpb validate`/`pack` reject the
+      # `inputSchema`/`outputSchema` keys Smithery scores and strip them from the
+      # bundle. A .mcpb IS a zip with manifest.json at root, so a plain `zip`
+      # preserves the rich schemas. We pin nothing supply-chain-risky: no global
+      # mcpb install (the `node -e` JSON gate replaces `mcpb validate`), and the
+      # inject script + npm ci run with --ignore-scripts.
       run: |
-        # Pin the exact version and skip lifecycle scripts: this job holds a
-        # contents:write token and produces the one-click .mcpb users install, so
-        # an unpinned/script-running mcpb would be a supply-chain RCE/tamper vector
-        # (publish-mcp.yml pins mcp-publisher for the same reason).
-        npm install -g @anthropic-ai/mcpb@2.1.2 --ignore-scripts
         stage="$(mktemp -d)"
         cp manifest.json package.json package-lock.json "$stage"/
         cp -R dist "$stage"/dist
         ( cd "$stage" && npm ci --omit=dev --ignore-scripts )
-        mcpb validate manifest.json
-        mcpb pack "$stage" "activitypub-mcp-${{ steps.get_version.outputs.VERSION }}.mcpb"
+        # Capture live tool schemas (inputSchema + outputSchema) from the built
+        # server and write them into the staged manifest.json.
+        node scripts/inject-tools-manifest.js "$stage/manifest.json" "$stage/dist/mcp-main.js"
+        # JSON sanity + tools-present gate (replaces mcpb validate, which rejects
+        # inputSchema). Fails loudly if the tools array is missing/short.
+        node -e "const m=require('$stage/manifest.json'); if(!Array.isArray(m.tools)||m.tools.length<18) throw new Error('manifest tools missing/short: '+(m.tools?.length))"
+        # Bundle the prod node_modules too — the ESM entrypoint needs its deps at
+        # runtime (Claude Desktop one-click install + Smithery's local run), so the
+        # zip MUST include node_modules, not just dist.
+        ( cd "$stage" && zip -r -q -X "$OLDPWD/activitypub-mcp-${{ steps.get_version.outputs.VERSION }}.mcpb" manifest.json package.json node_modules dist -x '*.map' )
 
     - name: Create Release
       uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.2.0] - 2026-06-16
+
+Structured tool output and Smithery listing improvements. No breaking changes —
+tool names and the human-readable text responses are unchanged; structured output
+is purely additive.
+
+### Added
+
+- **Structured tool results** — every read/default tool now declares an
+  `outputSchema` and returns `structuredContent` alongside the existing text, so
+  MCP clients can type-check responses. The prose `content[0].text` is byte-for-byte
+  unchanged for back-compat.
+- **Smithery listing** — homepage ownership verification (a `smithery-verification`
+  meta tag in the docs site, since `github.io` cannot host DNS TXT records) and a
+  backlink to the Smithery server page from the README badges and homepage footer.
+
+### Changed
+
+- **`.mcpb` release pipeline** — the bundle manifest now embeds the live tool
+  schemas (name/description/inputSchema/outputSchema), captured from the running
+  server and packaged via a plain zip (`mcpb pack` strips these keys). This is the
+  metadata Smithery's capability score reads. The bundle still ships its production
+  `node_modules` so it runs standalone.
+
+### Fixed
+
+- **`get-relationship`** — the `accountIds` rejection-guard parameter now carries a
+  description, completing parameter-description coverage across all tools.
+
 ## [3.1.6] - 2026-06-15
 
 Correctness, hardening, and docs patch from a third end-to-end review. Fixes a

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@
 
 <p align="center">
   <a href="https://glama.ai/mcp/servers/cameronrye/activitypub-mcp"><img src="https://glama.ai/mcp/servers/cameronrye/activitypub-mcp/badge" alt="Glama quality and maintenance score" width="200" /></a>
+  <a href="https://smithery.ai/servers/rye/activitypub-mcp"><img src="https://smithery.ai/badge/rye/activitypub-mcp" alt="Smithery" /></a>
 </p>
 
 ---

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.2",
   "name": "activitypub-mcp",
   "display_name": "ActivityPub MCP",
-  "version": "3.1.6",
+  "version": "3.2.0",
   "description": "Read-only-by-default MCP server: let LLMs explore the Fediverse — Mastodon, Misskey, Pleroma.",
   "long_description": "Lets an LLM explore and interact with the existing Fediverse — Mastodon, Misskey, Foundkey, Pleroma, and compatible servers. Read-only by default; write tools are opt-in. Untrusted fediverse content is wrapped in an <untrusted-content> envelope before it reaches the model.",
   "author": {

--- a/manifest.json
+++ b/manifest.json
@@ -17,6 +17,7 @@
   },
   "license": "MIT",
   "keywords": ["activitypub", "mcp", "fediverse", "mastodon", "misskey"],
+  "tools": [],
   "server": {
     "type": "node",
     "entry_point": "dist/mcp-main.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "activitypub-mcp",
-  "version": "3.1.6",
+  "version": "3.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "activitypub-mcp",
-      "version": "3.1.6",
+      "version": "3.2.0",
       "license": "MIT",
       "dependencies": {
         "@logtape/logtape": "^2.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5360,9 +5360,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.23",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
-      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
+      "version": "4.12.25",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
+      "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activitypub-mcp",
-  "version": "3.1.6",
+  "version": "3.2.0",
   "description": "Model Context Protocol (MCP) server for the Fediverse — let Claude and other LLMs explore and post to Mastodon, Misskey, and Pleroma. Read-only by default.",
   "mcpName": "io.github.cameronrye/activitypub-mcp",
   "main": "dist/mcp-main.js",

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "install:shell:windows": "powershell -ExecutionPolicy Bypass -File scripts/install.ps1",
     "uninstall": "node scripts/install.js uninstall",
     "build": "tsc",
+    "build:mcpb": "node scripts/inject-tools-manifest.js manifest.json dist/mcp-main.js",
     "build:site": "node scripts/generate-registry-manifest.js && astro build && npx pagefind --site dist-site && node scripts/generate-search-data.js",
     "dev:site": "astro dev",
     "preview:site": "astro preview",

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -116,7 +116,7 @@ Upgrading from v1.x? See [MIGRATION-v2.md](https://github.com/cameronrye/activit
 
 ---
 
-**Version:** 3.1.6
+**Version:** 3.2.0
 **License:** MIT
 **Maintainer:** Cameron Rye (https://rye.dev/)
 **Repository:** https://github.com/cameronrye/activitypub-mcp

--- a/scripts/inject-tools-manifest.js
+++ b/scripts/inject-tools-manifest.js
@@ -1,0 +1,156 @@
+#!/usr/bin/env node
+
+/**
+ * Inject the live tool manifest into a .mcpb manifest.json.
+ *
+ * Why query the running server instead of parsing TypeScript: this captures the
+ * EXACT JSON Schema the MCP SDK emits for each tool — including `outputSchema`,
+ * which only exists after the SDK serializes the registered Zod shapes. There is
+ * no source-parsing drift, and new schemas are picked up automatically.
+ *
+ * Why this replaces `mcpb pack`: `mcpb validate`/`pack` reject `inputSchema`/
+ * `outputSchema`/`annotations` as unrecognized keys and emit only
+ * `{name, description}` per tool, so the rich schemas Smithery scores would be
+ * stripped from the shipped bundle. The release workflow zips the bundle plainly
+ * instead (a .mcpb IS a zip with manifest.json at root).
+ *
+ * What it does:
+ *   1. Spawns the built server over stdio with writes DISABLED, so only the
+ *      default (read/always-on) tools register.
+ *   2. Sends initialize + tools/list and collects each tool.
+ *   3. Filters to the default tools (excludes the destructive write mutators),
+ *      strips `annotations`, keeps name/title/description/inputSchema/outputSchema.
+ *   4. Writes the array into the target manifest.json's `tools` field.
+ *   5. Fails loudly (exit 1) on no server response within the timeout, and if the
+ *      final tool count is not exactly EXPECTED_TOOL_COUNT — a registration
+ *      regression must break the release, not ship a short/wrong manifest.
+ *
+ * Usage:
+ *   node scripts/inject-tools-manifest.js <manifest.json> <dist/mcp-main.js>
+ */
+
+import { spawn } from "node:child_process";
+import { readFileSync, writeFileSync } from "node:fs";
+
+const TIMEOUT_MS = 10000;
+// The default tools Smithery scores: 9 read tools + 9 always-on (account
+// management + authenticated reads). The 19 write-gated mutators are excluded.
+const EXPECTED_TOOL_COUNT = 18;
+
+function fail(message) {
+  console.error(`inject-tools-manifest: ${message}`);
+  process.exit(1);
+}
+
+function main() {
+  const [, , manifestPath, serverPath] = process.argv;
+  if (!manifestPath || !serverPath) {
+    fail("usage: node scripts/inject-tools-manifest.js <manifest.json> <dist/mcp-main.js>");
+  }
+
+  const child = spawn(process.execPath, [serverPath], {
+    env: {
+      ...process.env,
+      MCP_TRANSPORT_MODE: "stdio",
+      LOG_LEVEL: "error",
+      // Writes OFF: only the default tools register. We additionally filter out
+      // any destructive mutator below as belt-and-suspenders.
+      ACTIVITYPUB_ENABLE_WRITES: undefined,
+    },
+    stdio: ["pipe", "pipe", "inherit"],
+  });
+
+  let settled = false;
+  const timer = setTimeout(() => {
+    if (settled) return;
+    settled = true;
+    child.kill();
+    fail("timed out waiting for the server to respond to tools/list");
+  }, TIMEOUT_MS);
+
+  child.on("error", (err) => {
+    if (settled) return;
+    settled = true;
+    clearTimeout(timer);
+    fail(`failed to spawn server: ${err.message}`);
+  });
+
+  let buffer = "";
+  child.stdout.on("data", (chunk) => {
+    buffer += chunk.toString();
+    // The server speaks newline-delimited JSON-RPC over stdout. Keep the trailing
+    // partial line (if any) in the buffer for the next chunk.
+    const lines = buffer.split("\n");
+    buffer = lines.pop() ?? "";
+    for (const raw of lines) {
+      const line = raw.trim();
+      if (!line) continue;
+      let message;
+      try {
+        message = JSON.parse(line);
+      } catch {
+        // Non-JSON noise (shouldn't happen on stdout, but be defensive).
+        continue;
+      }
+      if (message.id === 2 && message.result && Array.isArray(message.result.tools)) {
+        handleTools(message.result.tools, manifestPath, child, timer, () => {
+          settled = true;
+        });
+        return;
+      }
+    }
+  });
+
+  const send = (obj) => child.stdin.write(`${JSON.stringify(obj)}\n`);
+  send({
+    jsonrpc: "2.0",
+    id: 1,
+    method: "initialize",
+    params: {
+      protocolVersion: "2025-06-18",
+      capabilities: {},
+      clientInfo: { name: "inject-tools-manifest", version: "0" },
+    },
+  });
+  send({ jsonrpc: "2.0", method: "notifications/initialized" });
+  send({ jsonrpc: "2.0", id: 2, method: "tools/list", params: {} });
+}
+
+function handleTools(allTools, manifestPath, child, timer, markSettled) {
+  clearTimeout(timer);
+  markSettled();
+  child.kill();
+
+  // Keep the default tools, drop the destructive write mutators. switch-account
+  // is a default tool that carries `readOnlyHint: false` (it flips the active
+  // account) but is NOT destructive, so a strict readOnlyHint filter would wrongly
+  // drop it; filtering by `destructiveHint !== true` keeps exactly the 18 defaults.
+  const tools = allTools
+    .filter((tool) => tool.annotations?.destructiveHint !== true)
+    .map((tool) => ({
+      name: tool.name,
+      title: tool.title,
+      description: tool.description,
+      inputSchema: tool.inputSchema,
+      outputSchema: tool.outputSchema,
+    }));
+
+  if (tools.length !== EXPECTED_TOOL_COUNT) {
+    fail(
+      `expected ${EXPECTED_TOOL_COUNT} default tools but found ${tools.length}: ` +
+        `[${tools.map((t) => t.name).join(", ")}] — a tool-registration regression?`,
+    );
+  }
+
+  const manifest = JSON.parse(readFileSync(manifestPath, "utf-8"));
+  manifest.tools = tools;
+  writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+
+  console.log(`inject-tools-manifest: wrote ${tools.length} tools into ${manifestPath}`);
+  for (const tool of tools) {
+    console.log(`  - ${tool.name}${tool.outputSchema ? " (outputSchema ✓)" : ""}`);
+  }
+  process.exit(0);
+}
+
+main();

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.cameronrye/activitypub-mcp",
   "description": "Read-only-by-default MCP server: let LLMs explore the Fediverse — Mastodon, Misskey, Pleroma.",
-  "version": "3.1.6",
+  "version": "3.2.0",
   "repository": {
     "url": "https://github.com/cameronrye/activitypub-mcp",
     "source": "github"
@@ -12,7 +12,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "activitypub-mcp",
-      "version": "3.1.6",
+      "version": "3.2.0",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/site/layouts/BaseLayout.astro
+++ b/site/layouts/BaseLayout.astro
@@ -105,6 +105,9 @@ const structuredData = {
   <meta name="theme-color" content="#E8552D">
   <meta name="color-scheme" content="light dark">
 
+  <!-- Smithery homepage ownership verification (non-DNS; github.io has no DNS access) -->
+  <meta name="smithery-verification" content="69ef9387b83474ea998d2fc652fc0bb4a01a990bafd61863450449c1da1cc36e">
+
   <!-- Canonical URL -->
   <link rel="canonical" href={canonicalURL}>
 

--- a/site/pages/index.astro
+++ b/site/pages/index.astro
@@ -255,6 +255,7 @@ const chatgptConfig = `{
         <ul class="home-footer-list">
           <li><a href="https://github.com/cameronrye/activitypub-mcp" target="_blank" rel="noopener">GitHub</a></li>
           <li><a href="https://www.npmjs.com/package/activitypub-mcp" target="_blank" rel="noopener">npm</a></li>
+          <li><a href="https://smithery.ai/servers/rye/activitypub-mcp" target="_blank" rel="noopener">Smithery</a></li>
           <li><a href="https://github.com/cameronrye/activitypub-mcp/issues" target="_blank" rel="noopener">Issues</a></li>
           <li><a href={`${baseURL}docs/reference/changelog/`}>Changelog</a></li>
         </ul>

--- a/site/src/content/docs/reference/changelog.mdx
+++ b/site/src/content/docs/reference/changelog.mdx
@@ -9,6 +9,23 @@ order: 2
 
 All notable changes to the ActivityPub MCP Server are documented here. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### v3.2.0 - 2026-06-16
+
+**Structured tool output and Smithery listing improvements.** No breaking changes — tool names and human-readable responses are unchanged; structured output is purely additive. See [CHANGELOG.md](https://github.com/cameronrye/activitypub-mcp/blob/main/CHANGELOG.md) for the complete entry.
+
+#### Added
+
+- **Structured tool results** — every read/default tool now declares an `outputSchema` and returns `structuredContent` alongside the existing text, so MCP clients can type-check responses. The prose output is unchanged.
+- **Smithery listing** — homepage ownership verification and a backlink from the README and docs site.
+
+#### Changed
+
+- **`.mcpb` release pipeline** embeds the live tool schemas (inputSchema/outputSchema) in the bundle manifest, captured from the running server and packaged via a plain zip — the metadata Smithery's capability score reads.
+
+#### Fixed
+
+- **`get-relationship`** — the `accountIds` rejection-guard parameter now carries a description, completing parameter-description coverage.
+
 ### v3.1.6 - 2026-06-15
 
 **Correctness, hardening, and docs patch** from a third end-to-end review. Fixes a silent read-path data loss, several remote-input edge cases, and a cluster of tool-reference documentation drift. No breaking changes. See [CHANGELOG.md](https://github.com/cameronrye/activitypub-mcp/blob/main/CHANGELOG.md) for the complete entry.

--- a/src/config.ts
+++ b/src/config.ts
@@ -90,7 +90,7 @@ function parseBoolEnv(value: string | undefined, defaultValue: boolean): boolean
 export const SERVER_NAME = process.env.MCP_SERVER_NAME || "activitypub-mcp";
 
 /** MCP Server version */
-export const SERVER_VERSION = process.env.MCP_SERVER_VERSION || "3.1.6";
+export const SERVER_VERSION = process.env.MCP_SERVER_VERSION || "3.2.0";
 
 /**
  * Directory for the persisted credential store (accounts.json).

--- a/src/mcp/output-schemas.ts
+++ b/src/mcp/output-schemas.ts
@@ -1,0 +1,168 @@
+/**
+ * Output schemas (Zod raw shapes) for the default/read MCP tools.
+ *
+ * MCP `outputSchema` takes a Zod RAW SHAPE (a plain object of Zod fields, same
+ * as `inputSchema`) — NOT a wrapped `z.object(...)`. The top-level
+ * structuredContent the handler returns is always an object.
+ *
+ * When a tool declares an `outputSchema`, the SDK validates that every SUCCESS
+ * return carries a `structuredContent` matching the schema (error returns skip
+ * validation). Fields are `.optional()` generously so real, partially-populated
+ * remote data always parses; the prose `content[0].text` stays the source of
+ * truth for display and is never narrowed by these schemas.
+ */
+
+import { z } from "zod";
+
+// --- Shared leaf shapes ---------------------------------------------------
+// A single rendered post/status (timelines, bookmarks, favourites, thread, search).
+export const PostItem = z.object({
+  id: z.string().describe("Post/status ID"),
+  url: z.string().optional().describe("Canonical URL of the post"),
+  author: z.string().optional().describe("Author handle or display name"),
+  content: z.string().describe("Plain-text/summarized post body"),
+  contentWarning: z.string().optional().describe("Content warning / summary, if any"),
+  type: z.string().optional().describe("ActivityPub object type (Note, Announce, …)"),
+  createdAt: z.string().optional().describe("ISO timestamp"),
+  replies: z.number().optional(),
+  reblogs: z.number().optional(),
+  favourites: z.number().optional(),
+});
+
+export const ActorSummary = z.object({
+  id: z.string(),
+  preferredUsername: z.string().optional(),
+  name: z.string().optional(),
+  summary: z.string().optional(),
+  url: z.string().optional(),
+  inbox: z.string().optional(),
+  outbox: z.string().optional(),
+  followers: z.string().optional(),
+  following: z.string().optional(),
+});
+
+// --- Per-tool raw shapes (ZodRawShape = bare objects) ---------------------
+
+// discover-actor
+export const discoverActorOutput = {
+  actor: ActorSummary,
+} as const;
+
+// fetch-timeline, get-home-timeline, get-bookmarks, get-favourites,
+// get-public-timeline, get-trending-posts
+export const postListOutput = {
+  posts: z.array(PostItem),
+  nextCursor: z.string().optional().describe("Opaque cursor for the next page, if more results"),
+  hasMore: z.boolean().optional(),
+  source: z.string().optional().describe("Account/actor/instance the posts came from"),
+} as const;
+
+// get-post-thread
+export const threadOutput = {
+  ancestors: z.array(PostItem),
+  post: PostItem,
+  replies: z.array(PostItem),
+} as const;
+
+// search (multi-section)
+export const searchOutput = {
+  accounts: z.array(ActorSummary).optional(),
+  statuses: z.array(PostItem).optional(),
+  hashtags: z.array(z.object({ name: z.string(), url: z.string().optional() })).optional(),
+} as const;
+
+// get-instance-info
+export const instanceInfoOutput = {
+  domain: z.string(),
+  title: z.string().optional(),
+  description: z.string().optional(),
+  version: z.string().optional(),
+  software: z.string().optional(),
+  users: z.number().optional(),
+  registrationsOpen: z.boolean().optional(),
+} as const;
+
+// discover-instances
+export const instanceListOutput = {
+  instances: z.array(
+    z.object({
+      domain: z.string(),
+      software: z.string().optional(),
+      users: z.number().optional(),
+      description: z.string().optional(),
+    }),
+  ),
+  hasMore: z.boolean().optional(),
+} as const;
+
+// get-trending-hashtags
+export const trendingHashtagsOutput = {
+  hashtags: z.array(
+    z.object({
+      name: z.string(),
+      url: z.string().optional(),
+      uses: z.number().optional(),
+      accounts: z.number().optional(),
+    }),
+  ),
+} as const;
+
+// list-accounts
+export const accountListOutput = {
+  accounts: z.array(
+    z.object({
+      id: z.string(),
+      username: z.string(),
+      instance: z.string(),
+      label: z.string().optional(),
+      isActive: z.boolean(),
+      scopes: z.array(z.string()),
+    }),
+  ),
+  writeEnabled: z.boolean(),
+  activeAccountId: z.string().optional(),
+} as const;
+
+// switch-account / verify-account
+export const accountStatusOutput = {
+  accountId: z.string().optional(),
+  username: z.string().optional(),
+  instance: z.string().optional(),
+  active: z.boolean().optional(),
+  verified: z.boolean().optional(),
+} as const;
+
+// get-notifications
+export const notificationsOutput = {
+  notifications: z.array(
+    z.object({
+      id: z.string(),
+      type: z.string(),
+      account: z.string().optional(),
+      status: PostItem.optional(),
+      createdAt: z.string().optional(),
+    }),
+  ),
+} as const;
+
+// get-relationship
+export const relationshipOutput = {
+  acct: z.string(),
+  following: z.boolean().optional(),
+  followedBy: z.boolean().optional(),
+  blocking: z.boolean().optional(),
+  muting: z.boolean().optional(),
+  requested: z.boolean().optional(),
+} as const;
+
+// get-scheduled-posts
+export const scheduledPostsOutput = {
+  scheduledPosts: z.array(
+    z.object({
+      id: z.string(),
+      scheduledAt: z.string(),
+      text: z.string().optional(),
+      visibility: z.string().optional(),
+    }),
+  ),
+} as const;

--- a/src/mcp/tools-write.ts
+++ b/src/mcp/tools-write.ts
@@ -17,6 +17,14 @@ import { formatRemoteError, getErrorMessage, LocalMediaError } from "../utils/er
 import { sniffMediaType } from "../utils/media-type.js";
 import { sanitizeInline, wrapUntrusted } from "../utils/untrusted.js";
 import { trackedMcpServer } from "./capabilities.js";
+import {
+  accountListOutput,
+  accountStatusOutput,
+  notificationsOutput,
+  postListOutput,
+  relationshipOutput,
+  scheduledPostsOutput,
+} from "./output-schemas.js";
 import { checkRateLimit } from "./rate-limit-guard.js";
 
 const logger = getLogger(["activitypub-mcp", "tools-write"]);
@@ -123,6 +131,39 @@ function requireAuthEnabled(): void {
   }
 }
 
+/**
+ * Map a Mastodon-shaped status (home timeline, bookmarks, favourites) to the
+ * structured PostItem shape. Mirrors the prose render so structuredContent draws
+ * from the exact same data already formatted into content[0].text.
+ */
+function statusToPostItem(post: {
+  id?: string | null;
+  url?: string | null;
+  content?: string | null;
+  spoiler_text?: string | null;
+  created_at?: string | null;
+  account?: { acct?: string | null; username?: string | null } | null;
+  favourites_count?: number | string | null;
+  reblogs_count?: number | string | null;
+  replies_count?: number | string | null;
+}) {
+  const num = (v: number | string | null | undefined) => {
+    const n = Number(v);
+    return Number.isFinite(n) ? n : undefined;
+  };
+  return {
+    id: typeof post.id === "string" ? post.id : "",
+    url: post.url ?? undefined,
+    author: post.account?.acct || post.account?.username || undefined,
+    content: post.content || "",
+    contentWarning: post.spoiler_text || undefined,
+    createdAt: post.created_at ?? undefined,
+    favourites: num(post.favourites_count),
+    reblogs: num(post.reblogs_count),
+    replies: num(post.replies_count),
+  };
+}
+
 /** A resolved (non-null) account, as returned by the account manager. */
 type ResolvedAccount = NonNullable<ReturnType<typeof accountManager.getActiveAccount>>;
 
@@ -220,6 +261,7 @@ function registerListAccountsTool(mcpServer: McpServer): void {
       title: "List Configured Accounts",
       description: "List all configured authenticated accounts for write operations",
       inputSchema: {},
+      outputSchema: accountListOutput,
       annotations: { readOnlyHint: true },
     },
     async () => {
@@ -248,6 +290,7 @@ Write operations are currently disabled. To enable write operations, configure a
 💡 For multiple accounts, use \`ACTIVITYPUB_ACCOUNTS=id1|instance1|token1|username1|label1,id2|instance2|token2|username2|label2\` (pipe-delimited; v2 changed from colon to avoid conflict with colons in tokens).`,
             },
           ],
+          structuredContent: { accounts: [], writeEnabled: false },
         };
       }
 
@@ -273,6 +316,18 @@ ${writeStatus.activeAccount ? `**Active Account**: @${writeStatus.activeAccount.
 💡 Use \`switch-account\` to change the active account for write operations.`,
           },
         ],
+        structuredContent: {
+          accounts: accounts.map((acc) => ({
+            id: acc.id,
+            username: acc.username,
+            instance: acc.instance,
+            label: acc.label,
+            isActive: acc.isActive,
+            scopes: acc.scopes,
+          })),
+          writeEnabled: writeStatus.enabled,
+          activeAccountId: writeStatus.activeAccount?.id,
+        },
       };
     },
   );
@@ -289,6 +344,7 @@ function registerSwitchAccountTool(mcpServer: McpServer): void {
           .string()
           .describe("The account ID to switch to (use list-accounts to see IDs)"),
       },
+      outputSchema: accountStatusOutput,
       annotations: { readOnlyHint: false },
     },
     async ({ accountId }) => {
@@ -337,6 +393,12 @@ Now using: **@${account?.username}@${account?.instance}**
 All write operations will use this account until switched.`,
           },
         ],
+        structuredContent: {
+          accountId,
+          username: account?.username,
+          instance: account?.instance,
+          active: true,
+        },
       };
     },
   );
@@ -354,6 +416,7 @@ function registerVerifyAccountTool(mcpServer: McpServer, rateLimiter: RateLimite
           .optional()
           .describe("The account ID to verify (defaults to active account)"),
       },
+      outputSchema: accountStatusOutput,
       annotations: { readOnlyHint: true },
     },
     async ({ accountId }) => {
@@ -441,6 +504,12 @@ Run \`activitypub-mcp login ${account.instance}\` to re-authorize.`,
 ✅ Credentials are valid and working.`,
             },
           ],
+          structuredContent: {
+            accountId: targetId,
+            username: info.username || account.username,
+            instance: account.instance,
+            verified: true,
+          },
         };
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
@@ -1219,6 +1288,7 @@ function registerGetHomeTimelineTool(mcpServer: McpServer, rateLimiter: RateLimi
         sinceId: z.string().optional().describe("Return posts newer than this ID"),
         accountId: z.string().optional().describe("Account ID"),
       },
+      outputSchema: postListOutput,
       annotations: { readOnlyHint: true },
     },
     async ({ limit = 20, maxId, sinceId, accountId }) => {
@@ -1279,6 +1349,11 @@ ${postsList || "No posts found"}
 ${posts.length > 0 ? `📄 Use maxId: "${posts[posts.length - 1].id}" for next page` : ""}`,
             },
           ],
+          structuredContent: {
+            posts: posts.map(statusToPostItem),
+            nextCursor: posts.length > 0 ? posts[posts.length - 1].id : undefined,
+            source: account.instance,
+          },
         };
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
@@ -1331,6 +1406,7 @@ function registerGetNotificationsTool(mcpServer: McpServer, rateLimiter: RateLim
           .describe("Filter by notification types"),
         accountId: z.string().optional().describe("Account ID"),
       },
+      outputSchema: notificationsOutput,
       annotations: { readOnlyHint: true },
     },
     async ({ limit = 20, types, accountId }) => {
@@ -1398,6 +1474,18 @@ function registerGetNotificationsTool(mcpServer: McpServer, rateLimiter: RateLim
 ${notificationList || "No notifications"}`,
             },
           ],
+          structuredContent: {
+            notifications: notifications.map((n) => {
+              const rec = n as { id?: string; created_at?: string };
+              return {
+                id: typeof rec.id === "string" ? rec.id : "",
+                type: n.type,
+                account: n.account?.acct,
+                status: n.status ? { id: "", content: n.status.content || "" } : undefined,
+                createdAt: rec.created_at,
+              };
+            }),
+          },
         };
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
@@ -1430,6 +1518,7 @@ function registerGetBookmarksTool(mcpServer: McpServer, rateLimiter: RateLimiter
         limit: z.number().min(1).max(40).optional().describe("Number of posts (default: 20)"),
         accountId: z.string().optional().describe("Account ID"),
       },
+      outputSchema: postListOutput,
       annotations: { readOnlyHint: true },
     },
     async ({ limit = 20, accountId }) => {
@@ -1481,6 +1570,10 @@ function registerGetBookmarksTool(mcpServer: McpServer, rateLimiter: RateLimiter
 ${bookmarkList || "No bookmarks found"}`,
             },
           ],
+          structuredContent: {
+            posts: bookmarks.map(statusToPostItem),
+            source: account.instance,
+          },
         };
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
@@ -1513,6 +1606,7 @@ function registerGetFavouritesTool(mcpServer: McpServer, rateLimiter: RateLimite
         limit: z.number().min(1).max(40).optional().describe("Number of posts (default: 20)"),
         accountId: z.string().optional().describe("Account ID"),
       },
+      outputSchema: postListOutput,
       annotations: { readOnlyHint: true },
     },
     async ({ limit = 20, accountId }) => {
@@ -1564,6 +1658,10 @@ function registerGetFavouritesTool(mcpServer: McpServer, rateLimiter: RateLimite
 ${favouriteList || "No favourites found"}`,
             },
           ],
+          structuredContent: {
+            posts: favourites.map(statusToPostItem),
+            source: account.instance,
+          },
         };
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
@@ -1610,8 +1708,12 @@ function registerGetRelationshipTool(mcpServer: McpServer, rateLimiter: RateLimi
             message:
               "get-relationship takes 'acct' (a single username@instance string), not 'accountIds'. Call this tool once per account.",
           })
-          .optional(),
+          .optional()
+          .describe(
+            "Deprecated / not supported. Use 'acct' (a single username@instance string) and call this tool once per account.",
+          ),
       },
+      outputSchema: relationshipOutput,
       annotations: { readOnlyHint: true },
     },
     async ({ acct, accountId }) => {
@@ -1676,6 +1778,14 @@ ${relationship.note ? `\n📝 **Note**: ${wrapUntrusted(relationship.note, `rela
 - Use \`mute-account\` or \`block-account\` to manage interactions`,
             },
           ],
+          structuredContent: {
+            acct,
+            following: relationship.following,
+            followedBy: relationship.followed_by,
+            blocking: relationship.blocking,
+            muting: relationship.muting,
+            requested: relationship.requested,
+          },
         };
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
@@ -1990,6 +2100,7 @@ function registerGetScheduledPostsTool(mcpServer: McpServer, rateLimiter: RateLi
         limit: z.number().min(1).max(40).optional().describe("Number of posts (default: 20)"),
         accountId: z.string().optional().describe("Account ID"),
       },
+      outputSchema: scheduledPostsOutput,
       // Read-only: this tool only fetches scheduled posts (a GET). It must not
       // carry the destructive annotation the actual mutators use, or clients
       // that gate destructive tools behind confirmation will friction a read.
@@ -2038,6 +2149,7 @@ No scheduled posts found.
 💡 **Tip:** Use \`post-status\` with the \`scheduledAt\` parameter to schedule a post for later.`,
               },
             ],
+            structuredContent: { scheduledPosts: [] },
           };
         }
 
@@ -2074,6 +2186,14 @@ ${postsList}
 - Use \`update-scheduled-post\` to change the scheduled time`,
             },
           ],
+          structuredContent: {
+            scheduledPosts: scheduled.map((post) => ({
+              id: post.id,
+              scheduledAt: post.scheduled_at,
+              text: post.params.text || undefined,
+              visibility: post.params.visibility || undefined,
+            })),
+          },
         };
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -21,6 +21,15 @@ import {
   validateQuery,
 } from "../validation/validators.js";
 import { trackedMcpServer } from "./capabilities.js";
+import {
+  discoverActorOutput,
+  instanceInfoOutput,
+  instanceListOutput,
+  postListOutput,
+  searchOutput,
+  threadOutput,
+  trendingHashtagsOutput,
+} from "./output-schemas.js";
 import { checkRateLimit } from "./rate-limit-guard.js";
 import { registerWriteTools } from "./tools-write.js";
 
@@ -132,6 +141,40 @@ async function withReadTool(
 }
 
 /**
+ * Map a Mastodon-shaped status (trending/public timelines) to the structured
+ * PostItem shape. Mirrors the prose render: counts are coerced to numbers and
+ * the spoiler_text becomes the contentWarning. Used so structuredContent draws
+ * from the exact same data already formatted into content[0].text.
+ */
+function mastodonStatusToPostItem(post: {
+  id?: string;
+  url?: string;
+  content?: string;
+  spoiler_text?: string;
+  created_at?: string;
+  account?: { acct?: string; username?: string; display_name?: string };
+  favourites_count?: number | string;
+  reblogs_count?: number | string;
+  replies_count?: number | string;
+}) {
+  const num = (v: number | string | undefined) => {
+    const n = Number(v);
+    return Number.isFinite(n) ? n : undefined;
+  };
+  return {
+    id: typeof post.id === "string" ? post.id : "",
+    url: post.url,
+    author: post.account?.acct || post.account?.username,
+    content: post.content || "",
+    contentWarning: post.spoiler_text || undefined,
+    createdAt: post.created_at,
+    favourites: num(post.favourites_count),
+    reblogs: num(post.reblogs_count),
+    replies: num(post.replies_count),
+  };
+}
+
+/**
  * Discover actor tool - find actors across the fediverse.
  */
 function registerDiscoverActorTool(mcpServer: McpServer, rateLimiter: RateLimiter): void {
@@ -148,6 +191,7 @@ function registerDiscoverActorTool(mcpServer: McpServer, rateLimiter: RateLimite
           "Actor handle in 'user@domain' or '@user@domain' form (e.g., 'alice@mastodon.social')",
         ),
       },
+      outputSchema: discoverActorOutput,
       annotations: { readOnlyHint: true },
     },
     async ({ identifier }) => {
@@ -176,6 +220,19 @@ function registerDiscoverActorTool(mcpServer: McpServer, rateLimiter: RateLimite
 👤 Following: ${sanitizeInline(actor.following || "") || "Not available"}`,
             },
           ],
+          structuredContent: {
+            actor: {
+              id: actor.id,
+              preferredUsername: actor.preferredUsername,
+              name: actor.name,
+              summary: actor.summary,
+              url: actor.url || actor.id,
+              inbox: actor.inbox,
+              outbox: actor.outbox,
+              followers: actor.followers,
+              following: actor.following,
+            },
+          },
         };
       } catch (error) {
         const errorMessage = getErrorMessage(error);
@@ -230,6 +287,7 @@ function registerFetchTimelineTool(mcpServer: McpServer, rateLimiter: RateLimite
         maxId: z.string().optional().describe("Return posts older than this post ID (pagination)"),
         sinceId: z.string().optional().describe("Return posts more recent than this post ID"),
       },
+      outputSchema: postListOutput,
       annotations: { readOnlyHint: true },
     },
     async ({ identifier, limit = 20, cursor, minId, maxId, sinceId }) => {
@@ -302,6 +360,21 @@ ${paginationSection}
 ${postsSection}`,
             },
           ],
+          structuredContent: {
+            posts: posts.map((post: unknown) => {
+              const { type, content, cw } = summarizeOutboxItem(post);
+              const p = (post ?? {}) as Record<string, unknown>;
+              return {
+                id: typeof p.id === "string" ? p.id : "",
+                type,
+                content,
+                contentWarning: cw,
+              };
+            }),
+            nextCursor: timeline.hasMore ? timeline.nextCursor : undefined,
+            hasMore: timeline.hasMore,
+            source: validIdentifier,
+          },
         };
       } catch (error) {
         const errorMessage = getErrorMessage(error);
@@ -344,6 +417,7 @@ function registerGetInstanceInfoTool(mcpServer: McpServer, rateLimiter: RateLimi
       inputSchema: {
         domain: DomainSchema.describe("Instance domain (e.g., example.social)"),
       },
+      outputSchema: instanceInfoOutput,
       annotations: { readOnlyHint: true },
     },
     async ({ domain }) => {
@@ -355,6 +429,7 @@ function registerGetInstanceInfoTool(mcpServer: McpServer, rateLimiter: RateLimi
         logger.info("Getting instance info", { domain: validDomain });
 
         const instanceInfo = await remoteClient.getInstanceInfo(validDomain);
+        const userCount = Number(instanceInfo.stats?.user_count);
 
         return {
           content: [
@@ -382,6 +457,14 @@ ${
 ${instanceInfo.contact_account ? `📞 Contact: @${sanitizeInline(instanceInfo.contact_account.username || "")} (${sanitizeInline(instanceInfo.contact_account.display_name || "") || "No display name"})` : ""}`,
             },
           ],
+          structuredContent: {
+            domain: instanceInfo.domain,
+            description: instanceInfo.description,
+            version: instanceInfo.version,
+            software: instanceInfo.software,
+            users: Number.isFinite(userCount) ? userCount : undefined,
+            registrationsOpen: instanceInfo.registrations,
+          },
         };
       } catch (error) {
         const errorMessage = getErrorMessage(error);
@@ -444,6 +527,7 @@ function registerDiscoverInstancesLiveTool(mcpServer: McpServer, rateLimiter: Ra
         sortOrder: z.enum(["asc", "desc"]).optional().describe("Sort order (default: desc)"),
         limit: z.number().min(1).max(50).optional().describe("Number of results (default: 20)"),
       },
+      outputSchema: instanceListOutput,
       annotations: { readOnlyHint: true },
     },
     async ({
@@ -551,6 +635,15 @@ ${instanceList}${hasMoreText}
 - Filter by \`software\`, \`language\`, or \`minUsers\` for more specific results`,
             },
           ],
+          structuredContent: {
+            instances: instances.map((instance) => ({
+              domain: instance.domain || "",
+              software: instance.software,
+              users: instance.users,
+              description: instance.description,
+            })),
+            hasMore: result.hasMore,
+          },
         };
       } catch (error) {
         const errorMessage = getErrorMessage(error);
@@ -596,6 +689,7 @@ function registerGetPostThreadTool(mcpServer: McpServer, rateLimiter: RateLimite
           .optional()
           .describe("Maximum number of replies to fetch (default: 50)"),
       },
+      outputSchema: threadOutput,
       annotations: { readOnlyHint: true },
     },
     async ({ postUrl, depth = 2, maxReplies = 50 }) => {
@@ -650,6 +744,23 @@ function registerGetPostThreadTool(mcpServer: McpServer, rateLimiter: RateLimite
                 )}${thread.replies.length > 10 ? `\n... and ${thread.replies.length - 10} more replies` : ""}`
             : "**No replies yet**";
 
+        // Map a thread post-like object to the PostItem shape. Mirrors the prose:
+        // content falls back to summary, and the CW is surfaced separately when a
+        // post carries both a summary and a body.
+        const toPostItem = (p: {
+          id: string;
+          url?: string;
+          content?: string;
+          summary?: string;
+          published?: string;
+        }) => ({
+          id: p.id,
+          url: p.url,
+          content: p.content || p.summary || "",
+          contentWarning: p.summary && p.content ? p.summary : undefined,
+          createdAt: p.published,
+        });
+
         return {
           content: [
             {
@@ -669,6 +780,11 @@ ${repliesSection}
 - Use \`fetch-timeline\` to see more posts from this user`,
             },
           ],
+          structuredContent: {
+            ancestors: thread.ancestors.map(toPostItem),
+            post: toPostItem(thread.post),
+            replies: thread.replies.map(toPostItem),
+          },
         };
       });
     },
@@ -695,6 +811,7 @@ function registerGetTrendingHashtagsTool(mcpServer: McpServer, rateLimiter: Rate
           .optional()
           .describe("Number of hashtags to fetch (default: 20)"),
       },
+      outputSchema: trendingHashtagsOutput,
       annotations: { readOnlyHint: true },
     },
     async ({ domain, limit = 20 }) => {
@@ -734,6 +851,20 @@ ${hashtagsList || "No trending hashtags found"}
 - Use \`get-public-timeline\` to see recent posts from this instance`,
               },
             ],
+            structuredContent: {
+              hashtags: result.hashtags.map((tag) => {
+                // uses/accounts are unvalidated remote strings — coerce to numbers
+                // (matching the prose), dropping the field when it isn't numeric.
+                const history = tag.history?.[0];
+                const uses = Number.parseInt(history?.uses ?? "", 10);
+                const accounts = Number.parseInt(history?.accounts ?? "", 10);
+                return {
+                  name: tag.name || "",
+                  uses: Number.isFinite(uses) ? uses : undefined,
+                  accounts: Number.isFinite(accounts) ? accounts : undefined,
+                };
+              }),
+            },
           };
         },
       );
@@ -761,6 +892,7 @@ function registerGetTrendingPostsTool(mcpServer: McpServer, rateLimiter: RateLim
           .optional()
           .describe("Number of posts to fetch (default: 20)"),
       },
+      outputSchema: postListOutput,
       annotations: { readOnlyHint: true },
     },
     async ({ domain, limit = 20 }) => {
@@ -804,6 +936,10 @@ ${postsList || "No trending posts found"}${moreText}
 - Use \`discover-actor\` to learn more about a post author`,
             },
           ],
+          structuredContent: {
+            posts: result.posts.map(mastodonStatusToPostItem),
+            source: validDomain,
+          },
         };
       });
     },
@@ -833,6 +969,7 @@ function registerGetPublicTimelineTool(mcpServer: McpServer, rateLimiter: RateLi
           .describe("Number of posts to fetch (default: 20)"),
         maxId: z.string().optional().describe("Return results older than this ID (for pagination)"),
       },
+      outputSchema: postListOutput,
       annotations: { readOnlyHint: true },
     },
     async ({ domain, scope = "federated", limit = 20, maxId }) => {
@@ -887,6 +1024,12 @@ ${postsList || "No posts found"}${paginationInfo}
 - Use \`get-trending-posts\` to see what's popular`,
             },
           ],
+          structuredContent: {
+            posts: result.posts.map(mastodonStatusToPostItem),
+            nextCursor: result.hasMore ? result.nextMaxId : undefined,
+            hasMore: result.hasMore,
+            source: validDomain,
+          },
         };
       } catch (error) {
         const errorMessage = getErrorMessage(error);
@@ -937,6 +1080,7 @@ function registerUnifiedSearchTool(mcpServer: McpServer, rateLimiter: RateLimite
           .optional()
           .describe("Number of results per type (default: 10)"),
       },
+      outputSchema: searchOutput,
       annotations: { readOnlyHint: true },
     },
     async ({ query, domain = "mastodon.social", type = "all", limit = 10 }) => {
@@ -949,6 +1093,12 @@ function registerUnifiedSearchTool(mcpServer: McpServer, rateLimiter: RateLimite
         logger.info("Unified search", { domain: validDomain, query: validQuery, type, limit });
 
         const sections: string[] = [];
+        // Structured mirror of the prose sections, built from the same arrays.
+        const structured: {
+          accounts?: Array<{ id: string }>;
+          statuses?: Array<{ id: string; content: string }>;
+          hashtags?: Array<{ name: string; url?: string }>;
+        } = {};
 
         // Search accounts if requested
         if (type === "all" || type === "accounts") {
@@ -969,6 +1119,12 @@ function registerUnifiedSearchTool(mcpServer: McpServer, rateLimiter: RateLimite
 
           const accounts = accountResults.accounts?.slice(0, limit) || [];
           if (accounts.length > 0) {
+            structured.accounts = accounts.map((acc) => ({
+              id: acc.acct || acc.username || "",
+              preferredUsername: acc.username,
+              name: acc.display_name,
+              summary: acc.note,
+            }));
             const accountsList = accounts
               .map((acc, i) => {
                 const note = wrapUntrusted(acc.note || "", `bio on ${validDomain}`);
@@ -1001,6 +1157,12 @@ function registerUnifiedSearchTool(mcpServer: McpServer, rateLimiter: RateLimite
 
           const posts = postResults.statuses?.slice(0, limit) || [];
           if (posts.length > 0) {
+            structured.statuses = posts.map((post) => ({
+              id: "",
+              author: post.account.acct,
+              content: post.content || "",
+              contentWarning: post.spoiler_text || undefined,
+            }));
             const postsList = posts
               .map((post, i) => {
                 const content = wrapUntrusted(post.content || "", `post on ${validDomain}`);
@@ -1033,6 +1195,7 @@ function registerUnifiedSearchTool(mcpServer: McpServer, rateLimiter: RateLimite
 
           const hashtags = hashtagResults.hashtags?.slice(0, limit) || [];
           if (hashtags.length > 0) {
+            structured.hashtags = hashtags.map((tag) => ({ name: tag.name || "" }));
             const hashtagsList = hashtags
               .map((tag, i) => {
                 const recentUses =
@@ -1066,6 +1229,7 @@ ${resultsText}
 - Use \`fetch-timeline\` to see an account's recent posts`,
             },
           ],
+          structuredContent: structured,
         };
       } catch (error) {
         const errorMessage = getErrorMessage(error);

--- a/tests/unit/mcp-tools-sdk-validation.test.ts
+++ b/tests/unit/mcp-tools-sdk-validation.test.ts
@@ -1,0 +1,294 @@
+/**
+ * Real-SDK output-validation smoke test (the safety net the Map-stub unit tests
+ * cannot provide).
+ *
+ * The other tool tests stub `registerTool` into a Map and call handlers directly,
+ * which bypasses the SDK's `validateToolOutput`. This test instantiates a REAL
+ * `McpServer`, registers the tools, and invokes each of the 18 default tools
+ * through the SDK request path via a `Client` over an in-memory transport. The
+ * SDK validates every success return's `structuredContent` against the tool's
+ * `outputSchema` — if a handler emits structuredContent that doesn't match its
+ * schema, the SDK turns the result into an "Output validation error" tool error,
+ * which this test asserts never happens.
+ */
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { RateLimiter } from "../../src/resilience/rate-limiter.js";
+
+// --- Data-layer mocks (same shapes the Map-stub unit tests use) ------------
+
+vi.mock("../../src/activitypub/remote-client.js", () => ({
+  remoteClient: {
+    fetchRemoteActor: vi.fn().mockResolvedValue({
+      id: "https://example.social/users/testuser",
+      preferredUsername: "testuser",
+      name: "Test User",
+      summary: "A test user",
+      url: "https://example.social/@testuser",
+      inbox: "https://example.social/users/testuser/inbox",
+      outbox: "https://example.social/users/testuser/outbox",
+      followers: "https://example.social/users/testuser/followers",
+      following: "https://example.social/users/testuser/following",
+    }),
+    fetchActorOutboxPaginated: vi.fn().mockResolvedValue({
+      items: [{ type: "Note", content: "Hello world", id: "1" }],
+      totalItems: 1,
+      collectionId: "https://example.social/users/testuser/outbox",
+      hasMore: true,
+      nextCursor: "cursor-123",
+    }),
+    searchInstance: vi.fn().mockResolvedValue({
+      accounts: [{ acct: "user", username: "user", display_name: "User", followers_count: 10 }],
+      statuses: [],
+      hashtags: [],
+    }),
+    getInstanceInfo: vi.fn().mockResolvedValue({
+      domain: "mastodon.social",
+      software: "mastodon",
+      version: "4.2.0",
+      description: "A social network",
+      languages: ["en"],
+      registrations: true,
+      approval_required: false,
+      stats: { user_count: 1000000, status_count: 50000000, domain_count: 30000 },
+    }),
+    fetchTrendingHashtags: vi.fn().mockResolvedValue({
+      hashtags: [{ name: "test", history: [{ uses: "100", accounts: "50" }] }],
+    }),
+    fetchTrendingPosts: vi.fn().mockResolvedValue({
+      posts: [
+        {
+          id: "tp-1",
+          content: "<p>Trending post</p>",
+          account: { username: "user", acct: "user", display_name: "User" },
+          favourites_count: 100,
+          reblogs_count: 50,
+          replies_count: 20,
+        },
+      ],
+    }),
+    fetchLocalTimeline: vi.fn().mockResolvedValue({ posts: [], hasMore: false }),
+    fetchFederatedTimeline: vi.fn().mockResolvedValue({
+      posts: [
+        {
+          id: "pt-1",
+          content: "<p>Federated post</p>",
+          spoiler_text: "",
+          account: { username: "remoteuser", acct: "remoteuser" },
+          favourites_count: 20,
+          reblogs_count: 10,
+          replies_count: 5,
+        },
+      ],
+      hasMore: true,
+      nextMaxId: "123",
+    }),
+    fetchPostThread: vi.fn().mockResolvedValue({
+      post: {
+        content: "Original post",
+        id: "1",
+        url: "https://example.social/1",
+        published: "2024-01-01",
+      },
+      ancestors: [],
+      replies: [{ content: "A reply", id: "2" }],
+      totalReplies: 1,
+    }),
+  },
+}));
+
+vi.mock("../../src/discovery/dynamic-instance-discovery.js", () => ({
+  dynamicInstanceDiscovery: {
+    searchInstances: vi.fn().mockResolvedValue({
+      instances: [{ domain: "test.social", users: 1000, software: "mastodon" }],
+      total: 1,
+      source: "api",
+      hasMore: false,
+    }),
+  },
+}));
+
+vi.mock("../../src/auth/index.js", () => ({
+  accountManager: {
+    listAccounts: vi.fn().mockReturnValue([
+      {
+        id: "1",
+        username: "testuser",
+        instance: "example.social",
+        isActive: true,
+        label: "Test",
+        scopes: ["read", "write"],
+      },
+    ]),
+    getActiveAccount: vi
+      .fn()
+      .mockReturnValue({ id: "1", username: "testuser", instance: "example.social" }),
+    getAccount: vi
+      .fn()
+      .mockReturnValue({ id: "1", username: "testuser", instance: "example.social" }),
+    setActiveAccount: vi.fn().mockReturnValue(true),
+    verifyAccount: vi.fn().mockResolvedValue({
+      id: "1",
+      username: "testuser",
+      acct: "testuser@example.social",
+      display_name: "Test User",
+      url: "https://example.social/@testuser",
+      followers_count: 100,
+      following_count: 50,
+      statuses_count: 200,
+    }),
+  },
+  authenticatedClient: {
+    hasAuthenticatedAccount: vi.fn().mockReturnValue(true),
+    getWriteStatus: vi.fn().mockReturnValue({
+      enabled: true,
+      activeAccount: { id: "1", username: "testuser", instance: "example.social" },
+    }),
+    getHomeTimeline: vi.fn().mockResolvedValue([
+      {
+        id: "post-1",
+        content: "<p>Hello world</p>",
+        spoiler_text: "",
+        favourites_count: 5,
+        reblogs_count: 2,
+        replies_count: 1,
+        account: { acct: "user@example.social" },
+      },
+    ]),
+    getNotifications: vi.fn().mockResolvedValue([
+      {
+        type: "mention",
+        account: { acct: "mentioner@example.social" },
+        status: { content: "<p>Hey @testuser</p>" },
+      },
+    ]),
+    getBookmarks: vi.fn().mockResolvedValue([
+      {
+        id: "bookmark-1",
+        content: "<p>Bookmarked post</p>",
+        account: { acct: "poster@example.social" },
+      },
+    ]),
+    getFavourites: vi.fn().mockResolvedValue([
+      {
+        id: "fav-1",
+        content: "<p>Favourited post</p>",
+        account: { acct: "poster@example.social" },
+      },
+    ]),
+    lookupAccount: vi
+      .fn()
+      .mockResolvedValue({ id: "target-123", acct: "targetuser@example.social" }),
+    getRelationship: vi.fn().mockResolvedValue({
+      following: true,
+      followed_by: false,
+      requested: false,
+      blocking: false,
+      blocked_by: false,
+      muting: false,
+      muting_notifications: false,
+      domain_blocking: false,
+      endorsed: false,
+      note: "",
+    }),
+    getScheduledPosts: vi.fn().mockResolvedValue([
+      {
+        id: "scheduled-1",
+        scheduled_at: "2099-12-25T10:00:00Z",
+        params: { text: "Scheduled post content", visibility: "public" },
+        media_attachments: [],
+      },
+    ]),
+  },
+}));
+
+vi.mock("../../src/audit/logger.js", () => ({
+  auditLogger: { logToolInvocation: vi.fn() },
+}));
+
+vi.mock("@logtape/logtape", () => ({
+  getLogger: vi.fn().mockReturnValue({
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+import { registerTools } from "../../src/mcp/tools.js";
+
+// The 18 default tools and an argument set that reaches each success path.
+const DEFAULT_TOOL_CALLS: Array<{ name: string; args: Record<string, unknown> }> = [
+  { name: "discover-actor", args: { identifier: "testuser@example.social" } },
+  { name: "fetch-timeline", args: { identifier: "testuser@example.social", limit: 20 } },
+  { name: "get-post-thread", args: { postUrl: "https://example.social/@user/123" } },
+  { name: "search", args: { query: "test" } },
+  { name: "get-trending-hashtags", args: { domain: "mastodon.social", limit: 10 } },
+  { name: "get-trending-posts", args: { domain: "mastodon.social" } },
+  { name: "get-public-timeline", args: { domain: "mastodon.social", scope: "federated" } },
+  { name: "get-instance-info", args: { domain: "mastodon.social" } },
+  { name: "discover-instances", args: { limit: 10 } },
+  { name: "list-accounts", args: {} },
+  { name: "switch-account", args: { accountId: "1" } },
+  { name: "verify-account", args: {} },
+  { name: "get-home-timeline", args: {} },
+  { name: "get-notifications", args: {} },
+  { name: "get-bookmarks", args: {} },
+  { name: "get-favourites", args: {} },
+  { name: "get-relationship", args: { acct: "targetuser@example.social" } },
+  { name: "get-scheduled-posts", args: {} },
+];
+
+describe("real SDK output validation (default tools)", () => {
+  let server: McpServer;
+  let client: Client;
+  let rateLimiter: RateLimiter;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    server = new McpServer({ name: "activitypub-mcp-test", version: "0.0.0" });
+    rateLimiter = new RateLimiter({ enabled: false, maxRequests: 1000, windowMs: 60000 });
+    // Writes are OFF (default) → only the 18 default tools register.
+    registerTools(server, rateLimiter);
+
+    client = new Client({ name: "test-client", version: "0.0.0" });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await Promise.all([client.connect(clientTransport), server.connect(serverTransport)]);
+  });
+
+  afterEach(async () => {
+    rateLimiter.stop();
+    await client.close();
+    await server.close();
+  });
+
+  it("registers exactly the 18 default tools when writes are off", async () => {
+    const { tools } = await client.listTools();
+    const names = tools.map((t) => t.name).sort();
+    expect(tools.length).toBe(18);
+    expect(names).toEqual(DEFAULT_TOOL_CALLS.map((c) => c.name).sort());
+  });
+
+  it("every default tool returns SDK-valid structuredContent (no output-validation error)", async () => {
+    for (const { name, args } of DEFAULT_TOOL_CALLS) {
+      const result = (await client.callTool({ name, arguments: args })) as {
+        isError?: boolean;
+        structuredContent?: unknown;
+        content?: Array<{ type: string; text?: string }>;
+      };
+
+      const firstText = result.content?.[0]?.text ?? "";
+      // The SDK converts an outputSchema mismatch into a tool error whose text
+      // begins with "Output validation error". That must never happen.
+      expect(firstText, `tool ${name} must not fail SDK output validation`).not.toContain(
+        "Output validation error",
+      );
+      expect(result.isError, `tool ${name} must succeed`).toBeFalsy();
+      // A declared outputSchema means the SDK also requires structuredContent.
+      expect(result.structuredContent, `tool ${name} must emit structuredContent`).toBeDefined();
+    }
+  });
+});

--- a/tests/unit/mcp-tools-write.test.ts
+++ b/tests/unit/mcp-tools-write.test.ts
@@ -287,6 +287,14 @@ describe("MCP Write Tools", () => {
         "Configured Accounts",
       );
       expect(accountManager.listAccounts).toHaveBeenCalled();
+      expect(
+        (
+          result as {
+            structuredContent: { accounts: { username: string }[]; writeEnabled: boolean };
+          }
+        ).structuredContent.accounts[0].username,
+      ).toBe("testuser");
+      expect((tool?.config as { outputSchema?: unknown }).outputSchema).toBeDefined();
     });
 
     it("should show no accounts message when empty", async () => {
@@ -298,6 +306,11 @@ describe("MCP Write Tools", () => {
       expect((result as { content: { text: string }[] }).content[0].text).toContain(
         "No Accounts Configured",
       );
+      // Empty edge branch must still emit a valid structuredContent.
+      expect(
+        (result as { structuredContent: { accounts: unknown[]; writeEnabled: boolean } })
+          .structuredContent,
+      ).toEqual({ accounts: [], writeEnabled: false });
     });
   });
 
@@ -310,6 +323,11 @@ describe("MCP Write Tools", () => {
         "Account Switched",
       );
       expect(accountManager.setActiveAccount).toHaveBeenCalledWith("1");
+      expect(
+        (result as { structuredContent: { accountId: string; active?: boolean } })
+          .structuredContent,
+      ).toMatchObject({ accountId: "1", active: true });
+      expect((tool?.config as { outputSchema?: unknown }).outputSchema).toBeDefined();
     });
 
     it("should handle account not found", async () => {
@@ -345,6 +363,11 @@ describe("MCP Write Tools", () => {
         "Account Verified",
       );
       expect(accountManager.verifyAccount).toHaveBeenCalled();
+      expect(
+        (result as { structuredContent: { verified?: boolean; username?: string } })
+          .structuredContent,
+      ).toMatchObject({ verified: true, username: "testuser" });
+      expect((tool?.config as { outputSchema?: unknown }).outputSchema).toBeDefined();
     });
 
     it("should handle write not enabled", async () => {
@@ -617,6 +640,11 @@ describe("MCP Write Tools", () => {
         "Home Timeline",
       );
       expect(authenticatedClient.getHomeTimeline).toHaveBeenCalled();
+      expect(
+        (result as { structuredContent: { posts: { id: string; author?: string }[] } })
+          .structuredContent.posts[0],
+      ).toMatchObject({ id: "post-1", author: "user@example.social" });
+      expect((tool?.config as { outputSchema?: unknown }).outputSchema).toBeDefined();
     });
   });
 
@@ -629,6 +657,11 @@ describe("MCP Write Tools", () => {
         "Notifications",
       );
       expect(authenticatedClient.getNotifications).toHaveBeenCalled();
+      expect(
+        (result as { structuredContent: { notifications: { type: string }[] } }).structuredContent
+          .notifications[0].type,
+      ).toBe("mention");
+      expect((tool?.config as { outputSchema?: unknown }).outputSchema).toBeDefined();
     });
   });
 
@@ -639,6 +672,11 @@ describe("MCP Write Tools", () => {
 
       expect((result as { content: { text: string }[] }).content[0].text).toContain("Bookmarks");
       expect(authenticatedClient.getBookmarks).toHaveBeenCalled();
+      expect(
+        (result as { structuredContent: { posts: { id: string }[] } }).structuredContent.posts[0]
+          .id,
+      ).toBe("bookmark-1");
+      expect((tool?.config as { outputSchema?: unknown }).outputSchema).toBeDefined();
     });
   });
 
@@ -649,6 +687,11 @@ describe("MCP Write Tools", () => {
 
       expect((result as { content: { text: string }[] }).content[0].text).toContain("Favourites");
       expect(authenticatedClient.getFavourites).toHaveBeenCalled();
+      expect(
+        (result as { structuredContent: { posts: { id: string }[] } }).structuredContent.posts[0]
+          .id,
+      ).toBe("fav-1");
+      expect((tool?.config as { outputSchema?: unknown }).outputSchema).toBeDefined();
     });
   });
 
@@ -660,6 +703,10 @@ describe("MCP Write Tools", () => {
       expect((result as { content: { text: string }[] }).content[0].text).toContain("Relationship");
       expect(authenticatedClient.lookupAccount).toHaveBeenCalled();
       expect(authenticatedClient.getRelationship).toHaveBeenCalled();
+      expect(
+        (result as { structuredContent: { acct: string; following?: boolean } }).structuredContent,
+      ).toMatchObject({ acct: "targetuser@example.social", following: true });
+      expect((tool?.config as { outputSchema?: unknown }).outputSchema).toBeDefined();
     });
   });
 
@@ -817,6 +864,12 @@ describe("MCP Write Tools", () => {
         "Scheduled Posts",
       );
       expect(authenticatedClient.getScheduledPosts).toHaveBeenCalled();
+      // Empty edge branch must still emit a valid structuredContent.
+      expect(
+        (result as { structuredContent: { scheduledPosts: unknown[] } }).structuredContent
+          .scheduledPosts,
+      ).toEqual([]);
+      expect((tool?.config as { outputSchema?: unknown }).outputSchema).toBeDefined();
     });
 
     it("should list scheduled posts when present", async () => {
@@ -836,6 +889,10 @@ describe("MCP Write Tools", () => {
         "Scheduled Posts",
       );
       expect((result as { content: { text: string }[] }).content[0].text).toContain("scheduled-1");
+      expect(
+        (result as { structuredContent: { scheduledPosts: { id: string; text?: string }[] } })
+          .structuredContent.scheduledPosts[0],
+      ).toMatchObject({ id: "scheduled-1", text: "Scheduled post content" });
     });
   });
 
@@ -1334,6 +1391,20 @@ describe("MCP Write Tools", () => {
       const tool = registeredTools.get("get-relationship");
       const result = await tool?.handler({ acct: "user@example.social" });
       expect(result).toBeDefined();
+    });
+
+    it("describes the deprecated accountIds decoy param (param coverage)", () => {
+      // Smithery scores parameter-description coverage; the accountIds decoy is
+      // the sole param that was missing a .describe(). Its JSON-Schema must now
+      // surface a description keyword.
+      const tool = registeredTools.get("get-relationship");
+      const inputSchemaShape = (
+        tool?.config as { inputSchema: Record<string, import("zod").ZodTypeAny> }
+      ).inputSchema;
+      const jsonSchema = z.toJSONSchema(z.object(inputSchemaShape), { io: "input" }) as {
+        properties?: Record<string, { description?: string }>;
+      };
+      expect(jsonSchema.properties?.accountIds?.description).toMatch(/deprecated|not supported/i);
     });
   });
 

--- a/tests/unit/mcp-tools.test.ts
+++ b/tests/unit/mcp-tools.test.ts
@@ -136,6 +136,12 @@ describe("MCP Tools", () => {
         "Successfully discovered actor",
       );
       expect(remoteClient.fetchRemoteActor).toHaveBeenCalledWith("testuser@example.social");
+      // Dual-emit: structured output mirrors the prose, and the config declares an outputSchema.
+      expect(
+        (result as { structuredContent: { actor: { preferredUsername: string } } })
+          .structuredContent.actor.preferredUsername,
+      ).toBe("testuser");
+      expect((tool?.config as { outputSchema?: unknown }).outputSchema).toBeDefined();
     });
 
     it("should handle errors gracefully", async () => {
@@ -233,6 +239,11 @@ describe("MCP Tools", () => {
       expect((result as { content: { text: string }[] }).content[0].text).toContain(
         "Next page cursor",
       );
+      expect(
+        (result as { structuredContent: { posts: { content: string }[]; nextCursor?: string } })
+          .structuredContent.posts[0].content,
+      ).toContain("Hello world");
+      expect((tool?.config as { outputSchema?: unknown }).outputSchema).toBeDefined();
     });
 
     it("should handle empty timeline", async () => {
@@ -249,6 +260,10 @@ describe("MCP Tools", () => {
       expect((result as { content: { text: string }[] }).content[0].text).toContain(
         "Posts retrieved: 0",
       );
+      // Empty edge branch must still emit a valid structuredContent.
+      expect(
+        (result as { structuredContent: { posts: unknown[] } }).structuredContent.posts,
+      ).toEqual([]);
     });
   });
 
@@ -282,6 +297,11 @@ describe("MCP Tools", () => {
       expect((result as { content: { text: string }[] }).content[0].text).toContain(
         "mastodon.social",
       );
+      expect(
+        (result as { structuredContent: { domain: string; software?: string } }).structuredContent
+          .domain,
+      ).toBe("mastodon.social");
+      expect((tool?.config as { outputSchema?: unknown }).outputSchema).toBeDefined();
     });
   });
 
@@ -294,6 +314,11 @@ describe("MCP Tools", () => {
         "Live Instance Discovery",
       );
       expect(dynamicInstanceDiscovery.searchInstances).toHaveBeenCalled();
+      expect(
+        (result as { structuredContent: { instances: { domain: string }[] } }).structuredContent
+          .instances[0].domain,
+      ).toBe("test.social");
+      expect((tool?.config as { outputSchema?: unknown }).outputSchema).toBeDefined();
     });
 
     it("neutralizes a newline+markdown injection in a remote instance software/domain field", async () => {
@@ -336,6 +361,11 @@ describe("MCP Tools", () => {
 
       expect((result as { content: { text: string }[] }).content[0].text).toContain("Post Thread");
       expect(remoteClient.fetchPostThread).toHaveBeenCalled();
+      expect(
+        (result as { structuredContent: { post: { content: string } } }).structuredContent.post
+          .content,
+      ).toContain("Original post");
+      expect((tool?.config as { outputSchema?: unknown }).outputSchema).toBeDefined();
     });
 
     it("neutralizes a prompt-injection payload in the post URL field", async () => {
@@ -378,6 +408,11 @@ describe("MCP Tools", () => {
         "Trending Hashtags",
       );
       expect((result as { content: { text: string }[] }).content[0].text).toContain("#test");
+      expect(
+        (result as { structuredContent: { hashtags: { name: string; uses?: number }[] } })
+          .structuredContent.hashtags[0],
+      ).toMatchObject({ name: "test", uses: 100 });
+      expect((tool?.config as { outputSchema?: unknown }).outputSchema).toBeDefined();
     });
 
     it("coerces injected hashtag use/account counts to numbers", async () => {
@@ -414,6 +449,11 @@ describe("MCP Tools", () => {
       expect((result as { content: { text: string }[] }).content[0].text).toContain(
         "Trending Posts",
       );
+      expect(
+        (result as { structuredContent: { posts: { content: string }[] } }).structuredContent
+          .posts[0].content,
+      ).toContain("Trending post");
+      expect((tool?.config as { outputSchema?: unknown }).outputSchema).toBeDefined();
     });
   });
 
@@ -459,6 +499,14 @@ describe("MCP Tools", () => {
       );
       expect((result as { content: { text: string }[] }).content[0].text).toContain("localuser");
       expect((result as { content: { text: string }[] }).content[0].text).toContain("123");
+      expect(
+        (result as { structuredContent: { posts: { author?: string }[]; nextCursor?: string } })
+          .structuredContent.posts[0].author,
+      ).toBe("localuser");
+      expect(
+        (result as { structuredContent: { nextCursor?: string } }).structuredContent.nextCursor,
+      ).toBe("123");
+      expect((tool?.config as { outputSchema?: unknown }).outputSchema).toBeDefined();
     });
 
     it("should fetch federated timeline when scope is federated", async () => {
@@ -547,6 +595,11 @@ describe("MCP Tools", () => {
       expect((result as { content: { text: string }[] }).content[0].text).toContain(
         "Search Results",
       );
+      expect(
+        (result as { structuredContent: { accounts?: { id: string }[] } }).structuredContent
+          .accounts?.[0].id,
+      ).toBe("user");
+      expect((tool?.config as { outputSchema?: unknown }).outputSchema).toBeDefined();
     });
   });
 

--- a/tests/unit/output-schemas.test.ts
+++ b/tests/unit/output-schemas.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Tests for the default-tool output schemas.
+ *
+ * Each schema is a Zod RAW SHAPE (the form MCP `outputSchema` expects). We wrap
+ * it in `z.object(...)` to exercise parsing: a valid object must pass, and an
+ * object missing a required field must fail. This guards the schema contract the
+ * SDK enforces against `structuredContent` at runtime.
+ */
+
+import { describe, expect, it } from "vitest";
+import { type ZodRawShape, z } from "zod";
+import {
+  accountListOutput,
+  accountStatusOutput,
+  discoverActorOutput,
+  instanceInfoOutput,
+  instanceListOutput,
+  notificationsOutput,
+  postListOutput,
+  relationshipOutput,
+  scheduledPostsOutput,
+  searchOutput,
+  threadOutput,
+  trendingHashtagsOutput,
+} from "../../src/mcp/output-schemas.js";
+
+const parse = (shape: ZodRawShape, value: unknown) => z.object(shape).parse(value);
+const fails = (shape: ZodRawShape, value: unknown) => () => z.object(shape).parse(value);
+
+describe("output schemas", () => {
+  it("discoverActorOutput accepts a valid actor and rejects a missing actor id", () => {
+    expect(parse(discoverActorOutput, { actor: { id: "https://x/users/a" } })).toBeDefined();
+    expect(fails(discoverActorOutput, { actor: {} })).toThrow();
+  });
+
+  it("postListOutput accepts a post list (incl. empty) and rejects a post missing id", () => {
+    expect(parse(postListOutput, { posts: [] })).toBeDefined();
+    expect(parse(postListOutput, { posts: [{ id: "1", content: "hi" }] })).toBeDefined();
+    expect(fails(postListOutput, { posts: [{ content: "hi" }] })).toThrow();
+  });
+
+  it("threadOutput accepts a thread and rejects a missing main post", () => {
+    expect(
+      parse(threadOutput, {
+        ancestors: [],
+        post: { id: "1", content: "main" },
+        replies: [],
+      }),
+    ).toBeDefined();
+    expect(fails(threadOutput, { ancestors: [], replies: [] })).toThrow();
+  });
+
+  it("searchOutput accepts partial sections and rejects a malformed account", () => {
+    expect(parse(searchOutput, {})).toBeDefined();
+    expect(parse(searchOutput, { accounts: [{ id: "1" }], statuses: [] })).toBeDefined();
+    expect(fails(searchOutput, { accounts: [{ preferredUsername: "x" }] })).toThrow();
+  });
+
+  it("instanceInfoOutput accepts a domain and rejects a missing domain", () => {
+    expect(parse(instanceInfoOutput, { domain: "x.social" })).toBeDefined();
+    expect(fails(instanceInfoOutput, { title: "no domain" })).toThrow();
+  });
+
+  it("instanceListOutput accepts instances and rejects a missing domain", () => {
+    expect(parse(instanceListOutput, { instances: [{ domain: "x.social" }] })).toBeDefined();
+    expect(fails(instanceListOutput, { instances: [{ software: "mastodon" }] })).toThrow();
+  });
+
+  it("trendingHashtagsOutput accepts hashtags and rejects a missing name", () => {
+    expect(parse(trendingHashtagsOutput, { hashtags: [{ name: "tag" }] })).toBeDefined();
+    expect(fails(trendingHashtagsOutput, { hashtags: [{ uses: 1 }] })).toThrow();
+  });
+
+  it("accountListOutput accepts accounts and rejects a missing writeEnabled", () => {
+    expect(
+      parse(accountListOutput, {
+        accounts: [
+          { id: "1", username: "u", instance: "x.social", isActive: true, scopes: ["read"] },
+        ],
+        writeEnabled: true,
+      }),
+    ).toBeDefined();
+    expect(parse(accountListOutput, { accounts: [], writeEnabled: false })).toBeDefined();
+    expect(fails(accountListOutput, { accounts: [] })).toThrow();
+  });
+
+  it("accountStatusOutput accepts a status object (all optional)", () => {
+    expect(parse(accountStatusOutput, { accountId: "1", active: true })).toBeDefined();
+    expect(parse(accountStatusOutput, {})).toBeDefined();
+  });
+
+  it("notificationsOutput accepts notifications and rejects one missing type", () => {
+    expect(
+      parse(notificationsOutput, { notifications: [{ id: "1", type: "mention" }] }),
+    ).toBeDefined();
+    expect(parse(notificationsOutput, { notifications: [] })).toBeDefined();
+    expect(fails(notificationsOutput, { notifications: [{ id: "1" }] })).toThrow();
+  });
+
+  it("relationshipOutput accepts an acct and rejects a missing acct", () => {
+    expect(parse(relationshipOutput, { acct: "u@x.social", following: true })).toBeDefined();
+    expect(fails(relationshipOutput, { following: true })).toThrow();
+  });
+
+  it("scheduledPostsOutput accepts scheduled posts and rejects a missing scheduledAt", () => {
+    expect(
+      parse(scheduledPostsOutput, {
+        scheduledPosts: [{ id: "1", scheduledAt: "2099-01-01T00:00:00Z" }],
+      }),
+    ).toBeDefined();
+    expect(parse(scheduledPostsOutput, { scheduledPosts: [] })).toBeDefined();
+    expect(fails(scheduledPostsOutput, { scheduledPosts: [{ id: "1" }] })).toThrow();
+  });
+});

--- a/tests/unit/release-mcpb-asset.test.ts
+++ b/tests/unit/release-mcpb-asset.test.ts
@@ -9,13 +9,55 @@ import { describe, expect, it } from "vitest";
  * this asset on the *latest* release; v3.1.0 shipped without it because the
  * bundle was a one-off manual build that the release workflow never produced.
  * This test fails CI if the workflow stops building or attaching it.
+ *
+ * The bundle is now built with a plain `zip` (a .mcpb IS a zip with manifest.json
+ * at root) after injecting the live tool schemas, deliberately NOT `mcpb pack` —
+ * `mcpb validate`/`pack` strip the `inputSchema`/`outputSchema` keys Smithery
+ * scores. These tests enforce that durable pipeline.
  */
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 const releaseYml = readFileSync(path.join(ROOT, ".github/workflows/release.yml"), "utf-8");
 
 describe("release workflow ships the .mcpb bundle", () => {
-  it("builds the .mcpb bundle", () => {
-    expect(releaseYml).toMatch(/mcpb pack/);
+  it("builds the .mcpb bundle as a plain zip with manifest.json at root", () => {
+    // A .mcpb is a zip; plain zipping preserves the tool inputSchema/outputSchema
+    // that `mcpb pack` would strip.
+    expect(releaseYml).toMatch(/zip -r .*-X .*\.mcpb/);
+    expect(releaseYml).toMatch(/manifest\.json/);
+  });
+
+  it("bundles node_modules so the ESM entrypoint runs standalone", () => {
+    // The server's runtime deps must ship inside the .mcpb (Claude Desktop
+    // one-click install + Smithery's local run) — zipping only dist would
+    // produce a bundle that fails on missing dependencies.
+    const zipLine = releaseYml.split("\n").find((l) => /zip -r .*\.mcpb/.test(l));
+    expect(zipLine).toBeDefined();
+    expect(zipLine).toMatch(/node_modules/);
+  });
+
+  it("injects the live tool manifest before packaging", () => {
+    // The schemas Smithery scores are captured from the running server, not parsed
+    // from source — see scripts/inject-tools-manifest.js.
+    expect(releaseYml).toMatch(/inject-tools-manifest\.js/);
+  });
+
+  it("does NOT use mcpb pack/validate (which strips inputSchema/outputSchema)", () => {
+    // Inspect only command lines (ignore explanatory `#` comments that may name
+    // the removed tooling to explain why it's gone).
+    const commandLines = releaseYml
+      .split("\n")
+      .map((l) => l.trim())
+      .filter((l) => l.length > 0 && !l.startsWith("#"));
+    for (const line of commandLines) {
+      expect(line, "no mcpb pack command").not.toMatch(/mcpb pack/);
+      expect(line, "no mcpb validate command").not.toMatch(/mcpb validate/);
+      expect(line, "no mcpb global install").not.toMatch(/npm install -g @anthropic-ai\/mcpb/);
+    }
+  });
+
+  it("gates the bundle on at least 18 tools being present in the manifest", () => {
+    // A registration regression that drops a tool must break the release loudly.
+    expect(releaseYml).toMatch(/m\.tools\.length\s*<\s*18/);
   });
 
   it("attaches a versioned .mcpb asset to the GitHub release", () => {
@@ -28,18 +70,6 @@ describe("release workflow ships the .mcpb bundle", () => {
     expect(releaseYml).toMatch(
       /activitypub-mcp-\$\{\{\s*steps\.get_version\.outputs\.VERSION\s*\}\}\.tgz/,
     );
-  });
-
-  it("installs the mcpb builder version-pinned and with --ignore-scripts (no supply-chain RCE)", () => {
-    // The .mcpb is one-click-installed into Claude Desktop, and this job holds a
-    // contents:write token, so an unpinned mcpb (or its install scripts) is an
-    // RCE/tamper vector — exactly what publish-mcp.yml already pins against.
-    const installLine = releaseYml
-      .split("\n")
-      .find((l) => l.includes("npm install -g @anthropic-ai/mcpb"));
-    expect(installLine, "mcpb install line").toBeDefined();
-    expect(installLine).toMatch(/@anthropic-ai\/mcpb@\d+\.\d+\.\d+/); // exact version pin
-    expect(installLine).toContain("--ignore-scripts");
   });
 
   it("does not grant the unused packages:write permission", () => {


### PR DESCRIPTION
Ships v3.2.0: type-checkable structured tool output, plus durable Smithery capability metadata.

## What

- **Structured tool results** — all 18 read/default tools now declare an `outputSchema` and return `structuredContent` alongside the unchanged prose text. Existing clients are unaffected (text is byte-identical); new clients can type-check responses.
- **Durable `.mcpb` manifest** — the release now injects live tool schemas (name/description/inputSchema/outputSchema) into the bundle manifest by querying the running server and plain-zipping (`mcpb pack` strips those keys). This is the metadata Smithery reads to score capability. The bundle still ships its prod `node_modules` so it runs standalone, and CI gates on the expected tool count.
- **Smithery listing** — homepage ownership verification (a meta tag, since `github.io` can't host DNS TXT records) + a README/footer backlink.
- **Param fix** — `get-relationship`'s `accountIds` guard parameter is now described, completing parameter-description coverage.

## Smithery impact (already verified live on the listing)

- Output schemas: **0/18 → 18/18**
- Parameter descriptions: **17/18 → 18/18** (49/49 params)

## Testing

- **948 unit tests pass** (+33), including a new real-`McpServer` test that runs the SDK's `validateToolOutput` against `structuredContent` for every default tool.
- `typecheck` + `lint` clean.

No breaking changes — tool names and text responses are unchanged. Merging triggers the auto-release (npm + GitHub release + MCP registry) via the new durable pipeline.