### PR TITLE
v3.2.1: undici security patch + dependency maintenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.2.1] - 2026-06-22
+
+Dependency maintenance and security patch release. No source or API changes —
+tool names, schemas, and human-readable responses are identical to 3.2.0.
+
+### Security
+
+- **undici 7.26.0 → 7.28.0** — clears a HIGH-severity advisory chain affecting
+  undici `<= 7.27.2`, the HTTP client behind every Fediverse fetch: TLS
+  certificate-validation bypass via dropped `requestTls` in the SOCKS5
+  ProxyAgent (GHSA-vmh5-mc38-953g), shared-cache cross-user information
+  disclosure (GHSA-pr7r-676h-xcf6), `Set-Cookie` percent-decoding header
+  injection (GHSA-p88m-4jfj-68fv), WebSocket fragment-count denial of service
+  (GHSA-vxpw-j846-p89q), SOCKS5 proxy-pool cross-origin routing
+  (GHSA-hm92-r4w5-c3mj), keep-alive response-queue poisoning
+  (GHSA-35p6-xmwp-9g52), and `SameSite` attribute downgrade (GHSA-g8m3-5g58-fq7m).
+  Stayed on the 7.x line because undici 8 requires Node ≥ 22.19, while this
+  package still supports Node ≥ 20.
+
+### Changed
+
+- **Dependency maintenance** — refreshed transitive and dev/build dependencies
+  (`content-disposition`, `hasown`, `astro`, `tldts-core`, `@clack/prompts`,
+  `@emnapi/runtime`, and the `@csstools/*` tooling) and pinned CI actions
+  (`actions/checkout` 7, `softprops/action-gh-release`) to their latest patches.
+
 ## [3.2.0] - 2026-06-16
 
 Structured tool output and Smithery listing improvements. No breaking changes —

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.2",
   "name": "activitypub-mcp",
   "display_name": "ActivityPub MCP",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Read-only-by-default MCP server: let LLMs explore the Fediverse — Mastodon, Misskey, Pleroma.",
   "long_description": "Lets an LLM explore and interact with the existing Fediverse — Mastodon, Misskey, Foundkey, Pleroma, and compatible servers. Read-only by default; write tools are opt-in. Untrusted fediverse content is wrapped in an <untrusted-content> envelope before it reaches the model.",
   "author": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "activitypub-mcp",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "activitypub-mcp",
-      "version": "3.2.0",
+      "version": "3.2.1",
       "license": "MIT",
       "dependencies": {
         "@logtape/logtape": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activitypub-mcp",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Model Context Protocol (MCP) server for the Fediverse — let Claude and other LLMs explore and post to Mastodon, Misskey, and Pleroma. Read-only by default.",
   "mcpName": "io.github.cameronrye/activitypub-mcp",
   "main": "dist/mcp-main.js",

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -116,7 +116,7 @@ Upgrading from v1.x? See [MIGRATION-v2.md](https://github.com/cameronrye/activit
 
 ---
 
-**Version:** 3.2.0
+**Version:** 3.2.1
 **License:** MIT
 **Maintainer:** Cameron Rye (https://rye.dev/)
 **Repository:** https://github.com/cameronrye/activitypub-mcp

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.cameronrye/activitypub-mcp",
   "description": "Read-only-by-default MCP server: let LLMs explore the Fediverse — Mastodon, Misskey, Pleroma.",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "repository": {
     "url": "https://github.com/cameronrye/activitypub-mcp",
     "source": "github"
@@ -12,7 +12,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "activitypub-mcp",
-      "version": "3.2.0",
+      "version": "3.2.1",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/site/src/content/docs/reference/changelog.mdx
+++ b/site/src/content/docs/reference/changelog.mdx
@@ -9,6 +9,18 @@ order: 2
 
 All notable changes to the ActivityPub MCP Server are documented here. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### v3.2.1 - 2026-06-22
+
+**Dependency maintenance and security patch.** No source or API changes — tool names, schemas, and responses are identical to 3.2.0. See [CHANGELOG.md](https://github.com/cameronrye/activitypub-mcp/blob/main/CHANGELOG.md) for the complete entry.
+
+#### Security
+
+- **undici 7.26.0 → 7.28.0** — clears a HIGH-severity advisory chain affecting undici `<= 7.27.2` (the HTTP client behind every Fediverse fetch): TLS certificate-validation bypass, shared-cache information disclosure, `Set-Cookie` header injection, WebSocket denial of service, and SOCKS5 proxy-routing issues. Stayed on the 7.x line because undici 8 requires Node ≥ 22.19 while this server supports Node ≥ 20.
+
+#### Changed
+
+- **Dependency maintenance** — refreshed transitive and dev/build dependencies and pinned CI actions (`actions/checkout` 7, `softprops/action-gh-release`) to their latest patches.
+
 ### v3.2.0 - 2026-06-16
 
 **Structured tool output and Smithery listing improvements.** No breaking changes — tool names and human-readable responses are unchanged; structured output is purely additive. See [CHANGELOG.md](https://github.com/cameronrye/activitypub-mcp/blob/main/CHANGELOG.md) for the complete entry.

--- a/src/config.ts
+++ b/src/config.ts
@@ -90,7 +90,7 @@ function parseBoolEnv(value: string | undefined, defaultValue: boolean): boolean
 export const SERVER_NAME = process.env.MCP_SERVER_NAME || "activitypub-mcp";
 
 /** MCP Server version */
-export const SERVER_VERSION = process.env.MCP_SERVER_VERSION || "3.2.0";
+export const SERVER_VERSION = process.env.MCP_SERVER_VERSION || "3.2.1";
 
 /**
  * Directory for the persisted credential store (accounts.json).


### PR DESCRIPTION
## Summary

Patch release driven by a **HIGH-severity undici advisory chain** affecting `undici <= 7.27.2` (the HTTP client behind every Fediverse fetch). undici was bumped 7.26.0 → 7.28.0 (#190), clearing:

- TLS certificate-validation bypass via dropped `requestTls` in the SOCKS5 ProxyAgent (GHSA-vmh5-mc38-953g)
- shared-cache cross-user information disclosure (GHSA-pr7r-676h-xcf6)
- `Set-Cookie` percent-decoding header injection (GHSA-p88m-4jfj-68fv)
- WebSocket fragment-count DoS (GHSA-vxpw-j846-p89q)
- SOCKS5 proxy-pool cross-origin routing (GHSA-hm92-r4w5-c3mj)
- keep-alive response-queue poisoning (GHSA-35p6-xmwp-9g52)
- `SameSite` attribute downgrade (GHSA-g8m3-5g58-fq7m)

Held on the undici **7.x** line because 8.x requires Node ≥ 22.19 while this package supports Node ≥ 20 (#199 closed for that reason).

Also folds in the batch of transitive/dev dependency refreshes and CI-action pins merged since 3.2.0 (#191–#198, #200, #201).

## Release contents
- Version bumped 3.2.0 → 3.2.1 across all 8 stamp files (`validate:version` green)
- Production `npm audit --omit=dev --audit-level=high`: **0 vulnerabilities**
- 948/948 unit tests green; typecheck, lint, format, build all pass locally

Merging this triggers the auto-release pipeline (npm + GitHub release + MCP registry).