### PR TITLE
ci: auto-publish to Smithery on release

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -197,3 +197,20 @@ jobs:
     # No `secrets: inherit`: this job authenticates via OIDC (id-token) only and
     # references no named secret, so it must not receive NPM_TOKEN/other secrets —
     # that keeps them out of the blast radius of the downloaded mcp-publisher.
+
+  # Refresh the Smithery listing from the same .mcpb the release attached. Runs
+  # in parallel with publish-mcp (both only need the release). Smithery has no
+  # OIDC path, so this is the one publish that takes a stored secret — passed
+  # EXPLICITLY (not `secrets: inherit`) so only SMITHERY_API_KEY, and nothing
+  # like NPM_TOKEN, reaches the third-party CLI. No-ops if the secret is unset.
+  publish-smithery:
+    name: Publish to Smithery
+    needs: [check-version, release]
+    if: needs.check-version.outputs.should_release == 'true'
+    permissions:
+      contents: read
+    uses: ./.github/workflows/publish-smithery.yml
+    with:
+      version: ${{ needs.check-version.outputs.version }}
+    secrets:
+      SMITHERY_API_KEY: ${{ secrets.SMITHERY_API_KEY }}

--- a/.github/workflows/publish-smithery.yml
+++ b/.github/workflows/publish-smithery.yml
@@ -1,0 +1,100 @@
+name: Publish to Smithery
+
+# Publishes the release's .mcpb bundle to the Smithery listing
+# (smithery.ai/server/rye/activitypub-mcp).
+#
+# Why a stored secret here (when npm + the MCP registry use OIDC): the
+# @smithery/cli has NO OIDC / trusted-publishing path — auth is a bearer token
+# read from $SMITHERY_API_KEY (there is not even a --key flag). So Smithery is
+# the one channel that needs a secret. Mint a SCOPED, TTL-limited service token
+# (smithery.ai/account/api-keys, or `smithery auth token`), NOT the raw account
+# key, and add it as the repo Actions secret SMITHERY_API_KEY.
+#
+# Without the secret this job logs a notice and no-ops — forks and secret-less
+# runs stay green rather than hanging on the CLI's interactive key prompt.
+#
+# auto-release.yml calls this after the GitHub release exists (the .mcpb is a
+# release asset). It is also workflow_dispatch-able to re-publish a version.
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: "Version to publish (no leading v). Omit to use the latest release."
+        required: false
+        type: string
+    secrets:
+      SMITHERY_API_KEY:
+        required: false
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to publish (no leading v). Omit to use the latest release."
+        required: false
+        type: string
+
+# Read-only: the job needs the GITHUB_TOKEN only to download the release asset.
+# Smithery auth is the env bearer token, not OIDC — so NO id-token here.
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Publish .mcpb to Smithery
+    runs-on: ubuntu-latest
+    env:
+      # The ONLY privileged credential this job holds. No NPM_TOKEN, no write
+      # token, no id-token — so the third-party `npx @smithery/cli` it runs can
+      # reach nothing but the (ideally scoped) Smithery publish token.
+      SMITHERY_API_KEY: ${{ secrets.SMITHERY_API_KEY }}
+      GH_TOKEN: ${{ github.token }}
+      GH_REPO: ${{ github.repository }}
+
+    steps:
+      - name: Check for Smithery credentials
+        id: guard
+        run: |
+          if [ -z "${SMITHERY_API_KEY}" ]; then
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            echo "::notice title=Smithery publish skipped::SMITHERY_API_KEY is not configured. Add the repo secret to enable automatic Smithery publishing."
+          else
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Resolve version and tag
+        if: steps.guard.outputs.configured == 'true'
+        id: ver
+        run: |
+          VERSION="${{ inputs.version }}"
+          if [ -z "$VERSION" ]; then
+            VERSION="$(gh release view --json tagName --jq '.tagName')"
+          fi
+          VERSION="${VERSION#v}"
+          echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Publishing activitypub-mcp $VERSION to Smithery (rye/activitypub-mcp)"
+
+      - name: Download the release .mcpb bundle
+        if: steps.guard.outputs.configured == 'true'
+        run: |
+          gh release download "v${{ steps.ver.outputs.VERSION }}" --pattern '*.mcpb' --dir .
+          ls -la ./*.mcpb
+
+      - name: Publish to Smithery
+        if: steps.guard.outputs.configured == 'true'
+        # The CLI is PINNED to an exact version: this step runs third-party code
+        # while holding the Smithery token, so a moving @latest would be a
+        # supply-chain risk. Bump deliberately. (npx can't checksum-pin like the
+        # mcp-publisher binary does, so the scoped/TTL service token is the real
+        # blast-radius control.)
+        run: |
+          file="activitypub-mcp-${{ steps.ver.outputs.VERSION }}.mcpb"
+          test -f "$file" || { echo "::error::$file not found among release assets"; exit 1; }
+          for attempt in 1 2; do
+            if npx -y @smithery/cli@4.11.1 mcp publish "$file" -n rye/activitypub-mcp; then
+              echo "Published $file to Smithery (rye/activitypub-mcp)"
+              exit 0
+            fi
+            echo "::warning::Smithery publish attempt $attempt failed; retrying in 10s..."
+            sleep 10
+          done
+          echo "::error::Smithery publish failed after 2 attempts"
+          exit 1

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -161,18 +161,52 @@ earned by the tool/parameter descriptions we already control, not by hosting.
 > activitypub-mcp . && docker run --rm -i activitypub-mcp` runs the stdio server
 > for anyone wiring it into their own container stack.
 
-### Smithery — defer (highest effort, lowest marginal reach)
+### Smithery — live and auto-published
 
-Raw stdio hosting was deprecated (Sep 2025) and Smithery does not import from the
-official registry. The two viable routes are both heavy for this server:
+Listed as [`rye/activitypub-mcp`](https://smithery.ai/server/rye/activitypub-mcp).
+Smithery ingests the same self-contained `.mcpb` bundle built in §3 (it carries
+the rich `inputSchema`/`outputSchema` that drive the capability score), published
+with the CLI: `smithery mcp publish <bundle>.mcpb -n rye/activitypub-mcp`.
 
-- **MCPB bundle** — reuse the `.mcpb` from §3 and publish via `smithery.ai/new`.
-  Lowest-friction Smithery path, but depends on the bundle existing first.
-- **`runtime: typescript` + `target: local`** (Beta) — requires the entrypoint
-  to **export a Smithery-SDK config schema**, which `dist/mcp-main.js` does not.
-  Confirm `target: local` still exists before investing.
+This is now **automated** as part of every release. After a version bump merges,
+[`auto-release.yml`](../.github/workflows/auto-release.yml) creates the GitHub
+release (with the `.mcpb` asset), then runs
+[`publish-smithery.yml`](../.github/workflows/publish-smithery.yml) — which
+downloads that asset and publishes it to Smithery.
 
-Do this last, if at all.
+**One-time setup — add the `SMITHERY_API_KEY` repo secret.** Smithery is the only
+channel without an OIDC / trusted-publishing path (npm and the MCP registry both
+publish keyless via OIDC), so its CLI authenticates with a bearer token read from
+`$SMITHERY_API_KEY`. Mint a **scoped, TTL-limited service token** (not the raw
+account key) and store it:
+
+```bash
+# 1. Get a key from https://smithery.ai/account/api-keys
+#    (or mint a narrower service token: `smithery auth token`).
+# 2. Add it as a GitHub Actions secret:
+gh secret set SMITHERY_API_KEY --repo cameronrye/activitypub-mcp
+```
+
+Until the secret is set, the `publish-smithery` job logs a notice and no-ops
+(forks and secret-less runs stay green). To publish a past version on its own
+after setting the key, run the workflow manually:
+
+```bash
+gh workflow run publish-smithery.yml -f version=3.2.1
+```
+
+To do it entirely by hand instead (e.g. before the secret is in place):
+
+```bash
+gh release download v3.2.1 --pattern '*.mcpb' --dir /tmp
+SMITHERY_API_KEY=<key> npx -y @smithery/cli@4.11.1 \
+  mcp publish /tmp/activitypub-mcp-3.2.1.mcpb -n rye/activitypub-mcp
+```
+
+> Supply-chain note: the publish job runs the third-party `@smithery/cli` while
+> holding the token, so the CLI version is **pinned** and the job holds **only**
+> `SMITHERY_API_KEY` (no `NPM_TOKEN`, no write/`id-token` grants). A scoped
+> service token bounds the blast radius further.
 
 ---
 

--- a/tests/unit/release-smithery-publish.test.ts
+++ b/tests/unit/release-smithery-publish.test.ts
@@ -1,0 +1,97 @@
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Guards the automated Smithery publish wiring. Smithery is the one
+ * distribution channel whose CLI has NO OIDC / trusted-publishing path (npm and
+ * the MCP registry both publish via OIDC) — auth is a bearer token read from
+ * $SMITHERY_API_KEY. These tests lock in that the release pipeline publishes the
+ * .mcpb to Smithery automatically, holds ONLY the Smithery token (least
+ * privilege), pins the third-party CLI it executes, and degrades to a no-op when
+ * the secret is absent so forks/secret-less runs stay green.
+ */
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const smitheryYmlPath = path.join(ROOT, ".github/workflows/publish-smithery.yml");
+const autoReleaseYml = readFileSync(path.join(ROOT, ".github/workflows/auto-release.yml"), "utf-8");
+
+describe("publish-smithery.yml reusable workflow", () => {
+  it("exists", () => {
+    expect(existsSync(smitheryYmlPath)).toBe(true);
+  });
+
+  const smitheryYml = existsSync(smitheryYmlPath) ? readFileSync(smitheryYmlPath, "utf-8") : "";
+
+  it("is a reusable workflow (workflow_call) and manually runnable (workflow_dispatch)", () => {
+    expect(smitheryYml).toMatch(/workflow_call:/);
+    expect(smitheryYml).toMatch(/workflow_dispatch:/);
+  });
+
+  it("publishes via the Smithery CLI to the rye/activitypub-mcp namespace", () => {
+    expect(smitheryYml).toMatch(/@smithery\/cli@/);
+    expect(smitheryYml).toMatch(/mcp publish/);
+    expect(smitheryYml).toMatch(/-n rye\/activitypub-mcp/);
+  });
+
+  it("publishes the versioned .mcpb bundle (the same asset the release attaches)", () => {
+    expect(smitheryYml).toMatch(
+      /activitypub-mcp-\$\{\{\s*steps\.ver\.outputs\.VERSION\s*\}\}\.mcpb/,
+    );
+    expect(smitheryYml).toMatch(/\.mcpb/);
+  });
+
+  it("pins the Smithery CLI to an exact version (no moving @latest while holding the token)", () => {
+    // A floating @latest would run unreviewed third-party code in a job that
+    // holds the publish token. Require a pinned semver.
+    expect(smitheryYml).toMatch(/@smithery\/cli@\d+\.\d+\.\d+/);
+    expect(smitheryYml).not.toMatch(/@smithery\/cli@latest/);
+  });
+
+  it("authenticates only via the SMITHERY_API_KEY secret (no --key flag, no OIDC)", () => {
+    expect(smitheryYml).toMatch(/SMITHERY_API_KEY/);
+    expect(smitheryYml).toMatch(/secrets:\s*[\s\S]*SMITHERY_API_KEY/);
+    // Smithery has no OIDC publish path — id-token must NOT be granted here.
+    expect(smitheryYml).not.toMatch(/id-token:\s*write/);
+  });
+
+  it("gracefully skips when the secret is absent instead of hanging/failing", () => {
+    // Without the key the CLI would prompt on stdin and hang in CI. A guard must
+    // short-circuit so secret-less runs (forks, contributors) stay green.
+    expect(smitheryYml).toMatch(/configured/);
+    expect(smitheryYml).toMatch(/if:\s*steps\.guard\.outputs\.configured == 'true'/);
+  });
+
+  it("holds least privilege: read-only contents, no npm token, no write", () => {
+    expect(smitheryYml).toMatch(/permissions:\s*[\s\S]*contents:\s*read/);
+    // Inspect only non-comment lines — the explanatory comments deliberately
+    // NAME the credentials this job must NOT hold (NPM_TOKEN, write) to document
+    // why they're absent, the same convention as release-mcpb-asset.test.ts.
+    const commandLines = smitheryYml
+      .split("\n")
+      .filter((l) => !l.trim().startsWith("#"))
+      .join("\n");
+    expect(commandLines).not.toMatch(/contents:\s*write/);
+    expect(commandLines).not.toMatch(/packages:\s*write/);
+    expect(commandLines).not.toMatch(/NPM_TOKEN/);
+  });
+});
+
+describe("auto-release.yml wires the Smithery publish", () => {
+  it("calls publish-smithery.yml as a reusable workflow", () => {
+    expect(autoReleaseYml).toMatch(/uses:\s*\.\/\.github\/workflows\/publish-smithery\.yml/);
+  });
+
+  it("runs it only on an actual release and after the npm/release job", () => {
+    const job = autoReleaseYml.slice(autoReleaseYml.indexOf("publish-smithery:"));
+    expect(job).toMatch(/needs:\s*\[?\s*check-version\s*,\s*release/);
+    expect(job).toMatch(/if:\s*needs\.check-version\.outputs\.should_release == 'true'/);
+  });
+
+  it("passes the SMITHERY_API_KEY secret explicitly (not blanket inherit)", () => {
+    const job = autoReleaseYml.slice(autoReleaseYml.indexOf("publish-smithery:"));
+    expect(job).toMatch(
+      /secrets:\s*[\s\S]*SMITHERY_API_KEY:\s*\$\{\{\s*secrets\.SMITHERY_API_KEY\s*\}\}/,
+    );
+  });
+});


### PR DESCRIPTION
## What

Automates the last manual step in the release pipeline: publishing the `.mcpb` bundle to the Smithery listing (`rye/activitypub-mcp`). Until now this was a hand-run `smithery mcp publish` after every version.

`auto-release.yml` already creates the GitHub release (with the `.mcpb` asset) and publishes to npm + the MCP registry. This adds a parallel **`publish-smithery`** job that calls a new reusable **`publish-smithery.yml`**, which downloads the release's `.mcpb` and runs `npx @smithery/cli mcp publish … -n rye/activitypub-mcp`.

## Why a stored secret (and how it's contained)

Unlike npm and the MCP registry — which publish **keyless via GitHub OIDC** — Smithery's CLI has **no OIDC / trusted-publishing path**. Auth is a bearer token read from `$SMITHERY_API_KEY` (there isn't even a `--key` flag). So this is the one channel that needs a secret. Containment:

- The job holds **only** `SMITHERY_API_KEY` (+ the default read-only `GITHUB_TOKEN` to fetch the asset) — **no `NPM_TOKEN`, no write/`id-token` grants**.
- The third-party `@smithery/cli` is **version-pinned** (not `@latest`), since it runs while holding the token.
- The secret is passed **explicitly** from `auto-release.yml` (not `secrets: inherit`).

## Graceful degradation

If `SMITHERY_API_KEY` is not set, the job logs a notice and **no-ops** — forks and secret-less runs stay green (and it never hangs on the CLI's interactive key prompt).

## Activation (maintainer, one-time)

The workflow is **inert until the secret exists**:

```bash
# key from https://smithery.ai/account/api-keys (ideally a scoped `smithery auth token`)
gh secret set SMITHERY_API_KEY --repo cameronrye/activitypub-mcp
```

Re-publish a past version on demand: `gh workflow run publish-smithery.yml -f version=3.2.1`.

## Tests

New `tests/unit/release-smithery-publish.test.ts` (TDD) locks in the wiring, the least-privilege posture, the pinned CLI, and the graceful-skip guard. Full suite: **959 green** (was 948 + 11 new); typecheck/lint/format clean.

> Note: the `publish-smithery` job only runs on release/`workflow_dispatch`, so it won't execute on this PR — the meta-tests cover its structure.